### PR TITLE
Fix JSON and JSONTIME export with gprints or rules

### DIFF
--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -415,7 +415,7 @@ rpnp_t   *rpn_parse(
         }
 
         else {
-            rrd_set_error("don't undestand '%s'",expr);
+            rrd_set_error("don't understand '%s'",expr);
             free(rpnp);
             return NULL;
         }

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -1067,10 +1067,10 @@ int rrd_xport_format_addprints(int flags,stringbuffer_t *buffer,image_desc_t *im
   /* now add gprints */
   if (gprints.len) {
     if (json){
-      snprintf(buf,sizeof(buf),"    \"%s\": [\n","gprints");
+      snprintf(buf,sizeof(buf),"    ,\"%s\": [\n","gprints");
       addToBuffer(buffer,buf,0);
       addToBuffer(buffer,(char*)gprints.data+2,gprints.len-2);
-      addToBuffer(buffer,"\n        ],\n",0);
+      addToBuffer(buffer,"\n        ]\n",0);
     } else {
       snprintf(buf,sizeof(buf),"    <%s>\n", "gprints");
       addToBuffer(buffer,buf,0);
@@ -1083,10 +1083,10 @@ int rrd_xport_format_addprints(int flags,stringbuffer_t *buffer,image_desc_t *im
   /* now add rules */
   if (rules.len) {
     if (json){
-      snprintf(buf,sizeof(buf),"    \"%s\": [\n","rules");
+      snprintf(buf,sizeof(buf),"    ,\"%s\": [\n","rules");
       addToBuffer(buffer,buf,0);
       addToBuffer(buffer,(char*)rules.data+2,rules.len-2);
-      addToBuffer(buffer,"\n        ],\n",0);
+      addToBuffer(buffer,"\n        ]\n",0);
     } else {
       snprintf(buf,sizeof(buf),"    <%s>\n", "rules");
       addToBuffer(buffer,buf,0);


### PR DESCRIPTION
when you have gprints or rules, json is not formated correctly : a comma is inserted after each block, making two mistakes :
- there is no comma between "legend" and "gprints" block
- there is a trailing comma in "meta" block

So, JSON output is incorrect and does not pass basic checks.

I decided to rewrite this part and add the comma before each block, so this works in all cases : when you don't have any block, only one of them or both.

To reproduce the problem : 
```
/rrdtool graph output.json --imgformat JSONTIME DEF:user=file.rrd:user:AVERAGE XPORT:user#ff0000
/rrdtool graph output.json --imgformat JSONTIME DEF:user=file.rrd:user:AVERAGE XPORT:user#ff0000 VDEF:totalmax=user,AVERAGE GPRINT:totalmax:"%6.2lf"
```