### PR TITLE
Update a maximum of row_cnt rows when updating an rra

### DIFF
--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -1476,8 +1476,9 @@ static int update_all_cdp_prep(
             proc_pdp_cnt % rrd->rra_def[rra_idx].pdp_cnt;
         skip_update[rra_idx] = 0;
         if (start_pdp_offset <= elapsed_pdp_st) {
-            rra_step_cnt[rra_idx] = (elapsed_pdp_st - start_pdp_offset) /
-                rrd->rra_def[rra_idx].pdp_cnt + 1;
+            rra_step_cnt[rra_idx] = min((elapsed_pdp_st - start_pdp_offset) /
+                rrd->rra_def[rra_idx].pdp_cnt + 1,
+                rrd->rra_def[rra_idx].row_cnt);
         } else {
             rra_step_cnt[rra_idx] = 0;
         }


### PR DESCRIPTION
When performing an `rrd update` on a database that hasn't been updated in a long period of time, the update process generates rows for every step period between the last update and the current time. This is the right thing to do, but on embedded devices this can take an extremely long time (think tens of minutes) to get caught up.

The worst case scenario is that and RRD is created before the system clock is set so all the data going in starts based on UNIX timestamp 0. A short time later, the clock is updated to real time and 30 years worth of rows must be generated before the database catches up. In my case the step size was 2 seconds and this could take more than an hour. Other cases are not as severe but can still cause long delays in startup if several months have passed since the last time my system was used.

This patch limits the number of rows that will be generated to a maximum of the number of rows in the RRA. It seems to me this is ok to do, new CDPs aren't based on old CDPs  right?
