### PR TITLE
src/rrd_list.c: fix local directory listing when connection to rrdcached fails

### DIFF
--- a/src/rrd_list.c
+++ b/src/rrd_list.c
@@ -246,6 +246,9 @@ char *rrd_list(int argc, char **argv)
 			if (err)
 				fprintf(stderr, ": %s", err);
 			fprintf(stderr, "\n");
+
+			free(opt_daemon);
+			return NULL;
 		}
 		list = rrd_list_r(argv[options.optind]);
 


### PR DESCRIPTION
Without this fix, when the remote rrdcached cannot be reached and a path that exists on the local machine (such as '/') is asked for,  'list' returns 'ls' of the local path.

Example of erroneous output:

```
	$ rrdtool list -d rrdcached-host:42222 /
        Error connecting to rrdcached: Unable to connect to rrdcached: Connection refused
        var
        storage
        lib
        sysroot
        rules.d
        lib64
        backup
        opt
        bin
        sbin
        boot
        proc
        usr
        dev
        sys
        srv
        mnt
        run
        etc
        media
        tmp
        home
        root
        ERROR: Unable to connect to rrdcached: Connection refused
```