### PR TITLE
rrdcached: Adds CLI option '-V log_level'

### DIFF
--- a/doc/rrdcached.pod
+++ b/doc/rrdcached.pod
@@ -24,6 +24,7 @@ B<rrdcached>
 [B<-s>E<nbsp>I<group>]
 [B<-t>E<nbsp>I<write_threads>]
 [B<-U>E<nbsp>I<user>]]
+[B<-V>E<nbsp>I<log_level>]
 [B<-w>E<nbsp>I<timeout>]
 [B<-z>E<nbsp>I<delay>]
 
@@ -156,6 +157,20 @@ be accepted, too.
 =back
 
 Please also read L</"SECURITY CONSIDERATIONS"> below.
+
+=item B<-V> I<log_level>
+
+rrdcached under load can severely flood the logs. This command line option
+specifies the maximum log_level to be used, meaning that a message with
+verbosity I<higher> than log_level is muted (LOG_EMERG being the lowest and
+LOG_DEBUG highest).
+
+Accepted values for "log_level" (lowest to highest verbosity):
+LOG_EMERG, LOG_ALERT, LOG_CRIT, LOG_ERR, LOG_WARNING, LOG_NOTICE, LOG_INFO, LOG_DEBUG
+
+Default log level when this flag is I<NOT> present: B<LOG_ERR>
+
+See also: L<syslog.h>
 
 =item B<-w> I<timeout>
 


### PR DESCRIPTION
rrdcached under load can severely flood the logs. This PR adds a command line option to specify the maximum log_level to be used, meaning that a message with verbosity **higher** than log_level is muted (LOG_EMERG being the lowest and LOG_DEBUG highest).

syslog.h:
```
#define LOG_EMERG       0       /* system is unusable */
#define LOG_ALERT       1       /* action must be taken immediately */
#define LOG_CRIT        2       /* critical conditions */
#define LOG_ERR         3       /* error conditions */
#define LOG_WARNING     4       /* warning conditions */
#define LOG_NOTICE      5       /* normal but significant condition */
#define LOG_INFO        6       /* informational */
#define LOG_DEBUG       7       /* debug-level messages */
```

Option: "-V [log_level]"
Accepted values for "log_level": LOG_EMERG, LOG_ALERT, ... , LOG_DEBUG
Default log level when this flag is NOT present: LOG_ERR