### PR TITLE
Allow empty imginfo format string

### DIFF
--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -4021,7 +4021,7 @@ rrd_info_t *rrd_graph_v(
      ** Also, if needed, print a line with information about the image.
      */
 
-    if (im.imginfo) {
+    if (im.imginfo && *im.imginfo) {
         rrd_infoval_t info;
         char     *path;
         char     *filename;


### PR DESCRIPTION
Empty -f|--imginfo used to be very usefull to print data as text format
on stdout. It was allowed up to 1.4.7 and was particularly interesting
because there was no filename/width/height printed out. The "feature"
was broken in 1.4.8 by the addition of a format check on the imginfo
value. The recent rework based on regexp still breaks it. Adding it back
would preserve compatibility on scripts/parser eating rrdtool graph
/dev/null -f '' output.

Before :

[root@nagios-2b ~]# rrdtool graph /dev/null -f "" --start -1d \
    DEF:d=/var/lib/rrd/nagios-2b/load.rrd:load5:AVERAGE \
    VDEF:v=d,AVERAGE \
    PRINT:v:%.6lf
5.284605

After :

[root@nagios-2b ~]# rrdtool graph /dev/null -f "" --start -1d \
    DEF:d=/var/lib/rrd/nagios-2b/load.rrd:load5:AVERAGE \
    VDEF:v=d,AVERAGE \
    PRINT:v:%.6lf
ERROR: bad format for imginfo
