### PR TITLE
Fix a signedness/unsignedness conversion bug in the expression

### DIFF
--- a/src/rrd_dump.c
+++ b/src/rrd_dump.c
@@ -411,7 +411,7 @@ int rrd_dump_cb_r(
             now = (rrd.live_head->last_up
                    - rrd.live_head->last_up
                    % (rrd.rra_def[i].pdp_cnt * rrd.stat_head->pdp_step))
-                + (timer * rrd.rra_def[i].pdp_cnt * rrd.stat_head->pdp_step);
+                + (timer * (long)rrd.rra_def[i].pdp_cnt * (long)rrd.stat_head->pdp_step);
 
             timer++;
 #if HAVE_STRFTIME


### PR DESCRIPTION
calculating "now" before printout of the timestamp.  Negative values
are first cast to unsigned, it seems, causing overflow.

This is the fix belonging to issue #749, where the title is actually
misleading.
