### PR TITLE
Straighten command line options

### DIFF
--- a/doc/rrdcgi.pod
+++ b/doc/rrdcgi.pod
@@ -4,7 +4,7 @@ rrdcgi - Create web pages containing RRD graphs based on templates
 
 =head1 SYNOPSIS
 
-C<#!/path/to/>B<rrdcgi> S<[B<--filter>]>
+C<#!/path/to/>B<rrdcgi> S<[B<--filter>|B<-f>]>
 
 =head1 DESCRIPTION
 
@@ -20,7 +20,7 @@ The argument parser uses the same semantics as you are used from your C-shell.
 
 =over 8
 
-=item B<--filter>
+=item B<--filter>|B<-f>
 
 Assume that rrdcgi is run as a filter and not as a cgi.
 

--- a/doc/rrdcreate.pod
+++ b/doc/rrdcreate.pod
@@ -9,8 +9,8 @@ S<[B<--start>|B<-b> I<start time>]>
 S<[B<--step>|B<-s> I<step>]>
 S<[B<--template>|B<-t> I<template-file>]>
 S<[B<--source>|B<-r> I<source-file>]>
-S<[B<--no-overwrite>]>
-S<[B<--daemon> I<address>]>
+S<[B<--no-overwrite>|B<-O>]>
+S<[B<--daemon>|B<-d> I<address>]>
 S<[B<DS:>I<ds-name>[B<=>I<mapped-ds-name>[B<[>I<source-index>B<]>]]B<:>I<DST>B<:>I<dst arguments>]>
 S<[B<RRA:>I<CF>B<:>I<cf arguments>]>
 
@@ -49,11 +49,11 @@ into the B<RRD>.
 A scaling factor may be present as a suffix to the integer; see
 L<"STEP, HEARTBEAT, and Rows As Durations">.
 
-=head2 B<--no-overwrite>
+=head2 B<--no-overwrite>|B<-O>
 
 Do not clobber an existing file of the same name.
 
-=head2 B<--daemon> I<address>
+=head2 B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon.  For a list of accepted formats, see 
 the B<-l> option in the L<rrdcached> manual.

--- a/doc/rrddump.pod
+++ b/doc/rrddump.pod
@@ -6,8 +6,8 @@ rrddump - dump the contents of an RRD to XML format
 
 B<rrdtool> B<dump> I<filename.rrd> [I<filename.xml>]
 S<[B<--header>|B<-h> {none,xsd,dtd}]>
-S<[B<--no-header>]>
-S<[B<--daemon> I<address>]>
+S<[B<--no-header>|B<-n>]>
+S<[B<--daemon>|B<-d> I<address>]>
 S<[E<gt> I<filename.xml>]>
 
 =head1 DESCRIPTION
@@ -36,14 +36,14 @@ By default RRDtool will add a dtd header to the xml file. Here
 you can customize this to and xsd header or no header at all.
 
 
-=item B<--no-header>
+=item B<--no-header>|B<-n>
 
 A shortcut for S<--header=none>.
 
 If you want to restore the dump with RRDtool 1.2 you should use the
 S<--no-header> option since 1.2 can not deal with xml headers.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon. If specified, a C<flush> command is sent
 to the server before reading the RRD files. This allows B<rrdtool> to return

--- a/doc/rrdfetch.pod
+++ b/doc/rrdfetch.pod
@@ -8,7 +8,8 @@ B<rrdtool> B<fetch> I<filename> I<CF>
 S<[B<--resolution>|B<-r> I<resolution>]>
 S<[B<--start>|B<-s> I<start>]>
 S<[B<--end>|B<-e> I<end>]>
-S<[B<--daemon> I<address>]>
+S<[B<--align-start>|B<-a>]>
+S<[B<--daemon>|B<-d> I<address>]>
 
 =head1 DESCRIPTION
 
@@ -60,7 +61,7 @@ the need for external calculations described in L<RESOLUTION
 INTERVAL>, though if a specific RRA is desired this will not ensure
 the start and end fall within its bounds.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon. If specified, a C<flush> command is sent
 to the server before reading the RRD files. This allows B<rrdtool> to return

--- a/doc/rrdfirst.pod
+++ b/doc/rrdfirst.pod
@@ -4,7 +4,7 @@ rrdfirst - Return the date of the first data sample in an RRA within an RRD
 
 =head1 SYNOPSIS
 
