### PR TITLE
Update tcl gitignore for version 1.5

### DIFF
--- a/bindings/tcl/.gitignore
+++ b/bindings/tcl/.gitignore
@@ -3,4 +3,4 @@
 /ifOctets.tcl
 ## enh-gitignore
 /pkgIndex.tcl
-/tclrrd1.4.999.so
+/tclrrd1.5.999.so


### PR DESCRIPTION
I get this warning when I do a `git status`:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	bindings/tcl/tclrrd1.5.999.so
```