### PR TITLE
Allow sql// and sql|| (pipe pipe) for libdbi datasources

### DIFF
--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -240,7 +240,7 @@ int rrd_fetch_fn(
 
 #ifdef HAVE_LIBDBI
     /* handle libdbi datasources */
-    if (strncmp("sql//",filename,5)==0) {
+    if (strncmp("sql//",filename,5)==0 || strncmp("sql||",filename,5)==0) {
 	return rrd_fetch_fn_libdbi(filename,cf_idx,start,end,step,ds_cnt,ds_namv,data);
     }
 #endif


### PR DESCRIPTION
This update enables developers using libdbi with rrdtool to provide full paths for the sqlite3_dbdir parameter when connecting to sqlite. Here is an example:

```
sql||sqlite3|sqlite3_dbdir=/home/user/db|dbname=logger.db|.....
```