-B<rrdtool> B<first> I<filename> [I<--rraindex number>] [B<--daemon> I<address>]
+B<rrdtool> B<first> I<filename> [B<--rraindex> I<number>] [B<--daemon>|B<-d> I<address>]
 
 =head1 DESCRIPTION
 
@@ -17,13 +17,13 @@ sample entered into the specified RRA of the RRD file.
 
 The name of the B<RRD> that contains the data.
 
-=item I<--rraindex number>
+=item B<--rraindex> I<number>
 
 The index number of the B<RRA> that is to be examined. If not specified, the
 index defaults to zero. B<RRA> index numbers can be determined through
 B<rrdtool info>.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon.  For a list of accepted formats, see 
 the B<-l> option in the L<rrdcached> manual.

--- a/doc/rrdflushcached.pod
+++ b/doc/rrdflushcached.pod
@@ -5,7 +5,7 @@ rrdflushcached - Flush the values for a spcific RRD file from memory.
 =head1 SYNOPSIS
 
 B<rrdtool> B<flushcached>
-S<[B<--daemon> I<address>]>
+S<[B<--daemon>|B<-d> I<address>]>
 I<filename> [I<filename> ...]
 
 =head1 DESCRIPTION
@@ -22,7 +22,7 @@ written to disk.
 
 The name(s) of the B<RRD> file(s) that are to be written to disk.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon. If not specified, the
 RRDCACHED_ADDRESS environment variable must be set (see below).  For a

--- a/doc/rrdgraph.pod
+++ b/doc/rrdgraph.pod
@@ -362,7 +362,7 @@ can really rely on before RRDtool 1.3.7 is that lazy will not generate the
 graph when it is already there and up to date, and also that it will output
 the size of the graph. 
 
-[B<--daemon> I<address>]
+[B<-d>|B<--daemon> I<address>]
 
 Address of the L<rrdcached> daemon. If specified, a C<flush> command is sent
 to the server before reading the RRD files. This allows the graph to contain

--- a/doc/rrdinfo.pod
+++ b/doc/rrdinfo.pod
@@ -5,7 +5,7 @@ rrdinfo - extract header information from an RRD
 =head1 SYNOPSIS
 
 B<rrdtool> B<info> I<filename>
-S<[B<--daemon> I<address>]>
+S<[B<--daemon>|B<-d> I<address> S<[B<--noflush>|B<-F>]>]>
 
 =head1 DESCRIPTION
 
@@ -21,7 +21,7 @@ individual keys.
 
 The name of the B<RRD> you want to examine.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon. If specified, a C<flush> command is sent
 to the server before reading the RRD files. This allows B<rrdtool> to return
@@ -30,7 +30,7 @@ For a list of accepted formats, see the B<-l> option in the L<rrdcached> manual.
 
  rrdtool info --daemon unix:/var/run/rrdcached.sock /var/lib/rrd/foo.rrd
 
-=item B<--noflush> 
+=item B<--noflush>|B<-F>
 
 Omit the C<flush> command usually sent to the daemon prior to retrieving the
 data.  If all you are interested in the the RRD Structure, and not the last update

--- a/doc/rrdlast.pod
+++ b/doc/rrdlast.pod
@@ -5,7 +5,7 @@ rrdlast - Return the date of the last data sample in an RRD
 =head1 SYNOPSIS
 
 B<rrdtool> B<last> I<filename>
-S<[B<--daemon> I<address>]>
+S<[B<--daemon>|B<-d> I<address>]>
 
 =head1 DESCRIPTION
 
@@ -18,7 +18,7 @@ update of the RRD.
 
 The name of the B<RRD> that contains the data.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon. If specified, a C<flush> command is sent
 to the server before reading the RRD files. This allows B<rrdtool> to return
@@ -26,13 +26,6 @@ fresh data even if the daemon is configured to cache values for a long time.
 For a list of accepted formats, see the B<-l> option in the L<rrdcached> manual.
 
  rrdtool last --daemon unix:/var/run/rrdcached.sock /var/lib/rrd/foo.rrd
-
-=item B<--noflush> 
-
-If the L<rrdcached> daemon is being used, then omit the flush normally 
-send before returning the last update.  If you add this option, you get the 
-last time the file on disk was updated; if you have relatively low cache times
-and are calling this frequently it will preserve the caching benefit
 
 =back
 

