### PR TITLE
Cleanup gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ Makefile
 /config.status
 /etc/rrdcached.service
 /etc/rrdcached.socket
-/examples/*.pl
 /libtool
 /rrd_config.h
 /src/librrd.pc
@@ -64,3 +63,10 @@ Makefile
 
 #vim swp file
 *.swp
+
+# generated documentation files
+/doc/*.txt
+/doc/*.html
+/doc/*.1
+/doc/*.3
+/doc/pod2*.tmp

--- a/bindings/perl-piped/.gitignore
+++ b/bindings/perl-piped/.gitignore
@@ -1,0 +1,4 @@
+# generated files
+/MYMETA.yml
+/blib/
+/pm_to_blib

--- a/bindings/perl-shared/.gitignore
+++ b/bindings/perl-shared/.gitignore
@@ -1,0 +1,6 @@
+# generated files
+/MYMETA.yml
+/RRDs.bs
+/RRDs.c
+/blib/
+/pm_to_blib

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -1,0 +1,2 @@
+# generated files
+/build/

--- a/bindings/tcl/.gitignore
+++ b/bindings/tcl/.gitignore
@@ -1,3 +1,6 @@
 # autoconf generated files
 /ifCOC
 /ifOctets.tcl
+## enh-gitignore
+/pkgIndex.tcl
+/tclrrd1.4.999.so

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+# autoconf generated files
+/*.pl
+/cgi-demo.cgi

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,7 @@
+# build-generated files
+/.libs/
+/librrd.sym
+/rrdcached
+/rrdcgi
+/rrdtool
+/rrdupdate


### PR DESCRIPTION
These leave a clean response from "git status" for me after all normal steps, making it easier to see that I didn't break anything.  (I have in the past objected to ignoring some derived files, because I like doing "git clean -fd" to get back to a known state, but I've found having to run "bootstrap" after "git clean -fdx" instead is an acceptable alternative.)
