### PR TITLE
Fixed failed IEEE check for cross-compile support.

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -358,7 +358,9 @@ int main(void){
     if (! rrdinf > 0) {printf ("not inf > 0 ... "); return 1;}
     if (! -rrdinf < 0) {printf ("not -inf < 0 ... "); return 1;}
     return 0;
- }]])],[rd_cv_ieee_$2=yes],[rd_cv_ieee_$2=no],[:])])
+ }]])],[rd_cv_ieee_$2=yes],[rd_cv_ieee_$2=no],[$as_echo_n "(skipped ... cross-compiling) " >&6
+  # Bypass further checks
+  rd_cv_ieee_works=yes])])
 dnl these we run regardles is cached or not
 if test x${rd_cv_ieee_$2} = "xyes"; then
  AC_MSG_RESULT(yes)


### PR DESCRIPTION
Hi Tobi,

This fixes the issue where the autoconfigure script required successful generation of IEEE-validated programs on the build host, when compiling from source.

Now, if cross-compile is detected, it will be logged and the IEEE checks will be bypassed.

This allows me to build both natively (x86_64) and cross-compile (Freescale P2020).

Hope this helps!

Trevor
