### PR TITLE
Makefile.am: Fix broken build on Fedora

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,7 @@ clean-local:
 
 
 dist-hook: VERSION
-	$(AM_V_GEN)cd $(distdir) && $(PERL) -i -p -e 's/^\$VERSION.+/\$VERSION='$(NUM_VERS)';/' bindings/perl-*/*.pm
+	$(AM_V_GEN)cd $(distdir) && $(PERL) -i -p -e 's/^\$$VERSION.+/\$$VERSION='$(NUMVERS)';/' bindings/perl-*/*.pm
 	$(AM_V_GEN)cd $(distdir) && $(PERL) -i -p -e 's/RRDtool 1.GIT, Copyright by Tobi Oetiker/RRDtool '$(PACKAGE_VERSION)', Copyright 1997-'`date +%Y`' by Tobi Oetiker/' src/*.h src/*.c
 	$(AM_V_GEN)cd $(distdir) && $(PERL) -i -p -e 's/^Version:.+/Version: '$(PACKAGE_VERSION)'/' rrdtool.spec
 	$(AM_V_GEN)$(PERL) -i -p -e 's/rrdtool-[\.\d]+\d(-[a-z0-9]+)?/rrdtool-'$(PACKAGE_VERSION)'/g' doc/rrdbuild.pod


### PR DESCRIPTION
Fix the following build error:

```
make top_distdir="bxrrdtool-1.6.1" distdir="bxrrdtool-1.6.1" dist-hook
make[2]: Entering directory '/home/vficet/src/rrdtool-1.x'
cd bxrrdtool-1.6.1 && /usr/bin/perl -i -p -e 's/^\1ERSION.+/\1ERSION='1.6002';/' bindings/perl-*/*.pm
Reference to nonexistent group in regex; marked by <-- HERE in m/^\1 <-- HERE ERSION.+/ at -e line 1.
Makefile:933: recipe for target 'dist-hook' failed
```

Attempt at replacing `$VERSION` by `$NUM_VERS` was introduced in 6f1c8623 but it seems that this code never did anything (make needs `$$` in order to have a literal `$`). In the perl bindings RPM in `/usr/lib64/perl5/vendor_perl/RRDs.pm` I have:

```
$VERSION=1.4003;
```

and it does seem that `NUM_VERS` is a typo and it should have been `NUMVERS`:

```
$ grep -r NUM_VERS *   
Makefile.am:    $(AM_V_GEN)cd $(distdir) && $(PERL) -i -p -e 's/^\$VERSION.+/\$VERSION='$(NUM_VERS)';/' bindings/perl-*/*.pm
Makefile.in:    $(AM_V_GEN)cd $(distdir) && $(PERL) -i -p -e 's/^\$VERSION.+/\$VERSION='$(NUM_VERS)';/' bindings/perl-*/*.pm

$ grep -r NUMVERS * 
Makefile.in:NUMVERS = @NUMVERS@
bindings/lua/Makefile.in:NUMVERS = @NUMVERS@
bindings/tcl/Makefile.in:NUMVERS = @NUMVERS@
bindings/Makefile.in:NUMVERS = @NUMVERS@
configure:NUMVERS
configure:NUMVERS=1.6999
configure.ac:NUMVERS=1.6999
configure.ac:AC_SUBST(NUMVERS)
doc/Makefile.in:NUMVERS = @NUMVERS@
examples/Makefile.in:NUMVERS = @NUMVERS@
examples/rrdcached/Makefile.in:NUMVERS = @NUMVERS@
rrdtool-1.2-release:PERLVERS=`perl -n -e 'm/NUMVERS=(\d+\.\d+)/ && print $1' configure.ac`
rrdtool-release:PERLVERS=`perl -n -e 'm/NUMVERS=(\d+\.\d+)/ && print $1' configure.ac`
src/rrd_version.c:    return NUMVERS;
src/get_ver.awk:    if (match ($0, /^NUMVERS=/)) {
src/get_ver.awk:      if (match ($0, /@@NUMVERS@@/)) {
src/get_ver.awk:        gsub("@@NUMVERS@@", my_ver_num, $0);
src/get_ver.awk:    print "RRD_NUMVERS = " my_ver_num "";
src/Makefile.am:        -DNUMVERS=@NUMVERS@
src/Makefile.in:NUMVERS = @NUMVERS@
src/Makefile.in:        -DNUMVERS=@NUMVERS@
tests/Makefile.in:NUMVERS = @NUMVERS@
win32/rrd_config.h:#define NUMVERS             1.4999
```

By the way, this looks suspicious too...: `win32/rrd_config.h:#define NUMVERS             `**1.4999**