### PR TITLE
Add deamon variable to cache key

### DIFF
--- a/src/rrd_graph.h
+++ b/src/rrd_graph.h
@@ -46,7 +46,7 @@
 #define NO_RRDTOOL_TAG 0x400  /* disable the rrdtool tag */
 #define ALLOW_MISSING_DS 0x800  /* missing DS is not fatal */
 
-#define gdes_fetch_key(x)  sprintf_alloc("%s:%d:%d:%d:%d",x.rrd,x.cf,x.cf_reduce,x.start_orig,x.end_orig,x.step_orig)
+#define gdes_fetch_key(x)  sprintf_alloc("%s:%s:%d:%d:%d:%d",x.rrd,x.daemon,x.cf,x.cf_reduce,x.start_orig,x.end_orig,x.step_orig)
 
 enum tmt_en { TMT_SECOND = 0, TMT_MINUTE, TMT_HOUR, TMT_DAY,
     TMT_WEEK, TMT_MONTH, TMT_YEAR


### PR DESCRIPTION
This allows for two identically named rrd's on two different rrdcache daemons
to be graphed on the same graph. Without this patch the following

rrdtool graph - --start=1478559600 --end=1478685600 --width=1000 --step=300 --imgformat=JSONTIME \
  DEF:rrd1=aname.rrd:ds_name:AVERAGE:daemon=rrdcache1 \
  DEF:rrd2=aname.rrd:ds_name:AVERAGE:daemon=rrdcache2

would not actually fetch any data from rrdcache2, but rrd2 would reuse the data from rrd1,
since the current logic determines them to be equal.

With this patch rrd2 data is actually fetched from rrdcache2.