--- a/doc/rrdlastupdate.pod
+++ b/doc/rrdlastupdate.pod
@@ -5,7 +5,7 @@ rrdlastupdate - Return the most recent update to an RRD
 =head1 SYNOPSIS
 
 B<rrdtool> B<lastupdate> I<filename>
-S<[B<--daemon> I<address>]>
+S<[B<--daemon>|B<-d> I<address>]>
 
 =head1 DESCRIPTION
 
@@ -18,7 +18,7 @@ value stored for each datum in the most recent update of an RRD.
 
 The name of the B<RRD> that contains the data.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon. If specified, a C<flush> command is sent
 to the server before reading the RRD files. This allows B<rrdtool> to return

--- a/doc/rrdtune.pod
+++ b/doc/rrdtune.pod
@@ -10,17 +10,18 @@ S<[B<--minimum>|B<-i> I<ds-name>:I<min>]>
 S<[B<--maximum>|B<-a> I<ds-name>:I<max>]>
 S<[B<--data-source-type>|B<-d> I<ds-name>:I<DST>]>
 S<[B<--data-source-rename>|B<-r> I<old-name>:I<new-name>]>
-S<[B<--deltapos> I<scale-value>]>
-S<[B<--deltaneg> I<scale-value>]>
-S<[B<--failure-threshold> I<failure-threshold>]>
-S<[B<--window-length> I<window-length>]>
-S<[B<--alpha> I<adaption-parameter>]>
-S<[B<--beta> I<adaption-parameter>]>
-S<[B<--gamma> I<adaption-parameter>]>
-S<[B<--gamma-deviation> I<adaption-parameter>]>
-S<[B<--smoothing-window> I<fraction-of-season>]>
-S<[B<--smoothing-window-deviation> I<fraction-of-season>]>
-S<[B<--aberrant-reset> I<ds-name>]>
+S<[B<--deltapos>|B<-p> I<scale-value>]>
+S<[B<--deltaneg>|B<-n> I<scale-value>]>
+S<[B<--failure-threshold>|B<-f> I<failure-threshold>]>
+S<[B<--window-length>|B<-w> I<window-length>]>
+S<[B<--alpha>|B<-x> I<adaption-parameter>]>
+S<[B<--beta>|B<-y> I<adaption-parameter>]>
+S<[B<--gamma>|B<-z> I<adaption-parameter>]>
+S<[B<--gamma-deviation>|B<-v> I<adaption-parameter>]>
+S<[B<--smoothing-window>|B<-s> I<fraction-of-season>]>
+S<[B<--smoothing-window-deviation>|B<-S> I<fraction-of-season>]>
+S<[B<--aberrant-reset>|B<-b> I<ds-name>]>
+S<[B<--step>|B<-t> I<newstep>]>
 S<[B<--daemon>|B<-D> I<address>]>
 S<[B<DEL:>I<ds-name>]>
 S<[B<DS:>I<ds-spec>]>
@@ -82,7 +83,7 @@ alter the type B<DST> of a data source.
 
 rename a data source.
 
-=item S<B<--deltapos> I<scale-value>>
+=item S<B<--deltapos>|B<-p> I<scale-value>>
 
 Alter the deviation scaling factor for the upper bound of the
 confidence band used internally to calculate violations for the
@@ -92,14 +93,14 @@ CDEF argument to generate a graph with confidence bounds. The graph
 scale factor need not to agree with the value used internally by the
 FAILURES B<RRA>.
 
-=item S<B<--deltaneg> I<scale-value>>
+=item S<B<--deltaneg>|B<-n> I<scale-value>>
 
 Alter the deviation scaling factor for the lower bound of the confidence band
 used internally to calculate violations for the FAILURES B<RRA>. The default
 value is 2. As with B<--deltapos>, this argument is unrelated to the scale
 factor chosen when graphing confidence bounds.
 
-=item S<B<--failure-threshold> I<failure-threshold>>
+=item S<B<--failure-threshold>|B<-f> I<failure-threshold>>
 
 Alter the number of confidence bound violations that constitute a failure for
 purposes of the FAILURES B<RRA>. This must be an integer less than or equal to
@@ -107,44 +108,44 @@ the window length of the FAILURES B<RRA>. This restriction is not verified by
 the tune option, so one can reset failure-threshold and window-length
 simultaneously. Setting this option will reset the count of violations to 0.
 
