### PR TITLE
Add permissions to the sockets acquired from systemd during the socke…

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -3453,6 +3453,12 @@ static int open_listen_sockets_systemd(void) /* {{{ */
 
     listen_fds[listen_fds_num].fd = sd_fd;
     listen_fds[listen_fds_num].family = sa.sun_family;
+    /* Add permissions to the socket */
+    if (default_socket.permissions != 0)
+      socket_permission_copy(&listen_fds[listen_fds_num], &default_socket);
+    else
+      /* Add permission for ALL commands to the socket. */
+      socket_permission_set_all(&listen_fds[listen_fds_num]);
     listen_fds_num++;
   }
 


### PR DESCRIPTION


When rrdcached is started via socket activation process, the file descriptors received from systemd never get permissions added to them. Permissions are usually assigned inside read_options() function, but in case of socket activation, we discard all the file descriptors processed there.
As a result, any request gets denied:
```
info /var/lib/munin/switches/home/dlink-snmp_dlink_if_3-send-d.rrd
-1 Permission denied.
```
This PR makes sure permissions get assigned when rrdcached initializes the sockets during open_listen_sockets_systemd() function call.
