### PR TITLE
src/rrd_daemon.c: fix incorrect line number reporting by rrdcached in fetch

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -1981,7 +1981,9 @@ static int handle_request_fetch (HANDLER_PROTO) /* {{{ */
 	linebuf_fill = 0;
       }
     }
-    if (linebuf_fill>0) {
+
+    /* only print out a line if parsed something */
+    if (i > 0) {
       add_response_info (sock, "%s\n", linebuf);
     }
   } /* for (t) */


### PR DESCRIPTION
Example of error:
```
rrdtool fetch --daemon 127.0.0.1:42218 <path_to>.rrd --start -5min LAST
ERROR: rrdc_fetch: Got 34 lines, expected 37
```

  While the same, without `--daemon <address>` works fine.

  The bug manifests itself when the last element of line to write falls
  within the last 10% of the length of 'char linebuf[1024]', ie between
  922 and 1023 bytes; in that case the '\n' at the end of the line is
  not written, and so not seen by count_lines(), wrong number of lines
  given in the daemon's response -> 'rrdtool fetch' errors out.

src/rrd_daemon.c:1978
```
  if (linebuf_fill>sizeof(linebuf)*9/10) {
    add_response_info (sock, linebuf);
    memset (linebuf, 0, sizeof (linebuf));
    linebuf_fill = 0;
  }
}
if (linebuf_fill>0) {
  add_response_info (sock, "%s\n", linebuf);
}
```

If this condition is TRUE, and in case of `i == parsed.field_cnt` (line 1972), `linebuf_fill` is reset to 0, the for-loop ends, with the condition `linebuf_fill>0` the end of line marker '\n' is NOT written and a new line starts. 

At the end the daemon sends response with `XX Success` where XX is calculated by counting '\n' and doesn't match the number of lines expected by rrdtool fetch.