### PR TITLE
tcl bindings: install to libdir as previously

### DIFF
--- a/bindings/tcl/Makefile.am
+++ b/bindings/tcl/Makefile.am
@@ -27,8 +27,9 @@ tclpkgdir = @TCL_PACKAGE_DIR@
 tclpkg_DATA = pkgIndex.tcl
 tclpkg_SCRIPTS = ifOctets.tcl
 else
-pkgdata_DATA = pkgIndex.tcl
-pkgdata_SCRIPTS = ifOctets.tcl
+pkgindexdir = $(pkglibdir)
+pkgindex_DATA = pkgIndex.tcl
+pkgindex_SCRIPTS = ifOctets.tcl
 endif
 
 # Automake doen't like `tclrrd$(VERSION)$(TCL_SHLIB_SUFFIX)' as


### PR DESCRIPTION
I think it's better to install the tcl files from the tcl bindings to libdir as previously. What do you think?
