### PR TITLE
cleanup: fix make distclean in doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ Makefile
 /doc/*.1
 /doc/*.3
 /doc/pod2*.tmp
+/doc/RRD?.pod

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -6,8 +6,6 @@ AUTOMAKE_OPTIONS        =  foreign
 
 #ACLOCAL_M4 = $(top_srcdir)/config/aclocal.m4
 
-CLEANFILES = *.1 *.3 *.html *.txt *-dircache RRD?.pod *.pdf *~ core *itemcache *.rej *.orig *.tmp
-
 POD = bin_dec_hex.pod        rrddump.pod            rrdgraph_examples.pod  rrdrestore.pod         rrdupdate.pod  \
       cdeftutorial.pod       rrdfetch.pod           rrdgraph_graph.pod     rrdthreads.pod         rrdxport.pod   \
       rpntutorial.pod        rrdfirst.pod           rrdgraph_rpn.pod       rrdtool.pod            rrdcached.pod  \
@@ -34,8 +32,11 @@ TXT = $(MAN:.1=.txt) $(MAN3:.3=.txt)
 HTML = $(POD:.pod=.html) $(POD3:.pod=.html) $(PMP:.pod=.html)
 PDF = $(MAN:.1=.pdf) $(MAN3:.3=.pdf)
 
+GENERATED_EXTRADIST = $(HTML) $(MAN) $(MAN3) $(TXT) $(PMP) $(PDF)
+CLEANFILES = $(GENERATED_EXTRADIST) pod2htm*.tmp
+
 # what should go into the distribution
-EXTRA_DIST= $(POD) $(POD3) $(HTML) $(MAN) $(MAN3) $(TXT) rrdtool-dump.dtd rrdtool-xport.dtd rrdgraph_libdbi.pod rrdlua.pod
+EXTRA_DIST= $(GENERATED_EXTRADIST) $(POD) $(POD3) rrdtool-dump.dtd rrdtool-xport.dtd rrdgraph_libdbi.pod rrdlua.pod
 
 idocdir = $(RRDDOCDIR)/txt
 idoc_DATA = $(POD) $(TXT)

--- a/doc/RRDp.pod
+++ b/doc/RRDp.pod
@@ -1,1 +1,0 @@
-../bindings/perl-piped/RRDp.pm

--- a/doc/RRDs.pod
+++ b/doc/RRDs.pod
@@ -1,1 +1,0 @@
-../bindings/perl-shared/RRDs.pm


### PR DESCRIPTION
Check this one: unlike most of what I've done in cleanup this changes what goes into the distribution and what's in the repository.  If you prefer a different resolution to the inconsistencies I've noted, let me know and I'll rework it.

RRD*.pod were in the repository, but were always generated and were removed by "make distclean", resulting in an unexpected response from "git status".  Resolve this by removing them from the repository.

Also eliminate the wildcards from CLEANFILES, instead explicitly listing all derived files.

Also add a couple missed(?) files to EXTRADIST (PDF documentation and the RRD*.pod files).
