### PR TITLE
Fix src/build paths

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -36,8 +36,8 @@ except ImportError:
     from distutils.core import setup, Extension
 import sys, os
 
-TOP_SRCDIR = os.environ.get('ABS_TOP_SRCDIR', '../../src')
-TOP_BUILDDIR = os.environ.get('ABS_TOP_BUILDDIR', '../../src')
+TOP_SRCDIR = os.environ.get('ABS_TOP_SRCDIR', '../..')
+TOP_BUILDDIR = os.environ.get('ABS_TOP_BUILDDIR', '../..')
 
 setup(name = "py-rrdtool",
       version = "0.2.2",


### PR DESCRIPTION
Python bindings are built correctly from a top-level 'make'. If built using setup.py the paths point one directory too deep (remove the build directory and run 'python setup.py build' to see it fail).

This patch corrects the paths used in setup.py so that building these bindings with setup.py works in addition to them building as part of the top-level rrdtool build.