-=item S<B<--window-length> I<window-length>>
+=item S<B<--window-length>|B<-w> I<window-length>>
 
 Alter the number of time points in the temporal window for determining
 failures. This must be an integer greater than or equal to the window
 length of the FAILURES B<RRA> and less than or equal to 28. Setting
 this option will reset the count of violations to 0.
 
-=item S<B<--alpha> I<adaption-parameter>>
+=item S<B<--alpha>|B<-x> I<adaption-parameter>>
 
 Alter the intercept adaptation parameter for the Holt-Winters
 forecasting algorithm. This parameter must be between 0 and 1.
 
-=item S<B<--beta> I<adaption-parameter>>
+=item S<B<--beta>|B<-y> I<adaption-parameter>>
 
 Alter the slope adaptation parameter for the Holt-Winters forecasting
 algorithm. This parameter must be between 0 and 1.
 
-=item S<B<--gamma> I<adaption-parameter>>
+=item S<B<--gamma>|B<-z> I<adaption-parameter>>
 
 Alter the seasonal coefficient adaptation parameter for the SEASONAL
 B<RRA>. This parameter must be between 0 and 1.
 
-=item S<B<--gamma-deviation> I<adaption-parameter>>
+=item S<B<--gamma-deviation>|B<-v> I<adaption-parameter>>
 
 Alter the seasonal deviation adaptation parameter for the DEVSEASONAL
 B<RRA>. This parameter must be between 0 and 1.
 
-=item S<B<--smoothing-window> I<fraction-of-season>>
+=item S<B<--smoothing-window>|B<-s> I<fraction-of-season>>
 
 Alter the size of the smoothing window for the SEASONAL B<RRA>. This must
 be between 0 and 1.
 
-=item S<B<--smoothing-window-deviation> I<fraction-of-season>>
+=item S<B<--smoothing-window-deviation>|B<-S> I<fraction-of-season>>
 
 Alter the size of the smoothing window for the DEVSEASONAL B<RRA>. This must
 be between 0 and 1.
 
-=item S<B<--aberrant-reset> I<ds-name>>
+=item S<B<--aberrant-reset>|B<-b> I<ds-name>>
 
 This option causes the aberrant behavior detection algorithm to reset
 for the specified data source; that is, forget all it is has learnt so far.
@@ -171,6 +172,12 @@ data source.
 
 Use of this tuning option is advised when the behavior of the data source
 time series changes in a drastic and permanent manner.
+
+=item B<--step>|B<-t> I<newstep>
+
+Changes the step size of the RRD to newstep.
+
+TODO: add proper documentation
 
 =item B<--daemon>|B<-D> I<address>
 

--- a/doc/rrdupdate.pod
+++ b/doc/rrdupdate.pod
@@ -6,6 +6,7 @@ rrdupdate - Store a new set of values into the RRD
 
 B<rrdtool> {B<update> | B<updatev>} I<filename>
 S<[B<--template>|B<-t> I<ds-name>[B<:>I<ds-name>]...]>
+S<[B<--skip-past-updates>|B<-s>]>
 S<[B<--daemon>|B<-d> I<address>]> [B<-->]
 S<B<N>B<:>I<value>[B<:>I<value>]...>
 S<I<timestamp>B<:>I<value>[B<:>I<value>]...>
@@ -62,7 +63,7 @@ for the COMPUTE B<DST>.
 
 The caching daemon L<rrdcached> cannot be used together with templates yet.
 
-=item B<--skip-past-updates>
+=item B<--skip-past-updates>|B<-s>
 
 When updateing an rrd file with data earlier than the latest update already
 applied, rrdtool will issue an error message an abort. This option instructs

--- a/doc/rrdxport.pod
+++ b/doc/rrdxport.pod
@@ -10,7 +10,8 @@ S<[B<-e>|B<--end> I<seconds>]>
 S<[B<-m>|B<--maxrows> I<rows>]>
 S<[B<--step> I<value>]>
 S<[B<--json>]>
-S<[B<--daemon> I<address>]>
+S<[B<--enumds>]>
+S<[B<--daemon>|B<-d> I<address>]>
 S<[B<DEF:>I<vname>B<=>I<rrd>B<:>I<ds-name>B<:>I<CF>]>
 S<[B<CDEF:>I<vname>B<=>I<rpn-expression>]>
 S<[B<XPORT>B<:>I<vname>[B<:>I<legend>]]>
