### PR TITLE
Fix build with non-standard glib location

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -106,7 +106,7 @@
 #include <tcpd.h>
 #endif /* HAVE_LIBWRAP */
 
-#include <glib-2.0/glib.h>
+#include <glib.h>
 /* }}} */
 
 #define RRDD_LOG(severity, ...) \


### PR DESCRIPTION
pkg-config --cflags glib-2.0 already has glib-2.0/ in the include path (and does not have parent directory of glib-2.0/ there):

On the host with non-standard glib location:

build-opensuse-10:~ # pkg-config --cflags glib-2.0
-I/opt/gnome/include/glib-2.0 -I/opt/gnome/lib64/glib-2.0/include  

On the host with standard glib location:

build-opensuse-11:~ # pkg-config --cflags glib-2.0
-I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include 
