### PR TITLE
rrd_list: adds --recursive option (daemon: LIST [RECURSIVE] /<path..>)

### DIFF
--- a/bindings/python/rrdtoolmodule.c
+++ b/bindings/python/rrdtoolmodule.c
@@ -770,7 +770,8 @@ static char _rrdtool_list__doc__[] = "List RRDs in storage.\n\n" \
   "Usage: list(args..)\n\
   Arguments:\n\n\
     dirname\n\
-    [--daemon HOST]";
+    [-r|--recursive]\n\
+    [-d|--daemon address]";
 
 static PyObject *
 _rrdtool_list(PyObject *Py_UNUSED(self), PyObject *args)

--- a/doc/rrdcached.pod
+++ b/doc/rrdcached.pod
@@ -744,10 +744,10 @@ message itself.  The first user command after B<BATCH> is command number one.
     server:  1 message for command 1
     server:  12 message for command 12
 
-=item B<LIST> I<path>
+=item B<LIST> [RECURSIVE] I/<path>
 
 This command allows to list directories and rrd databases as seen by the daemon.
-The root "directory" is the base_dir (see '-b dir').
+The root "directory" is the base_dir (see '-b dir'). When invoked with 'LIST RECURSIVE /<path>' it will behave similarly to 'ls -R' but limited to rrd files (listing all the rrd bases in the subtree of <path>, skipping empty directories).
 
 =item B<QUIT>
 

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -166,7 +166,7 @@ struct rrd_t;
     void      rrd_info_free(
     rrd_info_t *);
     char      *rrd_list(int, char **);
-    char      *rrd_list_r(char *dirname);
+    char      *rrd_list_r(int, char *dirname);
     int       rrd_update(
     int,
     char **);

--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -1297,7 +1297,7 @@ rrd_info_t * rrdc_info (const char *filename) /* {{{ */
   return info;
 } /* }}} int rrdc_info */
 
-char *rrd_client_list(rrd_client_t *client, const char *dirname) /* {{{ */
+char *rrd_client_list(rrd_client_t *client, int recursive, const char *dirname) /* {{{ */
 {
   char buffer[RRD_CMD_MAX];
   char *buffer_ptr;
@@ -1325,6 +1325,15 @@ char *rrd_client_list(rrd_client_t *client, const char *dirname) /* {{{ */
   if (status != 0) {
     rrd_set_error ("rrdc_list: out of memory");
     return NULL;
+  }
+
+  if (recursive) {
+    status = buffer_add_string ("RECURSIVE", &buffer_ptr, &buffer_free);
+    if (status != 0)
+    {
+      rrd_set_error ("rrdc_list: out of memory");
+      return (NULL);
+    }
   }
 
   status = buffer_add_string (dirname, &buffer_ptr, &buffer_free);
@@ -1396,11 +1405,11 @@ out_free_res:
 
   return list;
 } /* }}} char *rrd_client_list */
-char *rrdc_list(const char *dirname) /* {{{ */
+char *rrdc_list(int recursive, const char *dirname) /* {{{ */
 {
   char *files;
   mutex_lock(&lock);
-  files = rrd_client_list(&default_client, dirname);
+  files = rrd_client_list(&default_client, recursive, dirname);
   mutex_unlock(&lock);
   return files;
 } /* }}} char *rrdc_list */

--- a/src/rrd_client.h
+++ b/src/rrd_client.h
@@ -74,7 +74,7 @@ int rrd_client_update(rrd_client_t *client, const char *filename, int values_num
     const char * const *values);
 
 rrd_info_t * rrd_client_info(rrd_client_t *client, const char *filename);
