### PR TITLE
mods of #477 rrdcached document changes/2

### DIFF
--- a/doc/rrdcached.pod
+++ b/doc/rrdcached.pod
@@ -83,7 +83,7 @@ empty string parameter.
 
 Set the group permissions of a UNIX domain socket. The option accepts either
 a numeric group id or group name. That group will then have both read and write
-permissions (the socket will have file permissions 0750) for the socket and,
+permissions (the socket will have file permissions 0760) for the socket and,
 therefore, is able to send commands to the daemon. This
 may be useful in cases where you cannot easily run all RRD processes with the same
 user privileges (e.g. graph generating CGI scripts that typically run in the
@@ -118,7 +118,7 @@ use the system default.
 
 =item B<-P> I<command>[,I<command>[,...]]
 
-Specifies the commands accepted via a network socket. This allows
+Specifies the commands accepted via both a network and a UNIX socket. This allows
 administrators of I<RRDCacheD> to control the actions accepted from various
 sources.
 


### PR DESCRIPTION
when group option is specified, socket permission is 760, not 750, i've tested this. the context confirms this behaviour is right, the text was wrong.
-P restricts unix sockets too! tested this also.
