### PR TITLE
Use memmove instead of memcpy in rrd_write() to fix undefined behaviour

### DIFF
--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -808,7 +808,8 @@ ssize_t rrd_write(
         rrd_set_error("attempting to write beyond end of file (%ld + %ld > %ld)",rrd_file->pos, count, old_size);
         return -1;
     }
-    memcpy(rrd_simple_file->file_start + rrd_file->pos, buf, count);
+    /* can't use memcpy since the areas overlap when tuning */
+    memmove(rrd_simple_file->file_start + rrd_file->pos, buf, count);
     rrd_file->pos += count;
     return count;       /* mimmic write() semantics */
 #else


### PR DESCRIPTION
At least rrdtune ends up calling rrd_write() with the same memory
area for the source and the destination, causing undefined behaviour that has been observed to actually break on the mips architecture.

Presumably the mmap'ed disk IO overhead makes the memmove performance penalty negligible.

Bug-Debian: https://bugs.debian.org/805391
Bug: https://github.com/oetiker/rrdtool-1.x/issues/688