### PR TITLE
Use `env` to start tclsh instead of /bin/bash

### DIFF
--- a/bindings/tcl/ifOctets.tcl.in
+++ b/bindings/tcl/ifOctets.tcl.in
@@ -1,6 +1,4 @@
-#!/bin/sh
-# the next line restarts using tclsh -*- tcl -*- \
-exec tclsh@TCL_VERSION@ "$0" "$@"
+#!/usr/bin/env tclsh@TCL_VERSION@
 
 #package require Tnm 3.0
 package require Rrd @VERSION@


### PR DESCRIPTION
This patch replaces the shebang line using /bin/bash with /usr/bin/env.
The previous version obfuscates which shell is being used by the tcl
script. Any benefits of using Bash as a start up are provided by `env`.

This closes issue #537.
