### PR TITLE
Add rrdcached client support to windows + misc compatibility fixes

### DIFF
--- a/MakeMakefile
+++ b/MakeMakefile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Run this script after the first cvs checkout to build
 # makefiles and friends

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,8 @@ EXTRA_DIST = COPYRIGHT CHANGES WIN32-BUILD-TIPS.txt TODO CONTRIBUTORS THREADS \
              libtool \
              netware/Makefile  \
              etc/rrdcached-default etc/rrdcached-init \
-             win32/Makefile  win32/config.h  win32/rrdlib.vcproj  win32/rrdtool.vcproj  win32/rrdupdate.vcproj \
-             win32/README    win32/rrd.sln   win32/rrdtool.sln    win32/rrdupdate.sln 
+             win32/Makefile  win32/rrd_config.h  win32/rrdlib.vcproj  win32/rrdtool.vcproj  win32/rrdupdate.vcproj \
+             win32/README    win32/rrd.sln   win32/rrdtool.sln    win32/rrdupdate.sln  win32/Makefile.msc
 
 CLEANFILES = config.cache
 
@@ -50,5 +50,8 @@ site-python-install: all
 # find . -name "*.c" -or -name "*.h" | xargs perl -0777 -n -e 'while (s/typedef\s+(?:unsigned\s+|signed\s+|unival\s+)?\S+\s+\*?([^{}\s;(]+)//){print "-T$1\n"}'
 indent:
 	find ./ -name "*.[ch]" | xargs indent
+
+clean-local:
+	-rm -f config.h bindings/perl-piped/Makefile.old bindings/perl-shared/Makefile.old
 
 ##END##

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # On MAC OS X, GNU libtoolize is named 'glibtoolize':
 if [ `(uname -s) 2>/dev/null` == 'Darwin' ]

--- a/bindings/lua/Makefile.am
+++ b/bindings/lua/Makefile.am
@@ -3,6 +3,8 @@
 # it's not already installed.
 EXTRA_DIST = README test.lua.bottom compat-5.1r5/compat-5.1.lua
 
+AUTOMAKE_OPTIONS = subdir-objects
+
 LIB_VERSION_INFO=0:0:0
 
 LUA                 = @LUA@

