### PR TITLE
m4/acinclude.m4: fix for build error 'possibly undefined macro: AS_VAR_COPY

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -13,6 +13,15 @@ dnl EX_CHECK_ALL(library, function, header, pkgconf name, tested-version, homepa
 dnl              $1       $2        $3      $4            $5              $6        $7
 dnl
 dnl
+
+dnl
+dnl Fix for 'configure:31803: error: possibly undefined macro: AS_VAR_COPY'
+dnl     when building on RHEL 6 (autoconf 2.63)
+dnl     see https://github.com/gdnsd/gdnsd/issues/85
+m4_ifndef([AS_VAR_COPY],
+[m4_define([AS_VAR_COPY],
+[AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
+
 AC_DEFUN([EX_CHECK_ALL],
 [
  AC_LANG_PUSH(C)


### PR DESCRIPTION
Fix build on RHEL6 / autoconf 2.63 or older.