### PR TITLE
Add "=encoding ISO8859-1" for es language.

### DIFF
--- a/doc/rrdtutorial.es.pod
+++ b/doc/rrdtutorial.es.pod
@@ -1,3 +1,4 @@
+=encoding ISO8859-1
 =head1 NAME
 
 rrdtutorial - Tutorial sobre RRDtool por Alex van den Bogaerdt


### PR DESCRIPTION
On Ubuntu 14.04, pod2man gets failure for Non-ASCII character.

Signed-off-by: darklightwu darklightwu@gmail.com
