### PR TITLE
vars may be used uninitialized. issue #576.

### DIFF
--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -5141,7 +5141,7 @@ int vdef_parse(
      * so the parsing is rather simple.  Change if needed.
      */
     double    param;
-    char      func[30], double_str[21];
+    char      func[30] = {0}, double_str[21] = {0};
     int       n;
 
     n = 0;


### PR DESCRIPTION
 This may lead to unattended behaviour at certain optimisation level, calling rrd_strtodbl on garbage.

Fixes #576 