### PR TITLE
Fixed perl-shared default path

### DIFF
--- a/bindings/perl-shared/Makefile.PL
+++ b/bindings/perl-shared/Makefile.PL
@@ -27,8 +27,8 @@ if (($Config{'osname'} eq 'MSWin32' && $ENV{'OSTYPE'} eq '')) {
 		) : ()
 	);
 }else{
-	my $TOP_SRCDIR = $ENV{'ABS_TOP_SRCDIR'} || '../../..';
-	my $TOP_BUILDDIR = $ENV{'ABS_TOP_BUILDDIR'} || '../../..';
+	my $TOP_SRCDIR = $ENV{'ABS_TOP_SRCDIR'} || '../..';
+	my $TOP_BUILDDIR = $ENV{'ABS_TOP_BUILDDIR'} || '../..';
 	my $SRCDIR = $ENV{'ABS_SRCDIR'} || '.';
 	# if the last argument when calling Makefile.PL is RPATH=/... and ... is the
 	# path to librrd.so then the Makefile will be written such that RRDs.so knows


### PR DESCRIPTION
This is only used if you use makemaker directly in the perl-shared directory.
Usually, bindings/Makefile will set up the right value.