### PR TITLE
adds command 'LIST'

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -11,7 +11,7 @@ POD = bin_dec_hex.pod        rrddump.pod            rrdgraph_examples.pod  rrdre
       rpntutorial.pod        rrdfirst.pod           rrdgraph_rpn.pod       rrdtool.pod            rrdcached.pod  \
       rrd-beginners.pod      rrdinfo.pod            rrdtune.pod            rrdbuild.pod           rrdflushcached.pod   \
       rrdcgi.pod             rrdgraph.pod           rrdlast.pod            rrdlastupdate.pod                     \
-      rrdcreate.pod          rrdgraph_data.pod      rrdresize.pod          rrdtutorial.pod                       
+      rrdcreate.pod          rrdgraph_data.pod      rrdresize.pod          rrdtutorial.pod        rrdlist.pod
 
 if BUILD_LIBDBI
   POD += rrdgraph_libdbi.pod

--- a/doc/rrdcached.pod
+++ b/doc/rrdcached.pod
@@ -367,6 +367,10 @@ xport
 
 create
 
+=item *
+
+list
+
 =back
 
 The B<update> command can send values to the daemon instead of writing them to
@@ -739,6 +743,11 @@ message itself.  The first user command after B<BATCH> is command number one.
     server:  2 Errors
     server:  1 message for command 1
     server:  12 message for command 12
+
+=item B<LIST> I<path>
+
+This command allows to list directories and rrd databases as seen by the daemon.
+The root "directory" is the base_dir (see '-b dir').
 
 =item B<QUIT>
 

--- a/doc/rrdlist.pod
+++ b/doc/rrdlist.pod
@@ -1,0 +1,51 @@
+=head1 NAME
+
+rrdlist - List directories and rrd databases.
+
+=head1 SYNOPSIS
+
+B<rrdtool> B<list>
+S<[B<--daemon>|B<-d> I<address>]>
+I<path>
+
+=head1 DESCRIPTION
+
+The B<list> function connects to L<rrdcached>, the RRD caching daemon,
+and issues a "list" command for the given path. This provides an 'ls-like'
+interface for traversing and listing the rrd database tree.
+
+=over 8
+
+=item I<path>
+
+The path (starting with '/') with '/' being the rrdcached base_dir.
+
+=item B<--daemon>|B<-d> I<address>
+
+Address of the L<rrdcached> daemon. If not specified, the
+RRDCACHED_ADDRESS environment variable must be set (see below).  For a
+list of accepted formats, see the B<-l> option in the L<rrdcached>
+manual.
+
+ rrdtool list --daemon 127.0.0.1:42218 /cluster/nodes/node1
+
+=back
+
+=head1 ENVIRONMENT VARIABLES
+
+The following environment variables may be used to change the behavior of
+C<rrdtoolE<nbsp>list>:
+
+=over 4
+
+=item B<RRDCACHED_ADDRESS>
+
+If this environment variable is set it will have the same effect as specifying
+the C<--daemon> option on the command line. If both are present, the command
+line argument takes precedence.
+
+=back
+
+=head1 AUTHOR
+
+Sebastien Dugue <sebastien.dugue@atos.net>

--- a/doc/rrdtool.pod
+++ b/doc/rrdtool.pod
@@ -111,6 +111,10 @@ Export data retrieved from one or several RRDs. Check L<rrdxport>.
 
 Flush the values for a specific RRD file from memory. Check L<rrdflushcached>.
 
+=item B<list>
+
+List the directories and rrd databases remotely. Check L<rrdlist>.
+
 =back
 
 =head2 HOW DOES RRDTOOL WORK?

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,7 +51,9 @@ RRD_C_FILES =		\
 	rrd_fetch.c	\
 	rrd_fetch_cb.c  \
 	rrd_resize.c \
-	rrd_tune.c
+	rrd_tune.c	\
+	rrd_list.c
+
 
 if BUILD_RRDGRAPH
 RRD_C_FILES += rrd_graph.c	\

