### PR TITLE
Fix "mkdir -p"

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -2293,7 +2293,8 @@ static int handle_request_create (HANDLER_PROTO) /* {{{ */
         goto done;
     }
     if (rrd_mkdir_p(dir, 0755) != 0) {
-        rc = send_response(sock, RESP_ERR, "Cannot create: %s\n", dir);
+        rc = send_response(sock, RESP_ERR, "Cannot create %s: %s\n",
+                           dir, strerror(errno));
         pthread_mutex_unlock(&rrdfilecreate_lock);
         goto done;
     }

--- a/src/rrd_utils.c
+++ b/src/rrd_utils.c
@@ -222,7 +222,7 @@ int rrd_mkdir_p(const char *pathname_unsafe, mode_t mode)
         return -1;
     }
 #else
-    if (0 != mkdir(pathname, mode)) {
+    if ((mkdir(pathname, mode) != 0) && (errno != EEXIST)) {
         free(pathname);
         return -1;
     }


### PR DESCRIPTION
This PR fixes a race condition when using rrdcached with "-R" option with several threads trying to mkdir the same directory (or simply if the directory already exists), and improves the log message in case of mkdir failure.