### PR TITLE
mods of #477 fix syntaxes, clarifications for rrdcached

### DIFF
--- a/doc/rrdupdate.pod
+++ b/doc/rrdupdate.pod
@@ -7,7 +7,9 @@ rrdupdate - Store a new set of values into the RRD
 B<rrdtool> {B<update> | B<updatev>} I<filename>
 S<[B<--template>|B<-t> I<ds-name>[B<:>I<ds-name>]...]>
 S<[B<--daemon>|B<-d> I<address>]> [B<-->]
-S<{{B<N> | I<timestamp>}B<:> | I<at-timestamp>B<@>}I<value>[B<:>I<value>]... ...> 
+S<B<N>B<:>I<value>[B<:>I<value>]...>
+S<I<timestamp>B<:>I<value>[B<:>I<value>]...>
+S<I<at-timestamp>B<@>I<value>[B<:>I<value>]...>
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
added text explaining templates cannot be used with rrdcached
rewrote timestamp syntax, maybe now it went to the other extreme..
removed deprecated --cache parameter from the example section
fixed --daemon behaviour description, please check if it is true
