### PR TITLE
Fixed constant used in timespan check to be a long long.

### DIFF
--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -480,7 +480,7 @@ int rrd_create_r2(
                         if (row_cnt <= 0)
                             rrd_set_error("Invalid row count: %i", row_cnt);
 #if SIZEOF_TIME_T == 4
-                        if ((long long) pdp_step * rrd.rra_def[rrd.stat_head->rra_cnt].pdp_cnt * row_cnt > 4294967296){
+                        if ((long long) pdp_step * rrd.rra_def[rrd.stat_head->rra_cnt].pdp_cnt * row_cnt > 4294967296LL){
                             /* database timespan > 2**32, would overflow time_t */
                             rrd_set_error("The time spanned by the database is too large: must be <= 4294967296 seconds");
                         }


### PR DESCRIPTION
This commit fixes the issue that mperzi noted in #368.

It builds under GCC on x86, but I am unable to test on AIX.
