### PR TITLE
Keep CPPFLAGS when building tcl bindings

### DIFF
--- a/bindings/tcl/Makefile.am
+++ b/bindings/tcl/Makefile.am
@@ -46,7 +46,7 @@ $(TCL_RRD_LIB): tclrrd.o
 	$(TCL_SHLIB_LD) $(TCL_LD_SEARCH_FLAGS) $(LIBDIRS) $< -o $@ -lrrd_th -lm $(TCL_STUB_LIB_SPEC) $(LDFLAGS) $(LIBS)
 
 tclrrd.o: tclrrd.c
-	$(CC) $(AM_CFLAGS) $(CFLAGS) $(TCL_SHLIB_CFLAGS) $(AM_CPPFLAGS) -c $(srcdir)/tclrrd.c -DVERSION=\"$(VERSION)\"
+	$(CC) $(AM_CFLAGS) $(CFLAGS) $(TCL_SHLIB_CFLAGS) $(AM_CPPFLAGS) $(CPPFLAGS) -c $(srcdir)/tclrrd.c -DVERSION=\"$(VERSION)\"
 
 pkgIndex.tcl:
 	echo "package ifneeded Rrd $(VERSION) \"load $(libdir)/tclrrd$(VERSION)[info sharedlibextension]\"" > $@


### PR DESCRIPTION
If CPPFLAGS=-D_FORTIFY_SOURCE=2 during configuration, tcl compilation was not fortified.
This patch adds the missing variable.