### PR TITLE
rrd_parsetime now unlocks its mutex also after parsing errors.

### DIFF
--- a/src/rrd_parsetime.c
+++ b/src/rrd_parsetime.c
@@ -843,8 +843,12 @@ char     *rrd_parsetime(
     /* yes this code is non re-entrant ... so lets make sure we do not run
        in twice */
     mutex_lock(&parsetime_mutex);
+
     char *result = rrd_parsetime_nomt(tspec, ptv);
+
+    /* ok done ... drop the mutex lock */
     mutex_unlock(&parsetime_mutex);
+
     return result;
 }
 
@@ -1005,11 +1009,9 @@ static char     *rrd_parsetime_nomt(
             panic(e("the specified time is incorrect (out of range?)"));
         }
     EnsureMemFree();
-    /* ok done ... drop the mutex lock */
-    mutex_unlock(&parsetime_mutex);
 
     return TIME_OK;
-}                       /* rrd_parsetime */
+}                       /* rrd_parsetime_nomt */
 
 
 int rrd_proc_start_end(

--- a/src/rrd_parsetime.c
+++ b/src/rrd_parsetime.c
@@ -832,16 +832,28 @@ static char *day(
 
 static mutex_t parsetime_mutex = MUTEX_INITIALIZER;
 
+static char     *rrd_parsetime_nomt(
+    const char *tspec,
+    rrd_time_value_t * ptv);
+    
 char     *rrd_parsetime(
+    const char *tspec,
+    rrd_time_value_t * ptv)
+{
+    /* yes this code is non re-entrant ... so lets make sure we do not run
+       in twice */
+    mutex_lock(&parsetime_mutex);
+    char *result = rrd_parsetime_nomt(tspec, ptv);
+    mutex_unlock(&parsetime_mutex);
+    return result;
+}
+
+static char     *rrd_parsetime_nomt(
     const char *tspec,
     rrd_time_value_t * ptv)
 {
     time_t    now = time(NULL);
     int       hr = 0;
-
-    /* yes this code is non re-entrant ... so lets make sure we do not run
-       in twice */
-    mutex_lock(&parsetime_mutex);
 
     /* this MUST be initialized to zero for midnight/noon/teatime */
 


### PR DESCRIPTION
Hello,
I have found a problematic behaviour in rrd_parsetime. When rrd_xport is called multiple times in a process and there are errors in parsing --start or --end parameters, the process blocks endless because the parsetime_mutex is locked.
The reason is, that try() and panic() leaving the function without unlocking the mutex.