### PR TITLE
Fix json output when printing legend entries

### DIFF
--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -804,7 +804,7 @@ int HandleInputLine(
                     rrd_value_t newval = DNAN;
                     newval = *ptr;
                     if (json){
-                        if (isnan(newval)){
+                        if (isnan(newval) || isinf(newval)){
                             printf("null");                        
                         } else {
                             printf("%0.10e",newval);


### PR DESCRIPTION
Branch 1.4 is missing this patch in order to produce valid json output.
This is related to issue #380 reported by apfeiffe.
