### PR TITLE
rrd_modify no longer exists

### DIFF
--- a/src/librrd.sym.in.in
+++ b/src/librrd.sym.in.in
@@ -37,7 +37,6 @@ rrd_last_r
 rrd_lastupdate
 rrd_lastupdate_r
 rrd_lock
-rrd_modify
 rrd_mkdir_p
 rrd_new_context
 rrd_open

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -199,9 +199,6 @@ struct rrd_t;
     int       rrd_tune(
     int,
     char **);
-    int       rrd_modify(
-    int,
-    char **);
     time_t    rrd_last(
     int,
     char **);


### PR DESCRIPTION
rd_modify seems to have gone. If I do not take these out I get link errors on librrd.so