### PR TITLE
configure.ac: remove explicit default path for libxml2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -549,7 +549,7 @@ EX_CHECK_ALL(cairo,      cairo_ps_surface_create,       cairo-ps.h,             
 EX_CHECK_ALL(pangocairo-1.0,  pango_font_map_create_context,  pango/pango.h,  pangocairo,  1.28.4,    http://ftp.gnome.org/pub/GNOME/sources/pango/1.28, "")
 
 fi
-EX_CHECK_ALL(xml2,       xmlParseFile,                  libxml/parser.h,        libxml-2.0,        2.7.8,  http://xmlsoft.org/downloads.html, /usr/include/libxml2)
+EX_CHECK_ALL(xml2,       xmlParseFile,                  libxml/parser.h,        libxml-2.0,        2.7.8,  http://xmlsoft.org/downloads.html, "")
 
 if test "$EX_CHECK_ALL_ERR" = "YES"; then
   AC_MSG_ERROR([Please fix the library issues listed above and try again.])


### PR DESCRIPTION
OpenEmbedded needs to cross-compile rrdtool, and historically has applied this patch locally because the implementation of EX_CHECK_ALL unconditionally added -I/usr/include.  Since the correct include path is automatically provided by a successful pkg-config invocation there is no need to set it explicitly.

(Commit cef27b4d0de373a6d5a865fd156a474d29179e5b changed the context so the patch OE's been using no longer applies; I figured it might as well be fixed upstream instead.)
