### PR TITLE
Create rrd file: Allow only short integer numbers in rpn formula

### DIFF
--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -47,7 +47,7 @@ short rpn_compact(
             /* rpnp.val is a double, rpnc.val is a short */
             double    temp = floor(rpnp[i].val);
 
-            if (temp < SHRT_MIN || temp > SHRT_MAX) {
+			if (temp < SHRT_MIN || temp > SHRT_MAX || temp != rpnp[i].val) {
                 rrd_set_error
                     ("constants must be integers in the interval (%d, %d)",
                      SHRT_MIN, SHRT_MAX);


### PR DESCRIPTION
It is possible to write a rpn formula in create rrd as decimal numbers.
But in the rrdfile it is stored as short integer.
Now an error is thrown if the number is no integer.
