### PR TITLE
fix segfault on non-existent RRD file when using rrdcached

### DIFF
--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -3794,7 +3794,7 @@ int graph_paint(
     }
 
     /* pull the data from the rrd files ... */
-    if (data_fetch(im) == -1)
+    if (data_fetch(im) != 0)
         return -1;
     /* evaluate VDEF and CDEF operations ... */
     if (data_calc(im) == -1)


### PR DESCRIPTION
"rrdtool graph" fails (segmentation violation) when used in combination of rrdcached and requesting data from a non-existent round-robin database file.  We have fixed the upstream code to ensure these requests no longer make it to rrdtool, but rrdtool shouldn't segfault.

All this pull request does is to change "data_fetch(im) == -1" to "data_fetch(im) != 0" in rrd_graph.c:graph_paint.  The specific return value I need to fix the segfault is EINVAL, but I beleive all other non-zero return values should short circuit graph_paint.  I checked rrd_client.c:1420,1427(the one at issue),1435,1441,1452,1462,621,639(only negatives values make it through, i.e. the DIE's and "parsed.field_cnt+5"? from rrd_daemon.c).  rrdc_fetch's return value isn't used when ALLOW_MISSING_DS is in effect.  So, I am confident 0 is the only return value for data_fetch whereby execution of graph_paint should continue.

Before the change, this is the segfault:
$ rrdtool graph /dev/null --daemon /var/run/rrdcached/rrdcached.sock --start -3600s --end now DEF:avg=/var/lib/ganglia/rrds/DOESNT_EXIST/__SummaryInfo__/cpu_num.rrd:sum:AVERAGE PRINT:avg:AVERAGE:%.2lf
Segmentation fault (core dumped)

After:
$ rrdtool graph /dev/null --daemon /var/run/rrdcached/rrdcached.sock --start -3600s --end now DEF:avg=/var/lib/ganglia/rrds/DOESNT_EXIST/__SummaryInfo__/cpu_num.rrd:sum:AVERAGE PRINT:avg:AVERAGE:%.2lf
ERROR: realpath(/var/lib/ganglia/rrds/DOESNT_EXIST/__SummaryInfo__/cpu_num.rrd): No such file or directory