-char *rrd_client_list(rrd_client_t *client, const char *dirname);
+char *rrd_client_list(rrd_client_t *client, int recursive, const char *dirname);
 time_t rrd_client_last(rrd_client_t *client, const char *filename);
 time_t rrd_client_first(rrd_client_t *client, const char *filename, int rraindex);
 int rrd_client_create(rrd_client_t *client, const char *filename,
@@ -121,7 +121,7 @@ int rrdc_update (const char *filename, int values_num,
     const char * const *values);
 
 rrd_info_t * rrdc_info (const char *filename);
-char *rrdc_list(const char *dirname);
+char *rrdc_list(int recursive, const char *dirname);
 time_t rrdc_last (const char *filename);
 time_t rrdc_first (const char *filename, int rraindex);
 int rrdc_create (const char *filename,

--- a/tests/list1
+++ b/tests/list1
@@ -6,7 +6,7 @@ BASE=$BASEDIR/`basename $0`
 BUILD=$BUILDDIR/`basename $0`
 LIST_DIR=$BUILDDIR/`basename $0`_dir
 
-# This is used both for 'direct' tests and for tests via rrdcached 
+# This is used both for 'direct' tests and for tests via rrdcached
 # (when RRDCACHED_ADDRESS is exported). In that case the 'root' directory
 # is BASEDIR (see '-b' in functions::run_cached) and the paths in tests
 # must be changed accordingly (see $LIST_TEST_DIR, $rrd)
@@ -28,19 +28,29 @@ function do_list_tests()
         cp ${BUILD}.rrd "$LIST_TEST_DIR"/
         cp ${BUILD}.rrd "$LIST_TEST_DIR"/second.rrd
         cp ${BUILD}.rrd "$LIST_TEST_DIR"/third.rrd
-        list_count=`$RRDTOOL list "$LIST_TEST_DIR" | wc -l`
+
+        list_count=`$RRDTOOL list "/$1" | wc -l`
         test $list_count -eq 3
         report "directory with several RRDs"
 
         touch "$LIST_TEST_DIR"/not_an_rrd
-        list_count=`$RRDTOOL list "$LIST_TEST_DIR" | wc -l`
+        list_count=`$RRDTOOL list "/$1" | wc -l`
         test $list_count -eq 3
         report "only lists files with .rrd suffix"
 
         mkdir -p "$LIST_TEST_DIR"/new_dir
-        list_count=`$RRDTOOL list "$LIST_TEST_DIR" | wc -l`
+        list_count=`$RRDTOOL list "/$1" | wc -l`
         test $list_count -eq 4
         report "only lists RRDs and directories"
+
+        mkdir -p "$LIST_TEST_DIR"/new_dir2
+        mkdir -p "$LIST_TEST_DIR"/new_dir3
+        mkdir -p "$LIST_TEST_DIR"/new_dir4
+        cp ${BUILD}.rrd "$LIST_TEST_DIR"/new_dir2/fourth.rrd
+        cp ${BUILD}.rrd "$LIST_TEST_DIR"/new_dir2/fifth.rrd
+        list_count=`$RRDTOOL list --recursive "/$1" | wc -l`
+        test $list_count -eq 5
+        report "recursive list only lists rrd files"
 }
 
 ################################################################################
@@ -71,7 +81,7 @@ else
 fi
 
 if is_cached; then
-        mkdir -p "$LIST_DIR" 
+        mkdir -p "$LIST_DIR"
         # This relies on '-b' setting in functions::run_cached()
         CACHED_DIR=`echo "$LIST_DIR" | sed "s|^$BASEDIR/||"`
         do_list_tests "$CACHED_DIR"


### PR DESCRIPTION
This behaves similarly to 'ls -R' but limited to rrd files (listing all the rrd bases in the subtree of `<path>`, skipping empty directories).

Example:

(this is the daemon's filesystem; "/" is at `storage/data/`, anything without a suffix is a directory)
```
$ tree storage/data/
storage/data/
|-- a
|   `-- b
|       |-- file.rrd
|       `-- g
|-- c
|   |-- d
|   |-- e
|   `-- f.rrd
|-- file.h
`-- i
```

A non-recursive "list" gives the rrd files (none) and directories in the "/" (both with `--daemon`, directly, and via the telnet interface):
```
$ rrdtool list --daemon 127.0.0.1:42218  /
i
c
a

$ rrdtool list storage/data/
i
c
a

$ telnet 127.0.0.1 42218
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
LIST /
3 RRDs
i
c
a
```

The recursive "list" finds all the rrd files under "/":
```
$ rrdtool list --daemon 127.0.0.1:42218 --recursive /
c/f.rrd
a/b/file.rrd

$ rrdtool list -r storage/data/
c/f.rrd
a/b/file.rrd

$ telnet 127.0.0.1 42218
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
LIST RECURSIVE /
2 RRDs
c/f.rrd
a/b/file.rrd
```
