### PR TITLE
Make 'option to let rrdcached recursively create directories' working.

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -1863,7 +1863,7 @@ static int handle_request_create (HANDLER_PROTO) /* {{{ */
         /* realpath puts the first problematic part in dir_tmp, so we can use
          * the parent of dir_tmp to stat in order to set a reasonable mode
          * since dir_tmp is  */
-        if (stat(dirname(dir_tmp), &st) && rrd_mkdir_p(dir, st.st_mode) != 0) {
+        if (rrd_mkdir_p(dir, st.st_mode) != 0) {
             return send_response(sock, RESP_ERR, "Cannot create: %s\n", dir);
         }
     }


### PR DESCRIPTION
before: 

Escape character is '^]'.
create aaa/sta_3.rrd -b 1383013773 -s 300 DS:rxrate:GAUGE:600:U:U DS:txrate:GAUGE:600:U:U RRA:AVERAGE:0.5:1:2016 RRA:AVERAGE:0.5:6:1488 RRA:AVERAGE:0.5:24:2160 RRA:AVERAGE:0.5:288:797
-1 RRD Error: creating '/var/lib/rrdcached/db/aaa/sta_3.rrd': No such file or directory
QUIT
Connection closed by foreign host.

after:
Escape character is '^]'.
create aaa/sta_3.rrd -b 1383013773 -s 300 DS:rxrate:GAUGE:600:U:U DS:txrate:GAUGE:600:U:U RRA:AVERAGE:0.5:1:2016 RRA:AVERAGE:0.5:6:1488 RRA:AVERAGE:0.5:24:2160 RRA:AVERAGE:0.5:288:797
0 RRD created OK
