### PR TITLE
Support 390x format of nl_langinfo(FIRST_WEEKDAY)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -526,6 +526,8 @@ AC_LANG_POP(C)
 dnl is time_t 32 of 64 bit ?
 AC_CHECK_SIZEOF([time_t])
 
+AC_CHECK_SIZEOF([long int])
+
 CONFIGURE_PART(Find 3rd-Party Libraries)
 
 have_libdbi=no

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -1500,8 +1500,18 @@ static int find_first_weekday(void){
         first_weekday = nl_langinfo (_NL_TIME_FIRST_WEEKDAY)[0];
         int week_1stday;
         long week_1stday_l = (long) nl_langinfo (_NL_TIME_WEEK_1STDAY);
-        if (week_1stday_l == 19971130) week_1stday = 0; /* Sun */
-        else if (week_1stday_l == 19971201) week_1stday = 1; /* Mon */
+        if (week_1stday_l == 19971130
+#if SIZEOF_LONG_INT > 4
+            || week_1stday_l >> 32 == 19971130
+#endif
+           )
+            week_1stday = 0; /* Sun */
+        else if (week_1stday_l == 19971201
+#if SIZEOF_LONG_INT > 4
+           || week_1stday_l >> 32 == 19971201
+#endif
+           )
+            week_1stday = 1; /* Mon */
         else
         {
             first_weekday = 1;

--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -512,8 +512,18 @@ static int find_first_weekday(void){
         first_weekday = nl_langinfo (_NL_TIME_FIRST_WEEKDAY)[0];
         int week_1stday;
         long week_1stday_l = (long) nl_langinfo (_NL_TIME_WEEK_1STDAY);
-        if (week_1stday_l == 19971130) week_1stday = 0; /* Sun */
-        else if (week_1stday_l == 19971201) week_1stday = 1; /* Mon */
+        if (week_1stday_l == 19971130
+#if SIZEOF_LONG_INT > 4
+            || week_1stday_l >> 32 == 19971130
+#endif
+           )
+            week_1stday = 0; /* Sun */
+        else if (week_1stday_l == 19971201
+#if SIZEOF_LONG_INT > 4
+           || week_1stday_l >> 32 == 19971201
+#endif
+           )
+            week_1stday = 1; /* Mon */
         else
         {
             first_weekday = 1;


### PR DESCRIPTION
nl_langinfo returns non-portable format for FIRST_WEEKDAY. See
https://www.gnu.org/software/libc/manual/html_node/The-Elegant-and-Fast-Way.html#The-Elegant-and-Fast-Way

That patch adds support for the format used on 390x architecture.
This permits the unit tests to work there.