### PR TITLE
Fix recursive directory creation in rrdcached on FREEBSD

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -475,7 +475,7 @@ static int open_pidfile(char *action, int oflag) /* {{{ */
     return -1;
   }
 
-  dir = dirname(file_copy);
+  dir = strdup(dirname(file_copy));
   if (rrd_mkdir_p(dir, 0777) != 0)
   {
     fprintf(stderr, "Failed to create pidfile directory '%s': %s\n",
@@ -2168,7 +2168,7 @@ static int handle_request_create (HANDLER_PROTO) /* {{{ */
   RRDD_LOG(LOG_INFO, "rrdcreate request for %s",file);
 
   pthread_mutex_lock(&rrdfilecreate_lock);
-  dir = dirname(file_copy);
+  dir = strdup(dirname(file_copy));
   if (realpath(dir, dir_tmp) == NULL && errno == ENOENT) {
     if (!config_allow_recursive_mkdir) {
         rc = send_response(sock, RESP_ERR,
@@ -3167,7 +3167,7 @@ static int open_listen_socket_unix (const listen_socket_t *sock) /* {{{ */
     return (-1);
   }
 
-  dir = dirname(path_copy);
+  dir = strdup(dirname(path_copy));
   if (rrd_mkdir_p(dir, 0777) != 0)
   {
     fprintf(stderr, "Failed to create socket directory '%s': %s\n",


### PR DESCRIPTION
Function dirname repeatedly overwrites and returns same pointer. Duplication of string returned in pointer solved the problem. Changes to rrd_daemon.c are sufficient - rrd_utils.c is fixed for safer future use.