### PR TITLE
rrd_info: make filename argument const

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -242,7 +242,7 @@ extern    "C" {
     int argc,
     const char **argv);
     rrd_info_t *rrd_info_r(
-    char *);
+    const char *);
 /* NOTE: rrd_update_r and rrd_update_v_r are only thread-safe if no at-style
    time specifications get used!!! */
 

--- a/src/rrd_info.c
+++ b/src/rrd_info.c
@@ -14,7 +14,7 @@ rrd_info_t *rrd_info(
     int,
     char **);
 rrd_info_t *rrd_info_r(
-    char *filename);
+    const char *filename);
 
 /* allocate memory for string */
 char     *sprintf_alloc(
@@ -156,7 +156,7 @@ rrd_info_t *rrd_info(
 } /* rrd_info_t *rrd_info */
 
 rrd_info_t *rrd_info_r(
-    char *filename)
+    const char *filename)
 {
     unsigned int i, ii = 0;
     rrd_t     rrd;


### PR DESCRIPTION
Avoids following error:

rrdinfo.cc:10:42: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
   rp = rrd_info_r("/home/pab/ted5000.rrd");

Signed-off-by: Peter A. Bigot pab@pabigot.com
