### PR TITLE
Fix I/O error detection in dump/restore

### DIFF
--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -1438,7 +1438,7 @@ int write_fh(
         strcpy(rrd->stat_head->version, "0003");
     }
 
-#define FWRITE_CHECK(ptr, size, nitems, fp)	               \
+#define FWRITE_CHECK(ptr, size, nitems, fp)                    \
     do {                                                       \
         if (fwrite((ptr), (size), (nitems), (fp)) != (nitems)) \
             return (-1);                                       \

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -2107,6 +2107,7 @@ static int handle_request_last (HANDLER_PROTO) /* {{{ */
   rrd_init(&rrd);
   rrd_file = rrd_open(file,&rrd,RRD_READONLY);
   if(!rrd_file) {
+    rrd_free(&rrd);
     return send_response(sock, RESP_ERR, "RRD Error: %s\n", rrd_get_error());
   }
   from_file = rrd.live_head->last_up;

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -472,8 +472,6 @@ read_check:
 #ifdef HAVE_MMAP
     if (data != MAP_FAILED)
       munmap(data, rrd_file->file_len);
-    rrd->__mmap_start = NULL;
-    rrd->__mmap_size = 0;
 #endif
 
     close(rrd_simple_file->fd);

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -1366,8 +1366,11 @@ int write_file(
 
     /* lets see if we had an error */
     if (ferror(fh)) {
-        rrd_set_error("a file error occurred while creating '%s'", file_name);
+        rrd_set_error("a file error occurred while creating '%s': %s", file_name,
+            rrd_strerror(errno));
         fclose(fh);
+        if (strcmp("-", file_name) != 0)
+            unlink(file_name);
         return (-1);
     }
 


### PR DESCRIPTION
The main reason for the fixes was 'rrdtool dump' not detecting I/O errors (exit code 0) and leaving incompletely written .rrd files in that case.

I also fixed a number of other bugs like:
- free'ing unallocated memory
- missing rrd_free() call