--- a/bindings/perl-shared/Makefile.PL
+++ b/bindings/perl-shared/Makefile.PL
@@ -4,15 +4,22 @@ use Config;
 # the contents of the Makefile that is written.
 
 if (($Config{'osname'} eq 'MSWin32' && $ENV{'OSTYPE'} eq '')) {
+	my ($perlver) = ($] =~ /(\d+\.\d{3})/);
+	$perlver =~ s/[.0]//g;
+
+	my $perl_core_dir = "$Config{privlib}/CORE";
+	my $vc_dir = $ENV{'VSINSTALLDIR'} || 'C:/Program Files (x86)/Microsoft Visual Studio 9.0/VC';
+	my $sdk_dir = $ENV{'WindowsSdkDir'} || 'C:/Program Files/Microsoft SDKs/Windows/v6.0A';
+
 	WriteMakefile(
 		'NAME'         => 'RRDs',
 		'VERSION_FROM' => 'RRDs.pm',
 		'DEFINE'       => "-DPERLPATCHLEVEL=$Config{PATCHLEVEL} -D_CRT_SECURE_NO_WARNINGS -DWIN32",
-		'INC'          => '-I../../src/ "-IC:/Perl/lib/CORE" -I"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\include" -I"C:\Program Files\Microsoft SDKs\Windows\v6.0A\Include"',
-		'LDDLFLAGS'    => '-dll -nologo -opt:ref,icf -ltcg -libpath:"C:\Perl\lib\CORE" -machine:X86',
-		'LDFLAGS'      => '-nologo -opt:ref,icf -ltcg -libpath:"C:\Perl\lib\CORE" -machine:X86',
+		'INC'          => '-I../../src -I../../win32 "-I$perl_core_dir" -I"$vc_dir/include" -I"$sdk_dir/Include"',
+		'LDDLFLAGS'    => '-dll -nologo -opt:ref,icf -ltcg -libpath:"$perl_core_dir" -machine:X86',
+		'LDFLAGS'      => '-nologo -opt:ref,icf -ltcg -libpath:"$perl_core_dir" -machine:X86',
 		'OPTIMIZE'     => '-O2 -MD',
-		'LIBS'         => '"..\..\win32\Release\rrdlib.lib" "..\..\win32\Release" "C:\Perl\lib\CORE\perl514.lib" -L../../contrib/lib -L"C:\Program Files\Microsoft SDKs\Windows\v6.0A\lib" -L"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\lib" -L"C:\Perl\lib\CORE"',
+		'LIBS'         => qq{"../../win32/librrd-4.lib" "perl$perlver.lib" -L../../contrib/lib -L../../win32 -L"$sdk_dir/lib" -L"$vc_dir/lib" -L"$perl_core_dir"},
 		'realclean'    => {FILES => 't/demo?.rrd t/demo?.png' },
 		($] ge '5.005') ? (
 			'AUTHOR'   => 'Tobias Oetiker (tobi@oetiker.ch)',

--- a/bindings/perl-shared/RRDs.xs
+++ b/bindings/perl-shared/RRDs.xs
@@ -434,7 +434,6 @@ rrd_restore(...)
        OUTPUT:
                RETVAL
 
-#ifndef WIN32
 int
 rrd_flushcached(...)
 	PROTOTYPE: @
@@ -445,5 +444,3 @@ rrd_flushcached(...)
 		rrdcode(rrd_flushcached);
 	OUTPUT:
 		RETVAL
-
-#endif

--- a/configure.ac
+++ b/configure.ac
@@ -409,25 +409,22 @@ AC_LANG_PUSH(C)
 dnl solaris has some odd defines it needs in order to propperly compile ctime_r
 AC_MSG_CHECKING([if ctime_r need special care to act posixly correct])
 AC_LINK_IFELSE(
-    AC_LANG_PROGRAM(
+    [AC_LANG_PROGRAM(
            [[#include <time.h>]],
-           [[ctime_r(NULL,NULL,0)]]
-                   ),
+           [[ctime_r(NULL,NULL,0)]])],
     [ CPPFLAGS="$CPPFLAGS -D_POSIX_PTHREAD_SEMANTICS"
       AC_LINK_IFELSE(
-          AC_LANG_PROGRAM(
+          [AC_LANG_PROGRAM(
                 [[#include <time.h>]],
-                [[ctime_r(NULL,NULL)]]
-    	                 ),
+                [[ctime_r(NULL,NULL)]])],
           [AC_MSG_RESULT([yes, this seems to be solaris style])],
           [AC_MSG_ERROR([Can't figure how to compile ctime_r])]
       )
     ],  
     [ AC_LINK_IFELSE(
-          AC_LANG_PROGRAM(
+          [AC_LANG_PROGRAM(
                 [[#include <time.h>]],
-                [[ctime_r(NULL,NULL)]]
-    	                 ),
+                [[ctime_r(NULL,NULL)]])],
           [AC_MSG_RESULT(no)],
           [AC_MSG_ERROR([Can't figure how to compile ctime_r])]
       )
@@ -462,18 +459,16 @@ AC_LANG_PUSH(C)
 dnl see if we have to include malloc/malloc.h
 AC_MSG_CHECKING([do we need malloc/malloc.h])
 AC_LINK_IFELSE(
-    AC_LANG_PROGRAM(
+    [AC_LANG_PROGRAM(
            [[#include <stdlib.h>]],
-           [[malloc(1)]]
-                   ),
+           [[malloc(1)]])],
     [ AC_MSG_RESULT([nope, works out of the box]) ],
     [ AC_LINK_IFELSE(
-          AC_LANG_PROGRAM(
+          [AC_LANG_PROGRAM(
                 [[#include <stdlib.h>
                   #include <malloc/malloc.h>]],
-                [[malloc(1)]]
-    	                 ),[
-           AC_DEFINE([MUST_HAVE_MALLOC_MALLOC_H])
+                [[malloc(1)]])],
+	  [AC_DEFINE([MUST_HAVE_MALLOC_MALLOC_H])
            AC_MSG_RESULT([yes we do])],
           [AC_MSG_ERROR([Can not figure how to compile malloc])]
       )

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -16,3 +16,5 @@ cgi-demo.cgi: @srcdir@/cgi-demo.cgi.in $(top_builddir)/config.status
 	sed 's,@''exec_prefix@,$(exec_prefix),' @srcdir@/cgi-demo.cgi.in > $@
 	chmod a+x $@
 
+clean-local:
+	-rm -f cgi-demo.cgi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,13 +9,15 @@ if STATIC_PROGRAMS
 AM_LDFLAGS = -all-static
 endif
 
-INCLUDES = -DLOCALEDIR="\"$(datadir)/locale\""
 RRD_DEFAULT_FONT=@RRD_DEFAULT_FONT@
-AM_CPPFLAGS = -DRRD_DEFAULT_FONT=\"$(RRD_DEFAULT_FONT)\" -DNUMVERS=@NUMVERS@
+AM_CPPFLAGS = -DLOCALEDIR="\"$(datadir)/locale\"" \
+	-DRRD_DEFAULT_FONT=\"$(RRD_DEFAULT_FONT)\" \
+	-DNUMVERS=@NUMVERS@
 AM_CFLAGS = @CFLAGS@ -I$(top_srcdir)
 ## no including this by default @WERROR@
 
 UPD_C_FILES =		\
+	mutex.c		\
 	rrd_create.c	\
 	hash_32.c	\
 	rrd_parsetime.c	\
@@ -56,6 +58,7 @@ endif
 noinst_HEADERS = \
 	unused.h \
         gettext.h \
+	mutex.h \
 	rrd_getopt.h rrd_parsetime.h \
 	rrd_config_bottom.h rrd_i18n.h \
 	rrd_format.h rrd_tool.h rrd_xport.h rrd.h rrd_rpncalc.h \
@@ -132,3 +135,6 @@ librrd.sym: librrd.sym.in
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir) && $(LN_S) rrdupdate rrdcreate && $(LN_S) rrdupdate rrdinfo) || true
+
+distclean-local:
+	-rm -rf rrd_config.h librrd.sym

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -1,0 +1,56 @@
+/*
+ *
+ * mutex.c
+ *
+ * Cross platform mutex
+ *
+ */
+
+#include "mutex.h"
+
+int mutex_init(mutex_t *mutex)
+{
+#ifdef WIN32
+  *mutex = CreateMutex(NULL, FALSE, NULL);
+  return (*mutex == NULL);
+#else
+  return pthread_mutex_init(mutex, NULL);;
+#endif
+}
+
+int mutex_lock(mutex_t *mutex)
+{
+#ifdef WIN32
+  if (*mutex == NULL) { /* static initializer? */
+    HANDLE p = CreateMutex(NULL, FALSE, NULL);
+    if (InterlockedCompareExchangePointer((PVOID*)mutex, (PVOID)p, NULL) != NULL)
+      CloseHandle(p);
+  }
+  return (WaitForSingleObject(*mutex, INFINITE) == WAIT_FAILED);
+#else
+  return pthread_mutex_lock(mutex);
+#endif
+}
+
+int mutex_unlock(mutex_t *mutex)
+{
+#ifdef WIN32
+  return (ReleaseMutex(*mutex) == 0);
+#else
+  return pthread_mutex_unlock(mutex);
+#endif
+}
+
+int mutex_cleanup(mutex_t *mutex)
+{
+#ifdef WIN32
+  return (CloseHandle(mutex) == 0);
+#else
+  return pthread_mutex_destroy(mutex);
+#endif
+}
+
+/*
+ * vim: set sw=2 sts=2 ts=8 et fdm=marker :
+ */
+

--- a/src/mutex.h
+++ b/src/mutex.h
@@ -1,0 +1,33 @@
+/*
+ *  mutex.h - Cross platform mutex
+ */
+
+#ifndef MUTEX__H
+#define MUTEX__H
+
+#ifdef WIN32
+#include <windows.h>
+#include <process.h>
+#else
+#include <pthread.h>
+#endif
+
+#ifndef WIN32
+#define mutex_t            pthread_mutex_t
+#define MUTEX_INITIALIZER  PTHREAD_MUTEX_INITIALIZER
+#else
+#define mutex_t            HANDLE
+#define MUTEX_INITIALIZER  NULL
+#endif
+
+int mutex_init(mutex_t *mutex);
+int mutex_lock(mutex_t *mutex);
+int mutex_unlock(mutex_t *mutex);
+int mutex_cleanup(mutex_t *mutex);
+
+#endif /* MUTEX__H */
+
+/*
+ * vim: set sw=2 sts=2 ts=8 et fdm=marker :
+ */
+

--- a/src/rrd_cgi.c
+++ b/src/rrd_cgi.c
@@ -9,11 +9,6 @@
 #include <stdlib.h>
 #endif
 
-#ifdef WIN32
-   #define strcasecmp stricmp
-   #define strcasencmp strnicmp
-#endif
-
 #define MEMBLK 1024
 /*#define DEBUG_PARSER
 #define DEBUG_VARS*/

--- a/src/rrd_client.h
+++ b/src/rrd_client.h
@@ -31,22 +31,6 @@
 #  include <stdint.h>
 # endif
 
-# ifdef HAVE_INTTYPES_H
-#  include <inttypes.h>
-# endif
-
-# if !(defined(HAVE_STDINT_H) || defined(HAVE_INTTYPES_H))
-#	include <stdlib.h>
-	typedef signed char 	int8_t;
-	typedef unsigned char 	uint8_t;
-	typedef signed int 	int16_t;
-	typedef unsigned int 	uint16_t;
-	typedef signed long int 	int32_t;
-	typedef unsigned long int 	uint32_t;
-	typedef signed long long int 	int64_t;
-	typedef unsigned long long int 	uint64_t;
-# endif
-
 /* max length of socket command or response */
 #define RRD_CMD_MAX 4096
 
@@ -58,15 +42,12 @@
 #define ENV_RRDCACHED_ADDRESS "RRDCACHED_ADDRESS"
 
 
-// Windows version has no daemon/client support
-
-#ifndef WIN32
 int rrdc_connect (const char *addr);
 int rrdc_is_connected(const char *daemon_addr);
 int rrdc_disconnect (void);
 
 int rrdc_update (const char *filename, int values_num,
-        const char * const *values);
+    const char * const *values);
 
 rrd_info_t * rrdc_info (const char *filename);
 time_t rrdc_last (const char *filename);
@@ -89,19 +70,6 @@ int rrdc_fetch (const char *filename,
     unsigned long *ret_ds_num,
     char ***ret_ds_names,
     rrd_value_t **ret_data);
-
-#else
-#   define rrdc_create(a,b,c,d,e,f) 0
-#	define rrdc_flush_if_daemon(a,b) 0
-#	define rrdc_connect(a) 0
-#	define rrdc_is_connected(a) 0
-#	define rrdc_flush(a) 0
-#	define rrdc_update(a,b,c) 0
-#   define rrdc_last(a) 0
-#   define rrdc_first(a,b) 0
-#   define rrdc_fetch(a,b,c,d,e,f,g,h) 0
-#   define rrdc_info(a) 0
-#endif
 
 struct rrdc_stats_s
 {

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -69,11 +69,11 @@
 #include "unused.h"
 
 #include <stdlib.h>
-
-#ifndef WIN32
 #ifdef HAVE_STDINT_H
 #  include <stdint.h>
 #endif
+
+#ifndef WIN32
 #include <unistd.h>
 #include <strings.h>
 #include <inttypes.h>
@@ -3023,7 +3023,7 @@ static int open_listen_sockets_systemd(void) /* {{{ */
 
     l = sizeof(sa);
     memset(&sa, 0, l);
-    if (getsockname(sd_fd, &sa, &l) < 0)
+    if (getsockname(sd_fd, (struct sockaddr *)&sa, &l) < 0)
     {
       fprintf(stderr, "open_listen_sockets_systemd: problem getting fd %d: %s\n", sd_fd, rrd_strerror (errno));
       return i;

--- a/src/rrd_flushcached.c
+++ b/src/rrd_flushcached.c
@@ -78,9 +78,10 @@ int rrd_flushcached (int argc, char **argv)
 
     if (! rrdc_is_connected(opt_daemon))
     {
-        rrd_set_error ("Daemon address unknown. Please use the \"--daemon\" "
+        rrd_set_error ("Daemon address \"%s\" unknown. Please use the \"--daemon\" "
                 "option to set an address on the command line or set the "
                 "\"%s\" environment variable.",
+                 opt_daemon,
                 ENV_RRDCACHED_ADDRESS);
         status = -1;
         goto out;

--- a/src/rrd_getopt.c
+++ b/src/rrd_getopt.c
@@ -39,12 +39,7 @@
 #endif
 #endif
 
-#ifndef WIN32
-#ifdef HAVE_CONFIG_H
-#include "../rrd_config.h"
-#endif
-#endif
-
+#include "rrd_config.h"
 #include "rrd_i18n.h"
 
 

--- a/src/rrd_getopt1.c
+++ b/src/rrd_getopt1.c
@@ -28,12 +28,7 @@
 #endif
 #endif
 
-#ifndef WIN32
-#ifdef HAVE_CONFIG_H
-#include "../rrd_config.h"
-#endif
-#endif
-
+#include "rrd_config.h"
 #include "rrd_getopt.h"
 
 #include <stdio.h>

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -847,7 +847,6 @@ int data_fetch(
     image_desc_t *im)
 {
     int       i, ii;
-    int       skip;
     /* pull the data from the rrd files ... */
     for (i = 0; i < (int) im->gdes_c; i++) {
         /* only GF_DEF elements fetch data */

--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -6,7 +6,10 @@
  ****************************************************************************/
 
 #include <locale.h>
+#include "rrd_config.h"
+#ifdef HAVE_STDINT_H
 #include <stdint.h>
+#endif
 
 #include "rrd_graph.h"
 
@@ -531,6 +534,8 @@ static graph_desc_t* newGraphDescription(image_desc_t *const im,enum gf_en gf,pa
       if ((start)&&(parsetime_error = rrd_parsetime(start, &start_tv))) {
 	rrd_set_error("start time: %s", parsetime_error);return NULL; }
       dprintfparsed("got start: %s\n",start);
+    } else {
+	start = NULL;
     }
     /* now end */
     char* end;
@@ -543,6 +548,8 @@ static graph_desc_t* newGraphDescription(image_desc_t *const im,enum gf_en gf,pa
       if ((end)&&(parsetime_error = rrd_parsetime(end, &end_tv))) {
 	rrd_set_error("end time: %s", parsetime_error); return NULL; }
       dprintfparsed("got end: %s\n",end);
+    } else {
+	end = NULL;
     }
     /* and now put the pieces together (relative times like start=end-2days) */
     time_t    start_tmp = 0, end_tmp = 0;
@@ -838,6 +845,11 @@ int parse_axis(enum gf_en gf,parsedargs_t*pa,image_desc_t *const im){
   /* and other stuff */
   a->bounds.lowertxt=getKeyValueArgument("min",1,pa);
   a->bounds.uppertxt=getKeyValueArgument("max",1,pa);
+#else
+  /* prevent unused warnings */
+  (void)gf;
+  (void)pa;
+  (void)im;
 #endif
 
   /* and return */

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -6,7 +6,7 @@
 
 #include "rrd_config.h"
 
-#if defined(WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__) && !defined(HAVE_CONFIG_H)
+#if defined(WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <io.h>
@@ -533,9 +533,6 @@ int HandleInputLine(
     DIR      *curdir;   /* to read current dir with ls */
     struct dirent *dent;
 #endif
-#if defined(HAVE_SYS_STAT_H)
-    struct stat st;
-#endif
 
     /* Reset errno to 0 before we start.
      */
@@ -547,7 +544,7 @@ int HandleInputLine(
             }
             exit(0);
         }
-#if defined(HAVE_OPENDIR) && defined(HAVE_READDIR) && defined(HAVE_CHDIR)
+#if defined(HAVE_OPENDIR) && defined(HAVE_READDIR) && defined(HAVE_CHDIR) && defined(HAVE_SYS_STAT_H)
         if (argc > 1 && strcmp("cd", argv[1]) == 0) {
             if (argc != 3) {
                 printf("ERROR: invalid parameter count for cd\n");
@@ -607,6 +604,7 @@ int HandleInputLine(
                 return (1);
             }
             if ((curdir = opendir(".")) != NULL) {
+                struct stat st;
                 while ((dent = readdir(curdir)) != NULL) {
                     if (!stat(dent->d_name, &st)) {
                         if (S_ISDIR(st.st_mode)) {
@@ -765,10 +763,8 @@ int HandleInputLine(
 #endif
     } else if (strcmp("tune", argv[1]) == 0)
         rrd_tune(argc - 1, &argv[1]);
-#ifndef WIN32
     else if (strcmp("flushcached", argv[1]) == 0)
         rrd_flushcached(argc - 1, &argv[1]);
-#endif
     else {
         rrd_set_error("unknown function '%s'", argv[1]);
     }

--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -14,7 +14,9 @@
 #endif
 
 #include <locale.h>
-#include <stdint.h>
+#ifdef HAVE_STDINT_H
+#  include <stdint.h>
+#endif
 
 #include "rrd_hw.h"
 #include "rrd_rpncalc.h"
@@ -31,13 +33,6 @@
  * replacement.
  */
 #include <sys/timeb.h>
-
-#ifndef __MINGW32__
-struct timeval {
-    time_t    tv_sec;   /* seconds */
-    long      tv_usec;  /* microseconds */
-};
-#endif
 
 struct __timezone {
     int       tz_minuteswest;   /* minutes W of Greenwich */

--- a/src/rrd_utils.c
+++ b/src/rrd_utils.c
@@ -183,23 +183,24 @@ int rrd_mkdir_p(const char *pathname, mode_t mode)
         return -1;
     }
 #else
+    if (NULL == (base_dir = strdup(pathname_copy))) {
+        free(pathname_copy);
+        return -1;
+    }
+
     _splitpath(pathname_copy, NULL, base_dir, NULL, NULL);
 #endif
 
     if (0 != rrd_mkdir_p(base_dir, mode)) {
         int orig_errno = errno;
         free(pathname_copy);
-#ifndef _MSC_VER
         free(base_dir);
-#endif
         errno = orig_errno;
         return -1;
     }
 
     free(pathname_copy);
-#ifndef _MSC_VER
     free(base_dir);
-#endif
 
     /* keep errno as set by mkdir() */
 #ifdef _MSC_VER

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -1,43 +1,39 @@
 TOP = .
 RRD_LIB_NAME=librrd-4
+ARCH_PATH_X86=contrib
+ARCH_PATH_X64=contrib-x64
+
 
 !ifndef USE_64BIT
 LD_FLAGS=/RELEASE /MACHINE:X86
-
-CPPFLAGS = /TP /EHsc /O2 /arch:SSE2 /Zi /Fd$(TOP)/win32/vc.pdb \
-        /I $(TOP)/win32 /I $(TOP)/src \
-        /I E:\var\vcs\git\osb\windows-x86-msvcrt\include \
-        /I E:\var\vcs\git\osb\windows-x86-msvcrt\include\cairo \
-        /I E:\var\vcs\git\osb\windows-x86-msvcrt\include\pango-1.0 \
-        /I E:\var\vcs\git\osb\windows-x86-msvcrt\include\glib-2.0 \
-        /I E:\var\vcs\git\osb\windows-x86-msvcrt\include\libxml2
-
-THIRD_PARTY_LIB = /LIBPATH:E:\var\vcs\git\osb\windows-x86-msvcrt\lib \
-        libpng.lib libxml2-2.lib \
-        libglib-2.lib libgobject-2.lib \
-        libpango-1.lib libpangocairo-1.lib libcairo-2.lib
-
+ARCH_PATH=$(ARCH_PATH_X86)
+CPPFLAGS = /arch:SSE2
 !else
 LD_FLAGS=/RELEASE /MACHINE:X64
-
-CPPFLAGS = /TP /EHsc /O2 /Zi /Fd$(TOP)/win32/vc.pdb \
-        /I $(TOP)/win32 /I $(TOP)/src \
-        /I E:\var\vcs\git\osb\windows-x64-msvcrt\include \
-        /I E:\var\vcs\git\osb\windows-x64-msvcrt\include\cairo \
-        /I E:\var\vcs\git\osb\windows-x64-msvcrt\include\pango-1.0 \
-        /I E:\var\vcs\git\osb\windows-x64-msvcrt\include\glib-2.0 \
-        /I E:\var\vcs\git\osb\windows-x64-msvcrt\include\libxml2
-
-THIRD_PARTY_LIB = /LIBPATH:E:\var\vcs\git\osb\windows-x64-msvcrt\lib \
-        libpng.lib libxml2-2.lib \
-        libglib-2.lib libgobject-2.lib \
-        libpango-1.lib libpangocairo-1.lib libcairo-2.lib
+ARCH_PATH=$(ARCH_PATH_X64)
 !endif
+
+CPPFLAGS = $(CCPFLAGS) /TP /EHsc /O2 /Zi /Fd$(TOP)/win32/vc.pdb \
+        /I $(TOP)/win32 /I $(TOP)/src \
+        /I $(ARCH_PATH)\include \
+        /I $(ARCH_PATH)\include\cairo \
+        /I $(ARCH_PATH)\include\pango-1.0 \
+        /I $(ARCH_PATH)\include\glib-2.0 \
+        /I $(ARCH_PATH)\lib\glib-2.0\include \
+        /I $(ARCH_PATH)\include\libxml2
+
+THIRD_PARTY_LIB = /LIBPATH:$(ARCH_PATH)\lib \
+        libpng.lib libxml2.lib \
+        glib-2.0.lib gobject-2.0.lib \
+        pango-1.0.lib pangocairo-1.0.lib cairo.lib \
+		Ws2_32.lib
 
 RRD_LIB_OBJ_LIST = \
         $(TOP)/src/hash_32.obj \
+        $(TOP)/src/mutex.obj \
         $(TOP)/src/plbasename.obj \
         $(TOP)/src/pngsize.obj \
+        $(TOP)/src/rrd_client.obj \
         $(TOP)/src/rrd_create.obj \
         $(TOP)/src/rrd_diff.obj \
         $(TOP)/src/rrd_dump.obj \

--- a/win32/README
+++ b/win32/README
@@ -3,26 +3,33 @@ Win32 Build Instructions:
 1) See build-rrdtool.dot (build-rrdtool.svg or build-rrdtool.pdf) for build
    dependency.
 
-2) If you do not want to build the build-dependencies, you can download these
-   software from the following address:
+2) If you do not want to build the build-dependencies, you can download prebuilt
+   versions from the following address:
 
+   32bit dependencies should then be extracted into the contrib directory:
    http://ftp.gnome.org/pub/gnome/binaries/win32/
    http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/
 
+   64bit dependencies should then be extracted into the contrib-x64 directory:
    http://ftp.gnome.org/pub/gnome/binaries/win64/
    http://ftp.gnome.org/pub/gnome/binaries/win64/dependencies/
 
-3) Adjust the include path, library path, and library names which in the
+
+3) If you don't already have stdint.h for your system you can download it
+   from the following address:
+   http://msinttypes.googlecode.com/svn/trunk/stdint.h
+
+4) Adjust the include path, library path, and library names which in the
    Makefile.msc, to correspond with your local path or names.
 
-4) Run 'nmake -f win32\Makefile.msc' for 32 bit Windows target,
+5) Run 'nmake -f win32\Makefile.msc' for 32 bit Windows target,
    Run 'nmake -f win32\Makefile.msc USE_64BIT=1' for 64 bit Windows target.
    Run 'nmake -f win32\Makefile.msc clean' to remove all generated files.
 
-5) librrd-4.dll, librrd-4.lib, rrdtool.exe, rrdupdate.exe, rrdcgi.exe, and
+6) librrd-4.dll, librrd-4.lib, rrdtool.exe, rrdupdate.exe, rrdcgi.exe, and
    these corresponding pdb files will be located in the win32 directory.
 
-6) To install, copy these files which you required to their permanent location.
+7) To install, copy these files which you required to their permanent location.
 
-7) To build the binding module. Follow the instructions in the README file which
+8) To build the binding module. Follow the instructions in the README file which
    under the subdirectory of 'binding/'.

--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -33,8 +33,24 @@
     Linux x64 gcc, Windows x64 gcc, Visual C++ 2005 or later
  */
 
-/* The size of `time_t', as computed by sizeof. */
-#define SIZEOF_TIME_T 8 /* Visual C++ 2005 or later */
+/*
+ * The size of `time_t', as computed by sizeof.
+ * VS2005 and later dafault size for time_t is 64-bit, unless
+ * _USE_32BIT_TIME_T has been defined to use a 32-bit time_t.
+ */
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
+#  ifndef _USE_32BIT_TIME_T
+#    define SIZEOF_TIME_T 8
+#  else
+#    define SIZEOF_TIME_T 4
+#  endif
+#else
+#  ifdef _WIN64
+#    define SIZEOF_TIME_T 8
+#  else
+#    define SIZEOF_TIME_T 4
+#  endif
+#endif
 
 /* Define to 1 if you have the `chdir' function. */
 #define HAVE_CHDIR 1
@@ -72,20 +88,33 @@
 /* Define to 1 if you have the `tzset' function. */
 #define HAVE_TZSET 1
 
+/* Misc Missing Windows defines */
+#define PATH_MAX 1024
+
+/*
+ * Windows Sockets errors redefined as regular Berkeley error constants.
+ */
+#define ENOBUFS WSAENOBUFS
+#define ENOTCONN WSAENOTCONN
+
 #include <ctype.h>
 #include <direct.h>
 #include <float.h>
 #include <math.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <WinSock.h>
 
 #define isinf(a) (_fpclass(a) == _FPCLASS_NINF || _fpclass(a) == _FPCLASS_PINF)
 #define isnan _isnan
 #define finite _finite
 #define snprintf _snprintf
 #define rrd_realloc(a,b) ( (a) == NULL ? malloc( (b) ) : realloc( (a) , (b) ))
+#define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
+#define strcasecmp _stricmp
+#define strcasencmp _strnicmp
 
+#pragma warning(disable: 4244)
 __inline int round(double a){ return (int) (a + 0.5); }
 
 #endif


### PR DESCRIPTION
== Makefile / config fixes ==
- Fixed invalid AC_LANG_PROGRAM usage.
- Fixed AUTOMAKE_OPTIONS not defining subdir-objects which caused warnings
- Switched from legacy INCLUDES to AM_CPPFLAGS
- Added Makefile clean targets to ensure all autogenerated targets are removed
- Updated Makefile.PL to be more portable and less hardcoded for Win32
- Switched bash scripts to use #!/usr/bin/env bash for compatibility with none Linux OS's
- Cleaned up win32/Makefile.msc variable defines for easy updating
- Updated defines of SIZEOF_TIME_T to take into account the variances in Windows.

== Code Enhancements / fixes ==
- Added support for rrdcached client methods to windows builds
- Fixed invalid type warning for atoi assignment to a enum
- Fixed malloc cast warnings
- Fixed illegal use of this for variable
- Fixed getsockname cast warning
- Removed HAVE_CONFIG_H checks as all platforms now have it
- Removed unused skip variable from rrd_graph data_fetch
- Fixed unused var warnings for newGraphDescription params
- Fixed unused var st warning in HandleInputLine
- Fixed all includes for <stdint.h> to check HAVE_STDINT_H
- Fixed use of uninitialsed base_dir in rrd_mkdir_p on Win32
- Updated win32/README with details of obtaining stdint.h as well as locations
  for dependencies
