### PR TITLE
po: add remove-potcdate.sin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Makefile
 !/po/Makevars
 !/po/Makefile.in.in
 !/po/POTFILES.in
+!/po/remove-potcdate.sin
 
 # cscope
 /cscope.*

--- a/po/remove-potcdate.sin
+++ b/po/remove-potcdate.sin
@@ -1,0 +1,19 @@
+# Sed script that remove the POT-Creation-Date line in the header entry
+# from a POT file.
+#
+# The distinction between the first and the following occurrences of the
+# pattern is achieved by looking at the hold space.
+/^"POT-Creation-Date: .*"$/{
+x
+# Test if the hold space is empty.
+s/P/P/
+ta
+# Yes it was empty. First occurrence. Remove the line.
+g
+d
+bb
+:a
+# The hold space was nonempty. Following occurrences. Do nothing.
+x
+:b
+}


### PR DESCRIPTION
My build was failing with
make rrdtool.pot-update
make[2]: Entering directory '/scratch/src/rrdtool-1.x/po'
make[2]: *** No rule to make target 'remove-potcdate.sin', needed by 'remove-potcdate.sed'.  Stop.

Fixed by adding this missing gettext-helper script.

Signed-off-by: Bernhard Reutner-Fischer <rep.dot.nop@gmail.com>