### PR TITLE
define _DEFAULT_SOURCE alongside _BSD_SOURCE

### DIFF
--- a/src/rrd_config_bottom.h
+++ b/src/rrd_config_bottom.h
@@ -10,6 +10,7 @@
 #  undef _BSD_SOURCE
 # endif
 # define _XOPEN_SOURCE 600
+# define _DEFAULT_SOURCE 1
 # define _BSD_SOURCE 1
 # include <features.h>
 #endif


### PR DESCRIPTION
_BSD_SOURCE deprecated since glibc 2.20 and _DEFAULT_SOURCE should be used
instead. Define both to fix deprecation warning.

Quoting the man page feature_test_macros(7):
Since glibc 2.20, this macro is deprecated.  It now has the same effect as
defining _DEFAULT_SOURCE, but generates a compile-time warning (unless
_DEFAULT_SOURCE is also defined).  Use _DEFAULT_SOURCE instead.  To allow
code that requires _BSD_SOURCE in glibc 2.19 and earlier and _DEFAULT_SOURCE
in glibc 2.20 and later to compile without warnings, define both _BSD_SOURCE
and _DEFAULT_SOURCE.