### PR TITLE
build: allow out-of-tree build

### DIFF
--- a/bindings/lua/Makefile.am
+++ b/bindings/lua/Makefile.am
@@ -25,7 +25,7 @@ else
 endif
 rrd_la_LIBADD = -lrrd -lm
 rrd_la_LDFLAGS = -module -version-info $(LIB_VERSION_INFO) $(LUA_LFLAGS) -L$(top_builddir)/src/.libs
-rrd_la_CFLAGS = -I$(top_srcdir)/src -I$(top_srcdir) $(LUA_CFLAGS) $(LUA_DEFINES) -DLIB_VERSION=\"$(LIB_VERSION)\"
+rrd_la_CFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src -I$(top_srcdir) $(LUA_CFLAGS) $(LUA_DEFINES) -DLIB_VERSION=\"$(LIB_VERSION)\"
 
 .PHONY: test.lua
 

--- a/bindings/tcl/Makefile.am
+++ b/bindings/tcl/Makefile.am
@@ -47,7 +47,7 @@ $(TCL_RRD_LIB): tclrrd.o
 	$(TCL_SHLIB_LD) $(TCL_LD_SEARCH_FLAGS) $(LIBDIRS) $< -o $@ -lrrd_th -lm $(TCL_STUB_LIB_SPEC) $(LDFLAGS) $(LIBS)
 
 tclrrd.o: tclrrd.c
-	$(CC) $(AM_CFLAGS) $(CFLAGS) $(TCL_SHLIB_CFLAGS) $(AM_CPPFLAGS) -c tclrrd.c -DVERSION=\"$(VERSION)\"
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(TCL_SHLIB_CFLAGS) $(AM_CPPFLAGS) -c $(srcdir)/tclrrd.c -DVERSION=\"$(VERSION)\"
 
 pkgIndex.tcl:
 	echo "package ifneeded Rrd $(VERSION) \"load $(libdir)/tclrrd$(VERSION)[info sharedlibextension]\"" > $@

--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -339,7 +339,7 @@ AC_DEFUN([AC_IEEE], [
 AC_MSG_CHECKING([if IEEE math works $1])
 AC_CACHE_VAL([rd_cv_ieee_$2],
 [AC_RUN_IFELSE([AC_LANG_SOURCE([[$3
-#include "src/rrd_config_bottom.h"
+#include "${srcdir}/src/rrd_config_bottom.h"
 #include <stdio.h>
 int main(void){
     double rrdnan,rrdinf,rrdc,rrdzero;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ endif
 INCLUDES = -DLOCALEDIR="\"$(datadir)/locale\""
 RRD_DEFAULT_FONT=@RRD_DEFAULT_FONT@
 AM_CPPFLAGS = -DRRD_DEFAULT_FONT=\"$(RRD_DEFAULT_FONT)\" -DNUMVERS=@NUMVERS@
-AM_CFLAGS = @CFLAGS@
+AM_CFLAGS = @CFLAGS@ -I$(top_srcdir)
 ## no including this by default @WERROR@
 
 UPD_C_FILES =		\


### PR DESCRIPTION
Building out of the tree is convenient because we there it does not
pollute VCS status and make it convenient to clean everything by just
removing the build directory.

Currently, the build won't work with Perl, Python and Ruby bindings.

Unfortunately, I don't know how to handle those.

With this patch, we can do:

``` sh
./autogen.sh
mkdir build
cd build
../configure -enable-lua --enable-tcl --disable-perl --disable-python --disable-ruby
make
```