--- a/src/librrd.sym
+++ b/src/librrd.sym
@@ -36,6 +36,8 @@ rrd_last
 rrd_last_r
 rrd_lastupdate
 rrd_lastupdate_r
+rrd_list
+rrd_list_r
 rrd_lock
 rrd_mkdir_p
 rrd_new_context

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -165,6 +165,7 @@ struct rrd_t;
     rrd_info_t * data);
     void      rrd_info_free(
     rrd_info_t *);
+    char      *rrd_list(int, char **);
     int       rrd_update(
     int,
     char **);

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -166,6 +166,7 @@ struct rrd_t;
     void      rrd_info_free(
     rrd_info_t *);
     char      *rrd_list(int, char **);
+    char      *rrd_list_r(char *dirname);
     int       rrd_update(
     int,
     char **);

--- a/src/rrd_client.h
+++ b/src/rrd_client.h
@@ -51,6 +51,7 @@ int rrdc_update (const char *filename, int values_num,
     const char * const *values);
 
 rrd_info_t * rrdc_info (const char *filename);
+char *rrdc_list(const char *dirname);
 time_t rrdc_last (const char *filename);
 time_t rrdc_first (const char *filename, int rraindex);
 int rrdc_create (const char *filename,
@@ -72,6 +73,8 @@ int rrdc_create_r2 (const char *filename,
 int rrdc_flush (const char *filename);
 int rrdc_forget (const char *filename);
 int rrdc_flush_if_daemon (const char *opt_daemon, const char *filename);
+int rrdc_flushall (void);
+int rrdc_flushall_if_daemon (const char *opt_daemon);
 
 int rrdc_fetch (const char *filename,
     const char *cf,

--- a/src/rrd_list.c
+++ b/src/rrd_list.c
@@ -38,7 +38,7 @@ char *rrd_list(int argc, char **argv)
 			if (opt_daemon != NULL) {
 				free (opt_daemon);
 			}
-			opt_daemon = strdup (optarg);
+			opt_daemon = strdup (options.optarg);
 			if (opt_daemon == NULL)
 			{
 				rrd_set_error ("strdup failed.");
@@ -71,7 +71,7 @@ char *rrd_list(int argc, char **argv)
 
 	}
 
-	if ((argc - optind) != 1) {
+	if ((argc - options.optind) != 1) {
 		rrd_set_error ("Usage: rrdtool %s [--daemon <addr> [--noflush]] <directory>",
                 argv[0]);
 
@@ -97,7 +97,7 @@ char *rrd_list(int argc, char **argv)
 	rrdc_connect (opt_daemon);
 
 	if (rrdc_is_connected (opt_daemon)) {
-		list = rrdc_list(argv[optind]);
+		list = rrdc_list(argv[options.optind]);
 		rrdc_disconnect();
 
 	} else {
@@ -109,7 +109,7 @@ char *rrd_list(int argc, char **argv)
 				fprintf(stderr, ": %s", err);
 			fprintf(stderr, "\n");
 		}
-		list = rrd_list_r(argv[optind]);
+		list = rrd_list_r(argv[options.optind]);
 	}
 
 	if (opt_daemon != NULL) {

--- a/src/rrd_list.c
+++ b/src/rrd_list.c
@@ -1,0 +1,120 @@
+
+#include <stdio.h>
+
+#include "rrd_tool.h"
+#include "rrd_client.h"
+
+char *rrd_list_r(char *dirname);
+char *rrd_list(int argc, char **argv);
+
+char *rrd_list_r(char *dirname)
+{
+	printf("rrd_list_r not implemented yet\n");
+	return NULL;
+}
+
+char *rrd_list(int argc, char **argv)
+{
+	char *opt_daemon = NULL;
+	int status;
+	int flushfirst = 1;
+	char *list;
+
+	static struct optparse_long long_options[] = {
+		{"daemon", 'd', OPTPARSE_REQUIRED},
+		{"noflush", 'F', OPTPARSE_NONE},
+		{0},
+	};
+	struct optparse options;
+	int    opt;
+	char    *err = NULL;
+
+        optparse_init(&options, argc, argv);
+
+        while ((opt = optparse_long(&options, long_options, NULL)) != -1) {
+
+		switch (opt) {
+		case 'd':
+			if (opt_daemon != NULL) {
+				free (opt_daemon);
+			}
+			opt_daemon = strdup (optarg);
+			if (opt_daemon == NULL)
+			{
+				rrd_set_error ("strdup failed.");
+				return NULL;
+			}
+			break;
+
+		case 'F':
+			flushfirst = 0;
+			break;
+
+
+                case '?':
+                        if (opt_daemon)
+                        	free(opt_daemon);
+                        rrd_set_error("%s", options.errmsg);
+                        return NULL;
+                        break;
+
+		default:
+			rrd_set_error ("Usage: rrdtool %s [--daemon <addr> [--noflush]] <file>",
+				       argv[0]);
+			if (opt_daemon != NULL) {
+				free (opt_daemon);
+			}
+
+			return NULL;
+			break;
+		}
+
+	}
+
+	if ((argc - optind) != 1) {
+		rrd_set_error ("Usage: rrdtool %s [--daemon <addr> [--noflush]] <directory>",
+                argv[0]);
+
+		if (opt_daemon != NULL) {
+			free (opt_daemon);
+		}
+
+		return NULL;
+	}
+
+	if( flushfirst ) {
+		status = rrdc_flushall_if_daemon(opt_daemon);
+
+		if (status) {
+			if (opt_daemon != NULL) {
+				free (opt_daemon);
+			}
+
+			return NULL;
+		}
+	}
+
+	rrdc_connect (opt_daemon);
+
+	if (rrdc_is_connected (opt_daemon)) {
+		list = rrdc_list(argv[optind]);
+		rrdc_disconnect();
+
+	} else {
+		if (opt_daemon) {
+			fprintf(stderr, "Error connecting to rrdcached");
+			err = rrd_get_error();
+
+			if (err)
+				fprintf(stderr, ": %s", err);
+			fprintf(stderr, "\n");
+		}
+		list = rrd_list_r(argv[optind]);
+	}
+
+	if (opt_daemon != NULL) {
+		free(opt_daemon);
+	}
+
+	return list;
+}

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -53,7 +53,7 @@ void PrintUsage(
     const char *help_list =
         N_
         ("Valid commands: create, update, updatev, graph, graphv,  dump, restore,\n"
-         "\t\tlast, lastupdate, first, info, fetch, tune\n"
+         "\t\tlast, lastupdate, first, info, list, fetch, tune,\n"
          "\t\tresize, xport, flushcached\n");
 
     const char *help_listremote =
@@ -81,6 +81,10 @@ void PrintUsage(
     const char *help_info =
         N_("* info - returns the configuration and status of the RRD\n\n"
            "\trrdtool info [--daemon|-d <addr> [--noflush|-F]] filename.rrd\n");
+
+    const char *help_listrrds =
+        N_("* list - returns the list of RRDs\n\n"
+           "\trrdtool list [--daemon <address>] [--noflush] <dirname>\n");
 
     const char *help_restore =
         N_("* restore - restore an RRD file from its XML form\n\n"
@@ -252,7 +256,7 @@ void PrintUsage(
         N_("RRDtool is distributed under the Terms of the GNU General\n"
            "Public License Version 2. (www.gnu.org/copyleft/gpl.html)\n\n"
            "For more information read the RRD manpages\n");
-    enum { C_NONE, C_CREATE, C_DUMP, C_INFO, C_RESTORE, C_LAST,
+    enum { C_NONE, C_CREATE, C_DUMP, C_INFO, C_LIST, C_RESTORE, C_LAST,
         C_LASTUPDATE, C_FIRST, C_UPDATE, C_FETCH, C_GRAPH, C_GRAPHV,
         C_TUNE,
         C_RESIZE, C_XPORT, C_QUIT, C_LS, C_CD, C_MKDIR, C_PWD,
@@ -267,6 +271,8 @@ void PrintUsage(
             help_cmd = C_DUMP;
         else if (!strcmp(cmd, "info"))
             help_cmd = C_INFO;
+        else if (!strcmp(cmd, "list"))
+            help_cmd = C_LIST;
         else if (!strcmp(cmd, "restore"))
             help_cmd = C_RESTORE;
         else if (!strcmp(cmd, "last"))
@@ -321,6 +327,9 @@ void PrintUsage(
         break;
     case C_INFO:
         puts(_(help_info));
+        break;
+    case C_LIST:
+        puts(_(help_listrrds));
         break;
     case C_RESTORE:
         puts(_(help_restore));
@@ -682,7 +691,15 @@ int HandleInputLine(
         rrd_info_print(data);
         rrd_info_free(data);
     }
+    else if (strcmp("list", argv[1]) == 0) {
+        char *list;
+        list = rrd_list(argc - 1, &argv[1]);
 
+	if (list) {
+	  printf("%s", list);
+	  free(list);
+	}
+    }
     else if (strcmp("--version", argv[1]) == 0 ||
              strcmp("version", argv[1]) == 0 ||
              strcmp("v", argv[1]) == 0 ||

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	dump-restore \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
-	create-from-template-1 dcounter1 vformatter1 xport1
+	create-from-template-1 dcounter1 vformatter1 xport1 list1
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/list1
+++ b/tests/list1
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+BASE=$BASEDIR/`basename $0`
+BUILD=$BUILDDIR/`basename $0`
+LIST_DIR=$BUILDDIR/`basename $0`_dir
+
+# This is used both for 'direct' tests and for tests via rrdcached 
+# (when RRDCACHED_ADDRESS is exported). In that case the 'root' directory
+# is BASEDIR (see '-b' in functions::run_cached) and the paths in tests
+# must be changed accordingly (see $LIST_TEST_DIR, $rrd)
+function do_list_tests()
+{
+        [ "$1" == "" ] && return 1
+        [ "$1" == "$LIST_DIR" ] && LIST_TEST_DIR="$1" || LIST_TEST_DIR="./$1"
+
+        list_count=`$RRDTOOL list "$LIST_TEST_DIR" 2>/dev/null | wc -l`
+        test $list_count -eq 0
+        report "empty directory $LIST_TEST_DIR returns nothing"
+
+        rrd_name=`basename ${BUILD}.rrd`
+        [ "$LIST_TEST_DIR" == "$LIST_DIR" ] && rrd=${BUILD}.rrd || rrd="/${rrd_name}"
+        list_name=`$RRDTOOL list $rrd`
+        test "$list_name" == "$rrd_name"
+        report "single file $rrd "
+
+        cp ${BUILD}.rrd "$LIST_TEST_DIR"/
+        cp ${BUILD}.rrd "$LIST_TEST_DIR"/second.rrd
+        cp ${BUILD}.rrd "$LIST_TEST_DIR"/third.rrd
+        list_count=`$RRDTOOL list "$LIST_TEST_DIR" | wc -l`
+        test $list_count -eq 3
+        report "directory with several RRDs"
+
+        touch "$LIST_TEST_DIR"/not_an_rrd
+        list_count=`$RRDTOOL list "$LIST_TEST_DIR" | wc -l`
+        test $list_count -eq 3
+        report "only lists files with .rrd suffix"
+
+        mkdir -p "$LIST_TEST_DIR"/new_dir
+        list_count=`$RRDTOOL list "$LIST_TEST_DIR" | wc -l`
+        test $list_count -eq 4
+        report "only lists RRDs and directories"
+}
+
+################################################################################
+rm -rf "$LIST_DIR"
+
+# if running via 'make check TESTS_STYLE="rrdcached"', use the existing instance
+if [ -n "$RRDCACHED_ADDRESS" ]; then
+        TEMP_RRDCACHED_ADDRESS=$RRDCACHED_ADDRESS
+        unset RRDCACHED_ADDRESS
+fi
+
+$RRDTOOL create ${BUILD}.rrd --start 1300000000 --step 60s DS:dv:DDERIVE:300:U:U DS:wh:DCOUNTER:300:0:U RRA:AVERAGE:0.5:1:600 RRA:AVERAGE:0.5:10:144
+report create
+
+list_count=`LC_ALL=C $RRDTOOL list | grep -c Usage`
+test $list_count -eq 1
+report "list without parameters displays Usage"
+
+mkdir -p "$LIST_DIR" || report "Failed to create '$LIST_DIR'; abort"
+do_list_tests "$LIST_DIR"
+rm -rf "$LIST_DIR"
+
+echo -e "\nStarting rrdcached..."
+if [ -n "$TEMP_RRDCACHED_ADDRESS" ]; then
+        export RRDCACHED_ADDRESS=$TEMP_RRDCACHED_ADDRESS
+else
+        run_cached
+fi
+
+if is_cached; then
+        mkdir -p "$LIST_DIR" 
+        # This relies on '-b' setting in functions::run_cached()
+        CACHED_DIR=`echo "$LIST_DIR" | sed "s|^$BASEDIR/||"`
+        do_list_tests "$CACHED_DIR"
+
+        # rrdcached-specific tests
+        ( cd "$LIST_DIR"; ln -s /tmp ./; )
+        list_count=`$RRDTOOL list "$CACHED_DIR" | grep -c '^tmp$'`
+        test $list_count -eq 0
+        report "escape from cached basedir via symlink denied"
+
+        rm -rf "$LIST_DIR"
+        stop_cached || true
+else
+        echo "rrdcached not started - skipping"
+fi
+report "tests with rrdcached"

--- a/win32/librrd-4.def
+++ b/win32/librrd-4.def
@@ -16,6 +16,7 @@ rrd_first
 rrd_first_r
 rrd_flush
 rrd_flushcached
+rrd_flushall
 rrd_free
 rrd_free_context
 rrd_freemem
@@ -29,6 +30,8 @@ rrd_info_free
 rrd_info_print
 rrd_info_push
 rrd_info_r
+rrd_list
+rrd_list_r
 rrd_init
 rrd_last
 rrd_last_r
@@ -63,6 +66,7 @@ rrdc_connect
 rrdc_is_connected
 rrdc_disconnect
 rrdc_flush
+rrdc_flushall
 rrdc_stats_free
 rrdc_stats_get
 rrdc_update


### PR DESCRIPTION
This PR adds a new command 'LIST' which allows traversal of the "remote filesystem" of an rrdcached instance. This permits to perform a "discovery" of the directory tree (with '/' being the rrdcached base_dir as specified by '-b' option). We use this (via Python bindings) to add rrdtool as backend into graphite-web; the LIST allows to have the element tree on the left as seen for example here: 

![graphite-remote](https://cloud.githubusercontent.com/assets/5499488/17935052/534937d8-6a1a-11e6-818a-9d5fde29a1b3.png)


Example of the traversal:

```
export RRDCACHED_ADDRESS=sid0:42219
$ rrdtool list /
sid
$ rrdtool list /sid          
switch
node
$ rrdtool list /sid/node/sid0
hca1
$ rrdtool list /sid/node/sid0/hca1
chip1
$ rrdtool list /sid/node/sid0/hca1/chip1
port1
$ rrdtool list /sid/node/sid0/hca1/chip1/port1
transport.rrd
error.rrd
data.rrd
```
