### PR TITLE
doc: updated options / parameters

### DIFF
--- a/doc/rrdtool.pod
+++ b/doc/rrdtool.pod
@@ -58,6 +58,11 @@ Operationally equivalent to B<update> except for output. Check L<rrdupdate>.
 Create a graph from data stored in one or several RRDs. Apart from
 generating graphs, data can also be extracted to stdout. Check L<rrdgraph>.
 
+=item B<graphv>
+
+Create a graph from data stored in one or several RRDs. Same as graph, but
+metadata are printed before the graph. Check L<rrdgraph>.
+
 =item B<dump>
 
 Dump the contents of an RRD in plain ASCII. In connection with restore
@@ -77,15 +82,24 @@ uses fetch to retrieve its data from an RRD. Check L<rrdfetch>.
 
 Alter setup of an RRD. Check L<rrdtune>.
 
+=item B<first>
+
+Find the first update time of an RRD. Check L<rrdfirst>.
+
 =item B<last>
 
 Find the last update time of an RRD. Check L<rrdlast>.
+
+=item B<lastupdate>
+
+Find the last update time of an RRD. It also returns the value stored
+for each datum in the most recent update. Check L<rrdlastupdate>.
 
 =item B<info>
 
 Get information about an RRD. Check L<rrdinfo>.
 
-=item B<rrdresize>
+=item B<resize>
 
 Change the size of individual RRAs. This is dangerous! Check L<rrdresize>.
 
@@ -96,11 +110,6 @@ Export data retrieved from one or several RRDs. Check L<rrdxport>.
 =item B<flushcached>
 
 Flush the values for a specific RRD file from memory. Check L<rrdflushcached>.
-
-=item B<rrdcgi>
-
-This is a standalone tool for producing RRD graphs on the fly. Check
-L<rrdcgi>.
 
 =back
 

--- a/doc/rrdupdate.pod
+++ b/doc/rrdupdate.pod
@@ -6,7 +6,7 @@ rrdupdate - Store a new set of values into the RRD
 
 B<rrdtool> {B<update> | B<updatev>} I<filename>
 S<[B<--template>|B<-t> I<ds-name>[B<:>I<ds-name>]...]>
-S<[B<--daemon> I<address>]> [B<-->]
+S<[B<--daemon>|B<-d> I<address>]> [B<-->]
 S<B<N>|I<timestamp>B<:>I<value>[B<:>I<value>...]>
 S<I<at-timestamp>B<@>I<value>[B<:>I<value>...]>
 S<[I<timestamp>B<:>I<value>[B<:>I<value>...] ...]>
@@ -68,7 +68,7 @@ rrdtool to silently skip such data. It can be useful when re-playing old
 data into an rrd file and you are not sure how many updates have already
 been applied.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 If given, B<RRDTool> will try to connect to the caching daemon L<rrdcached>
 at I<address> and will fail if the connection cannot be established. If the


### PR DESCRIPTION
Added missing options to the documentation (feel free to reword) to be in sync with the tools. Renamed rrdresize to resize in the rrdtool doc - I suppose it's typo. Removed rrdcgi, as it cannot be invoked from the rrdtool.
