### PR TITLE
Fix median filter in cdeftutorial

### DIFF
--- a/doc/cdeftutorial.pod
+++ b/doc/cdeftutorial.pod
@@ -852,8 +852,7 @@ You may do some complex data filtering:
     DEF:var=database.rrd:traffic:AVERAGE
     CDEF:prev1=PREV(var)
     CDEF:prev2=PREV(prev1)
-    CDEF:prev3=PREV(prev2)
-    CDEF:median=prev1,prev2,prev3,+,+,3,/
+    CDEF:median=var,prev1,prev2,3,SORT,POP,EXC,POP
     LINE3:median#000077:filtered
     LINE1:prev2#007700:'raw data'
 


### PR DESCRIPTION
Fixes commit 1198d31
What was described as an median filter was actually an average filter.

Sort the 3 values then take the middle of them using POP,EXC,POP.
Also uses one less prev() to decrease filter delay.

See https://en.wikipedia.org/w/index.php?title=Median_filter&oldid=558817813

Alternative fix is to rename "median" with "average" in the
description, but there already is an AVG rpn function for that.
