### PR TITLE
restart rrdcached on upgrade, start and stop in install/uninstall

### DIFF
--- a/rrdtool.spec
+++ b/rrdtool.spec
@@ -325,6 +325,10 @@ else # Upgrading
     /sbin/service rrdcached restart || :
 fi
 
+%posttrans
+/sbin/chkconfig --add rrdcached || :
+/sbin/service rrdcached restart || :
+
 %preun cached
 if [ $1 -lt 1 ] # Uninstalling
 then

--- a/rrdtool.spec
+++ b/rrdtool.spec
@@ -317,18 +317,28 @@ find examples/ -type f -exec chmod 0644 {} \;
 %post -p /sbin/ldconfig
 
 %post cached
-/sbin/chkconfig --add rrdcached
-/sbin/service rrdcached start
+/sbin/chkconfig --add rrdcached || :
+if [ $1 -lt 2 ] # Installing
+then
+    /sbin/service rrdcached start || :
+else # Upgrading
+    /sbin/service rrdcached restart || :
+fi
 
 %preun cached
-/sbin/service rrdcached stop
+if [ $1 -lt 1 ] # Uninstalling
+then
+    /sbin/service rrdcached stop || :
+    /sbin/chkconfig --del rrdcached || :
+fi
 
 %postun -p /sbin/ldconfig
 
 %postun cached
-/sbin/chkconfig --del rrdcached
-test "$1" != 0 || /usr/sbin/userdel %rrdcached_user &>/dev/null || :
-#test "$1" != 0 || /usr/sbin/groupdel %rrdcached_user &>/dev/null || :
+if [ $1 -lt 1 ] # Uninstalling
+then
+    /usr/sbin/userdel %rrdcached_user &>/dev/null || :
+fi
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
While using this spec file we had problems when upgrading rrdtool-cached. The package had disabled autostarting rrdcached due to the order of which the RPM scriptlets are run (pre, post new package then preun, postun old package) when doing an upgrade.

To mitigate the problem where the old pre- and postun scriplets are executed during and upgrade I added the %posttrans scriptlet which is run absolute last.

Values and recommendation taken from: https://fedoraproject.org/wiki/Packaging:Scriptlets

Signed-off-by: Tomas Vestelind <tomas.vestelind@gmail.com>