### PR TITLE
Fix the python module's name

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -49,7 +49,7 @@ setup(name = "py-rrdtool",
       #packages = ['rrdtool'],
       ext_modules = [
           Extension(
-            "rrdtoolmodule",
+            "rrdtool",
             ["rrdtoolmodule.c"],
             libraries=['rrd'],
             library_dirs=[ os.path.join(TOP_BUILDDIR, 'src', '.libs') ],


### PR DESCRIPTION
Hi

While upgrading rrdtool Debian package to 1.5, I reviewed local patches, and I noticed this one that you may like. It's related to renaming the python module from "rrdtoolmodule" to "rrdtool", as seen in your commit:9acd7d279f4c4290ad01702794450ac9c0bc3c87

Basically, it renames the python C module from /usr/lib/python2.7/dist-packages/rrdtoolmodule.so into /usr/lib/python2.7/dist-packages/rrdtool.so
This patch is applied in Debian since 2008.

Before the patch:
```
$ python -c 'import rrdtool'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named rrdtool

$ python -c 'import rrdtoolmodule'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: dynamic module does not define init function (initrrdtoolmodule)
```

After the patch, python bindings works correctly:
```
import rrdtool
rrdtool.graphv('temperature_py.png', 'DEF:t=temperature.rrd:temp:AVERAGE', 'LINE1:t#0000FF:temperature')
...
```

Cheers