@@ -50,7 +51,7 @@ for details.
 
 See L<rrdgraph> documentation.
 
-=item B<--daemon> I<address>
+=item B<--daemon>|B<-d> I<address>
 
 Address of the L<rrdcached> daemon. If specified, a C<flush> command is sent
 to the server before reading the RRD files. This allows B<rrdtool> to return

--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -93,7 +93,7 @@ int rrd_create(
     opterr = 0;         /* initialize getopt */
 
     while (1) {
-        opt = getopt_long(argc, argv, "Ob:s:d:", long_options, &option_index);
+        opt = getopt_long(argc, argv, "b:s:d:r:t:O", long_options, &option_index);
 
         if (opt == EOF)
             break;

--- a/src/rrd_dump.c
+++ b/src/rrd_dump.c
@@ -573,7 +573,9 @@ int rrd_dump(
 	   break;
 
         default:
-            rrd_set_error("usage rrdtool %s [--header|-h {none,xsd,dtd}] [--no-header]"
+            rrd_set_error("usage rrdtool %s [--header|-h {none,xsd,dtd}]\n"
+                          "[--no-header|-n]\n"
+                          "[--daemon|-d address]\n"
                           "file.rrd [file.xml]", argv[0]);
             return (-1);
             break;
@@ -581,8 +583,10 @@ int rrd_dump(
     }                   /* while (42) */
 
     if ((argc - optind) < 1 || (argc - optind) > 2) {
-        rrd_set_error("usage rrdtool %s [--header|-h {none,xsd,dtd}] [--no-header]"
-                      "file.rrd [file.xml]", argv[0]);
+        rrd_set_error("usage rrdtool %s [--header|-h {none,xsd,dtd}]\n"
+                      "[--no-header|-n]\n"
+                      "[--daemon|-d address]\n"
+                       "file.rrd [file.xml]", argv[0]);
         return (-1);
     }
 

--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -83,7 +83,7 @@ int rrd_fetch(
         {"resolution", required_argument, 0, 'r'},
         {"start", required_argument, 0, 's'},
         {"end", required_argument, 0, 'e'},
-        {"align-start", optional_argument, 0, 'a'},
+        {"align-start", no_argument, 0, 'a'},
         {"daemon", required_argument, 0, 'd'},
         {0, 0, 0, 0}
     };

--- a/src/rrd_first.c
+++ b/src/rrd_first.c
@@ -31,7 +31,7 @@ time_t rrd_first(
         int       option_index = 0;
         int       opt;
 
-        opt = getopt_long(argc, argv, "d:F", long_options, &option_index);
+        opt = getopt_long(argc, argv, "d:", long_options, &option_index);
 
         if (opt == EOF)
             break;
@@ -55,14 +55,14 @@ time_t rrd_first(
             }
             break;
         default:
-            rrd_set_error("usage rrdtool %s [--rraindex number] [--daemon <addr>] file.rrd",
+            rrd_set_error("usage rrdtool %s [--rraindex number] [--daemon|-d <addr>] file.rrd",
                           argv[0]);
             return (-1);
         }
     }
 
     if (optind >= argc) {
-        rrd_set_error("usage rrdtool %s [--rraindex number] [--daemon <addr>] file.rrd",
+        rrd_set_error("usage rrdtool %s [--rraindex number] [--daemon|-d <addr>] file.rrd",
                       argv[0]);
         return -1;
     }

--- a/src/rrd_flushcached.c
+++ b/src/rrd_flushcached.c
@@ -60,7 +60,7 @@ int rrd_flushcached (int argc, char **argv)
                 break;
 
             default:
-                rrd_set_error ("Usage: rrdtool %s [--daemon <addr>] <file>",
+                rrd_set_error ("Usage: rrdtool %s [--daemon|-d <addr>] <file>",
                         argv[0]);
                 return (-1);
         }
@@ -68,7 +68,7 @@ int rrd_flushcached (int argc, char **argv)
 
     if ((argc - optind) < 1)
     {
-        rrd_set_error ("Usage: rrdtool %s [--daemon <addr>] <file> [<file> ...]", argv[0]);
+        rrd_set_error ("Usage: rrdtool %s [--daemon|-d <addr>] <file> [<file> ...]", argv[0]);
         return (-1);
     }
 

--- a/src/rrd_info.c
+++ b/src/rrd_info.c
@@ -127,7 +127,7 @@ rrd_info_t *rrd_info(
             break;
 
         default:
-            rrd_set_error ("Usage: rrdtool %s [--daemon <addr> [--noflush]] <file>",
+            rrd_set_error ("Usage: rrdtool %s [--daemon|-d <addr> [--noflush|-F]] <file>",
                     argv[0]);
             return (NULL);
             break;
@@ -135,7 +135,7 @@ rrd_info_t *rrd_info(
     }                   /* while (42) */
 
     if ((argc - optind) != 1) {
-        rrd_set_error ("Usage: rrdtool %s [--daemon <addr> [--noflush]] <file>",
+        rrd_set_error ("Usage: rrdtool %s [--daemon |-d <addr> [--noflush|-F]] <file>",
                 argv[0]);
         return (NULL);
     }

--- a/src/rrd_last.c
+++ b/src/rrd_last.c
@@ -45,7 +45,7 @@ time_t rrd_last(
             break;
 
         default:
-            rrd_set_error ("Usage: rrdtool %s [--daemon <addr>] <file>",
+            rrd_set_error ("Usage: rrdtool %s [--daemon|-d <addr>] <file>",
                     argv[0]);
             return (-1);
             break;
@@ -53,7 +53,7 @@ time_t rrd_last(
     }                   /* while (42) */
 
     if ((argc - optind) != 1) {
-        rrd_set_error ("Usage: rrdtool %s [--daemon <addr>] <file>",
+        rrd_set_error ("Usage: rrdtool %s [--daemon|-d <addr>] <file>",
                 argv[0]);
         return (-1);
     }

--- a/src/rrd_lastupdate.c
+++ b/src/rrd_lastupdate.c
@@ -49,7 +49,7 @@ int rrd_lastupdate (int argc, char **argv)
             break;
 
         default:
-            rrd_set_error ("Usage: rrdtool %s [--daemon <addr>] <file>",
+            rrd_set_error ("Usage: rrdtool %s [--daemon|-d <addr>] <file>",
                     argv[0]);
             return (-1);
             break;
@@ -57,7 +57,7 @@ int rrd_lastupdate (int argc, char **argv)
     }                   /* while (42) */
 
     if ((argc - optind) != 1) {
-        rrd_set_error ("Usage: rrdtool %s [--daemon <addr>] <file>",
+        rrd_set_error ("Usage: rrdtool %s [--daemon|-d <addr>] <file>",
                 argv[0]);
         return (-1);
     }

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -1412,7 +1412,7 @@ int rrd_restore(
 
         default:
             rrd_set_error("usage rrdtool %s [--range-check|-r] "
-                          "[--force-overwrite/-f]  file.xml file.rrd",
+                          "[--force-overwrite|-f]  file.xml file.rrd",
                           argv[0]);
             return (-1);
             break;
@@ -1420,8 +1420,8 @@ int rrd_restore(
     }                   /* while (42) */
 
     if ((argc - optind) != 2) {
-        rrd_set_error("usage rrdtool %s [--range-check/-r] "
-                      "[--force-overwrite/-f] file.xml file.rrd", argv[0]);
+        rrd_set_error("usage rrdtool %s [--range-check|-r] "
+                      "[--force-overwrite|-f] file.xml file.rrd", argv[0]);
         return (-1);
     }
 

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -88,7 +88,8 @@ void PrintUsage(
 
     const char *help_last =
         N_("* last - show last update time for RRD\n\n"
-           "\trrdtool last filename.rrd\n");
+           "\trrdtool last filename.rrd\n"
+           "\t\t[--daemon|-d address]\n");
 
     const char *help_lastupdate =
         N_("* lastupdate - returns the most recent datum stored for\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -123,7 +123,8 @@ void PrintUsage(
            "\trrdtool fetch filename.rrd CF\n"
            "\t\t[-r|--resolution resolution]\n"
            "\t\t[-s|--start start] [-e|--end end]\n"
-	   "\t\t[--daemon <address>]\n");
+           "\t\t[-a|--align-start]\n"
+           "\t\t[-d|--daemon <address>]\n");
 
     const char *help_flushcached =
         N_("* flushcached - flush cached data out to an RRD file\n\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -151,7 +151,7 @@ void PrintUsage(
            "\t\t[-h|--height pixels] [-o|--logarithmic]\n"
            "\t\t[-u|--upper-limit value] [-z|--lazy]\n"
            "\t\t[-l|--lower-limit value] [-r|--rigid]\n"
-           "\t\t[-g|--no-legend] [--daemon <address>]\n"
+           "\t\t[-g|--no-legend] [-d|--daemon <address>]\n"
            "\t\t[-F|--force-rules-legend]\n" "\t\t[-j|--only-graph]\n");
     const char *help_graph2 =
         N_("\t\t[-n|--font FONTTAG:size:font]\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -105,8 +105,8 @@ void PrintUsage(
         N_("* update - update an RRD\n\n"
            "\trrdtool update filename\n"
            "\t\t[--template|-t ds-name:ds-name:...]\n"
-           "\t\t[--skip-past-updates]\n"
-	   "\t\t[--daemon <address>]\n"
+           "\t\t[--skip-past-updates|-s]\n"
+	   "\t\t[--daemon|-d <address>]\n"
            "\t\ttime|N:value[:value...]\n\n"
            "\t\tat-time@value[:value...]\n\n"
            "\t\t[ time:value[:value...] ..]\n");
@@ -116,7 +116,7 @@ void PrintUsage(
            "\treturns information about values, RRAs, and datasources updated\n\n"
            "\trrdtool updatev filename\n"
            "\t\t[--template|-t ds-name:ds-name:...]\n"
-           "\t\t[--skip-past-updates]\n"
+           "\t\t[--skip-past-updates|-s]\n"
            "\t\ttime|N:value[:value...]\n\n"
            "\t\tat-time@value[:value...]\n\n"
            "\t\t[ time:value[:value...] ..]\n");

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -201,17 +201,25 @@ void PrintUsage(
            "\t\t[--data-source-type|-d ds-name:DST]\n"
            "\t\t[--data-source-rename|-r old-name:new-name]\n"
            "\t\t[--minimum|-i ds-name:min] [--maximum|-a ds-name:max]\n"
-           "\t\t[--deltapos scale-value] [--deltaneg scale-value]\n"
-           "\t\t[--failure-threshold integer]\n"
-           "\t\t[--window-length integer]\n"
-           "\t\t[--alpha adaptation-parameter]\n");
+           "\t\t[--deltapos|-p scale-value] [--deltaneg|-n scale-value]\n"
+           "\t\t[--failure-threshold|-f integer]\n"
+           "\t\t[--window-length|-w integer]\n"
+           "\t\t[--alpha|-x adaptation-parameter]\n");
     const char *help_tune2 =
-        N_("\t\t[--beta adaptation-parameter]\n"
-           "\t\t[--gamma adaptation-parameter]\n"
-           "\t\t[--gamma-deviation adaptation-parameter]\n"
-           "\t\t[--aberrant-reset ds-name]\n");
+        N_("\t\t[--beta|-y adaptation-parameter]\n"
+           "\t\t[--gamma|-z adaptation-parameter]\n"
+           "\t\t[--gamma-deviation|-v adaptation-parameter]\n"
+           "\t\t[--smoothing-window|-s fraction-of-season]\n"
+           "\t\t[--smoothing-window-deviation|-S fraction-of-season]\n"
+           "\t\t[--aberrant-reset|-b ds-name]\n");
     const char *help_tune3 = 
-	N_("\t\t???");  // FIXME
+        N_("\t\t[--step|-t newstep]\n"
+           "\t\t[--daemon|-D address]\n"
+           "\t\t[DEL:ds-name]\n"
+           "\t\t[DS:ds-spec]\n"
+           "\t\t[DELRRA:index]\n"
+           "\t\t[RRA:rra-spec]\n"
+           "\t\t[RRA#index:[+-=]number]\n");
     const char *help_resize =
         N_
         (" * resize - alter the length of one of the RRAs in an RRD\n\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -73,7 +73,10 @@ void PrintUsage(
 
     const char *help_dump =
         N_("* dump - dump an RRD to XML\n\n"
-           "\trrdtool dump filename.rrd >filename.xml\n");
+           "\trrdtool dump [--header|-h {none,xsd,dtd}]\n"
+           "\t\t[--no-header|-n]\n"
+           "\t\t[--daemon|-d address]\n"
+           "\t\tfile.rrd [file.xml]");
 
     const char *help_info =
         N_("* info - returns the configuration and status of the RRD\n\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -228,7 +228,9 @@ void PrintUsage(
         N_("* xport - generate XML dump from one or several RRD\n\n"
            "\trrdtool xport [-s|--start seconds] [-e|--end seconds]\n"
            "\t\t[-m|--maxrows rows]\n" "\t\t[--step seconds]\n"
-           "\t\t[--enumds] [--json]\n" "\t\t[DEF:vname=rrd:ds-name:CF]\n"
+           "\t\t[--enumds] [--json]\n"
+           "\t\t[-d|--daemon address]\n"
+           "\t\t[DEF:vname=rrd:ds-name:CF]\n"
            "\t\t[CDEF:vname=rpn-expression]\n"
            "\t\t[XPORT:vname:legend]\n");
     const char *help_quit =

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -96,7 +96,7 @@ void PrintUsage(
 
     const char *help_first =
         N_("* first - show first update time for RRA within an RRD\n\n"
-           "\trrdtool first filename.rrd [--rraindex number]\n");
+           "\trrdtool first filename.rrd [--rraindex number] [--daemon|-d address]\n");
 
     const char *help_update =
         N_("* update - update an RRD\n\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -93,7 +93,9 @@ void PrintUsage(
 
     const char *help_lastupdate =
         N_("* lastupdate - returns the most recent datum stored for\n"
-           "  each DS in an RRD\n\n" "\trrdtool lastupdate filename.rrd\n");
+           "  each DS in an RRD\n\n"
+           "\trrdtool lastupdate filename.rrd\n"
+           "\t\t[--daemon|-d address]\n");
 
     const char *help_first =
         N_("* first - show first update time for RRA within an RRD\n\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -64,7 +64,10 @@ void PrintUsage(
         N_("* create - create a new RRD\n\n"
            "\trrdtool create filename [--start|-b start time]\n"
            "\t\t[--step|-s step]\n"
+           "\t\t[--template|-t template-file]\n"
+           "\t\t[--source|-r source-file]\n"
            "\t\t[--no-overwrite|-O]\n"
+           "\t\t[--daemon|-d address]\n"
            "\t\t[DS:ds-name:DST:dst arguments]\n"
            "\t\t[RRA:CF:cf arguments]\n");
 

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -80,7 +80,7 @@ void PrintUsage(
 
     const char *help_info =
         N_("* info - returns the configuration and status of the RRD\n\n"
-           "\trrdtool info filename.rrd\n");
+           "\trrdtool info [--daemon|-d <addr> [--noflush|-F]] filename.rrd\n");
 
     const char *help_restore =
         N_("* restore - restore an RRD file from its XML form\n\n"

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -129,7 +129,7 @@ void PrintUsage(
     const char *help_flushcached =
         N_("* flushcached - flush cached data out to an RRD file\n\n"
            "\trrdtool flushcached filename.rrd\n"
-	   "\t\t[--daemon <address>]\n");
+	   "\t\t[-d|--daemon <address>]\n");
 
 /* break up very large strings (help_graph, help_tune) for ISO C89 compliance*/
 

--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -124,7 +124,7 @@ int rrd_tune(
     
     while (1) {
 	int option_index = 0;
-	int opt = getopt_long(argc, argv, "h:i:a:d:r:p:n:w:f:x:y:z:v:b:",
+	int opt = getopt_long(argc, argv, "h:i:a:d:r:p:n:w:f:x:y:z:v:s:S:b:t:D:",
 			      long_options, &option_index);
         if (opt == EOF)
             break;
@@ -187,7 +187,7 @@ int rrd_tune(
         int       opt;
         unsigned int strtod_ret_val;
 
-        opt = getopt_long(argc, argv, "h:i:a:d:r:p:n:w:f:x:y:z:v:b:",
+        opt = getopt_long(argc, argv, "h:i:a:d:r:p:n:w:f:x:y:z:v:s:S:b:t:D:",
                           long_options, &option_index);
         if (opt == EOF)
             break;


### PR DESCRIPTION
This patchset tries to bring some coherence between the short and long command-line options, the documentation and the rrdtool help. It adds code for documented but unimplemented options and it documents the "hidden" options.

After trying to get _rrdtool create -t file.rrd -r file.rrd ..._ working, I took a look at the code only to find that the short options for template and source were not implemented.

As a suggestion, and since rrdtool already relies on glib, it might be a good idea to use its [commandline option parser](https://developer.gnome.org/glib/stable/glib-Commandline-option-parser.html) ?