### PR TITLE
Hurd first part

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,7 @@ AC_C_BIGENDIAN
 dnl for each function found we get a definition in config.h 
 dnl of the form HAVE_FUNCTION
 
-AC_CHECK_FUNCS(nl_langinfo tzset fsync mbstowcs opendir readdir chdir chroot getgid getuid setgid setuid strndup strerror snprintf vsnprintf vasprintf fpclass class fp_class isnan memmove strchr mktime getrusage gettimeofday getpwnam getgrnam)
+AC_CHECK_FUNCS(nl_langinfo tzset fsync mbstowcs opendir readdir chdir chroot getgid getuid setgid setuid strndup strerror snprintf vsnprintf vasprintf fpclass class fp_class isnan memmove strchr mktime getrusage gettimeofday getpwnam getgrnam get_current_dir_name)
 
 AC_FUNC_STRERROR_R
 

--- a/src/rrd_graph.h
+++ b/src/rrd_graph.h
@@ -30,11 +30,6 @@
 #include <glib.h>
 
 
-#ifdef WIN32
-#  include <windows.h>
-#  define MAXPATH MAX_PATH
-#endif
-
 #define ALTYGRID  	 0x01   /* use alternative y grid algorithm */
 #define ALTAUTOSCALE	 0x02   /* use alternative algorithm to find lower and upper bounds */
 #define ALTAUTOSCALE_MIN 0x04   /* use alternative algorithm to find lower bounds */
@@ -270,7 +265,7 @@ typedef struct graph_desc_t {
 typedef struct image_desc_t {
 
     /* configuration of graph */
-    char      graphfile[MAXPATH];   /* filename for graphic */
+    char      *graphfile;   /* filename for graphic */
     enum      gfx_type_en graph_type; /* type of the graph */
     long      xsize, ysize; /* graph area size in pixels */
     struct gfx_color_t graph_col[__GRC_END__];  /* real colors for the graph */

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -595,7 +595,13 @@ int HandleInputLine(
                 printf("ERROR: invalid parameter count for pwd\n");
                 return (1);
             }
+#ifdef MAXPATH
             cwd = getcwd(NULL, MAXPATH);
+#elif defined(HAVE_GET_CURRENT_DIR_NAME)
+            cwd = get_current_dir_name();
+#else
+#error "You must have either MAXPATH or get_current_dir_name()"
+#endif
             if (cwd == NULL) {
                 printf("ERROR: getcwd %s\n", rrd_strerror(errno));
                 return (1);

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -394,7 +394,7 @@ int rrd_graph_xport(image_desc_t *im) {
   }
 
   /* if we write a file, then open it */
-  if (strlen(im->graphfile)) {
+  if (im->graphfile) {
     buffer.file=fopen(im->graphfile,"w");
   }
 


### PR DESCRIPTION
Here's the first part of support for systems that don't hard code a file name length limit.

This is based on a patch by Marc Dequènes back in 2008, for version 1.3.7

The general idea for rrd_graph is to have image_desc_t.graphfile as a char*
I wrote a macro RRD_IMGDESC_HAS_FILE(image_desc) because there was a lot of #ifdef in the code. Not sure about the name nor the location, fell free to change them.

A few notes:
- In im_free(), in free(im->graphfile), I'm counting on the fact that free(NULL) is OK.
- In graph_cairo_finish, in error handling, I'm counting on the fact that printf("%s", NULL) prints "(null)". I'm unsure this is portable. Tested ok here.