### PR TITLE
Python bindings build with Distribute

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -28,7 +28,12 @@
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-from distutils.core import setup, Extension
+try:
+    # Attempt to build using Distribute, which also supports bdist_wheel
+    from setuptools import setup
+    from setuptools.extension import Extension
+except ImportError:
+    from distutils.core import setup, Extension
 import sys, os
 
 TOP_SRCDIR = os.environ.get('ABS_TOP_SRCDIR', '../../src')


### PR DESCRIPTION
This patch alters setup.py to build with Distribute instead of distutils. This supports existing build and package methods as well as the modern wheel format (python setup.py bdist_wheel) if the wheel package is also installed. The behaviour is to fall back to distutils in case Distribute is not importable.
