### PR TITLE
Fix bad_format_imginfo

### DIFF
--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -5134,7 +5134,7 @@ int bad_format_imginfo(
                 ptr++;
             /* '%s', '%S' are allowed */
             else if (*ptr == 's' || *ptr == 'S') {
-                n = 1;
+                n++;
                 ptr++;
             }
 


### PR DESCRIPTION
The previous behavior could segfault with an imginfo string such as "%s%s %lux%lu", whereas this correctly rejects that format string.

The segfault was exposed in a number of programs that call out to rrdtool, and can occasionally cause a denial of service condition for them as well.

If it's feasible for you to cut a new release given that bad_format_imginfo doesn't exist at all in 1.4.8, that would be helpful. The lack of bad_format_imginfo can be a more exploitable security concern, while this change is "just" a denial of service. (This pull request still addresses a security concern, but it's less important than the raw format string being exposed.)
