### PR TITLE
Fix rrdc_fetch behavior on RRDs with multiple DSes

### DIFF
--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -207,7 +207,7 @@ static int parse_char_array_header (char *line, /* {{{ */
 
   if (alloc == 0)
   {
-    memcpy (array, tmp_array, sizeof (tmp_array));
+    memcpy (array, tmp_array, array_len * sizeof (char*));
   }
   else
   {


### PR DESCRIPTION
When reading values from RRD files with multiple data sets, the auxiliary
parsing function would only copy the first item from the returned list; the
others were left uninitialized. On my x64_64 Linux machine, this actually reused
values form previous call to parse_char_array_header which happens to be a DS
definition. Given a RRD file with DS "a", "b" and "c", the first value on each
line would be correctly parsed, but the second value is "b", the actual DS name,
and the third one "c". These "values" cannot be parsed as numbers, and the whole
function therefore returns with an error. Making sure that all pointers within
the array are copied therefore fixes this problem.
