### PR TITLE
Fix pango fontmap threading issue.

### DIFF
--- a/src/rrd_graph.h
+++ b/src/rrd_graph.h
@@ -25,6 +25,7 @@
 
 #include "rrd_tool.h"
 #include "rrd_rpncalc.h"
+#include "mutex.h"
 
 #include <glib.h>
 
@@ -351,6 +352,7 @@ typedef struct image_desc_t {
     rrd_info_t *grinfo_current; /* pointing to current entry */
     GHashTable* gdef_map;  /* a map of all *def gdef entries for quick access */
     GHashTable* rrd_map;  /* a map of all rrd files in use for gdef entries */
+    mutex_t *fontmap_mutex; /* Mutex for locking the global fontmap */
 } image_desc_t;
 
 /* Prototypes */


### PR DESCRIPTION
Since pango v1.32.6 `pango_cairo_font_map_get_default` returns a per thread `fontmap`. But since we're allocating this statically on the first call to `rrd_init`,
if we then try to access it again via another thread glib will get stuck in an infinte assertion loop.

Instead use `pango_cairo_font_map_new()` when creating the `fontmap`. This will not create a per thread version and glib will be happy.

Also added some extra locking whenever using the `im->layout` pango structure that uses the `fontmap` internally as a precaution.

This fixes #600 