### PR TITLE
Lua5.2

### DIFF
--- a/bindings/lua/rrdlua.c
+++ b/bindings/lua/rrdlua.c
@@ -350,7 +350,7 @@ set_info (lua_State * L)
 
 /**********************************************************/
 
-static const struct luaL_reg rrd[] = {
+static const struct luaL_Reg rrd[] = {
   {"create", lua_rrd_create},
   {"dump", lua_rrd_dump},
   {"fetch", lua_rrd_fetch},
@@ -383,7 +383,7 @@ luaopen_rrd (lua_State * L)
   /* luaL_module is defined in compat-5.1.c */
   luaL_module (L, "rrd", rrd, 0);
 #else
-  luaL_register (L, "rrd", rrd);
+  luaL_newlib (L, rrd);
 #endif
   set_info (L);
   return 1;

--- a/bindings/lua/rrdlua.c
+++ b/bindings/lua/rrdlua.c
@@ -350,7 +350,13 @@ set_info (lua_State * L)
 
 /**********************************************************/
 
+#if defined LUA50
+static const struct luaL_reg rrd[] = {
+#elif LUA_VERSION_NUM == 501
 static const struct luaL_Reg rrd[] = {
+#else
+static const struct luaL_Reg rrd[] = {
+#endif
   {"create", lua_rrd_create},
   {"dump", lua_rrd_dump},
   {"fetch", lua_rrd_fetch},
@@ -382,8 +388,11 @@ luaopen_rrd (lua_State * L)
 #if defined LUA50
   /* luaL_module is defined in compat-5.1.c */
   luaL_module (L, "rrd", rrd, 0);
+#elif LUA_VERSION_NUM == 501
+  /* version 5.1 */
+  luaL_register (L, "rrd", rrd);
 #else
-  luaL_newlib (L, rrd);
+  luaL_newlib(L, rrd);
 #endif
   set_info (L);
   return 1;

--- a/configure.ac
+++ b/configure.ac
@@ -810,8 +810,8 @@ LUA_EOF
       LIBS=
       lua_havelib=no
       LUA_HAVE_COMPAT51=DONT_HAVE_COMPAT51
-      AC_SEARCH_LIBS(lua_call, lua$lua_vdot lua$lua_vndot lua,
-        [AC_SEARCH_LIBS(luaL_register, lua$lua_vdot lua$lua_vndot lua,
+      RRD_SEARCH_LIBS(lua_call, [#include <${lua_headerdir:+$lua_headerdir/}lua.h>], [0, 0, 0], lua$lua_vdot lua$lua_vndot lua,
+        [AC_SEARCH_LIBS(luaL_openlibs, lua$lua_vdot lua$lua_vndot lua,
           [lua_havelib=LUA$lua_vndot],
           [AC_SEARCH_LIBS(luaL_module, lualib$lua_vndot lualib$lua_vdot lualib,
             [lua_havelib=$lua_vndot; $LUA -l compat-5.1 2>/dev/null;

--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -612,3 +612,31 @@ AC_DEFUN([GC_TIMEZONE], [
                 fi
         fi
 ])
+
+dnl Like AC_SEARCH_LIBS, but allowing specifying a prologue and arguments so
+dnl that macros expand correctly.
+AC_DEFUN([RRD_SEARCH_LIBS],
+[AS_VAR_PUSHDEF([rrd_Search], [rrd_cv_search_$1])dnl
+AC_CACHE_CHECK([for library containing $1], [rrd_Search],
+[rrd_func_search_save_LIBS=$LIBS
+AC_LANG_CONFTEST([AC_LANG_PROGRAM([$2], [$1 ($3);])])
+for rrd_lib in '' $4; do
+  if test -z "$rrd_lib"; then
+    rrd_res="none required"
+  else
+    rrd_res=-l$rrd_lib
+    LIBS="-l$rrd_lib $7 $rrd_func_search_save_LIBS"
+  fi
+  AC_LINK_IFELSE([], [AS_VAR_SET([rrd_Search], [$rrd_res])])
+  AS_VAR_SET_IF([rrd_Search], [break])
+done
+AS_VAR_SET_IF([rrd_Search], , [AS_VAR_SET([rrd_Search], [no])])
+rm conftest.$ac_ext
+LIBS=$rrd_func_search_save_LIBS])
+AS_VAR_COPY([rrd_res], [rrd_Search])
+AS_IF([test "$rrd_res" != no],
+  [test "$rrd_res" = "none required" || LIBS="$rrd_res $LIBS"
+  $5],
+      [$6])
+AS_VAR_POPDEF([rrd_Search])dnl
+])


### PR DESCRIPTION
This add support for lua5.2

The first patch is from Ubuntu. It migrates from lua5.1 to 5.2.

The second patch adds some conditionals so that lua 5.0 and 5.1 still work, along with 5.2.

Reminder for testers: In 5.2, you need `rrd=require("rdd")` while before `require("rrd")` was enough.