### PR TITLE
Added missing GLib thread initialization.

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -396,6 +396,7 @@ int       rrd_proc_start_end(
     const char * rrd_scaled_duration (const char * token,
                                       unsigned long divisor,
                                       unsigned long * valuep);
+    void rrd_thread_init(void);
 
 /*
  * The following functions are _internal_ functions needed to read the raw RRD

--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -88,6 +88,7 @@ int rrd_create(
     const char **sources_array = NULL;
     char *template = NULL;
     
+    rrd_thread_init();
     optparse_init(&options, argc, argv);
     while ((opt = optparse_long(&options, longopts, NULL)) != -1) {
         switch (opt) {
@@ -795,6 +796,7 @@ int rrd_create_r2(
     int mappings_cnt = 0;
     const char *require_version = NULL;
     
+    rrd_thread_init();
     /* clear any previous errors */
     rrd_clear_error();
 

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -4697,6 +4697,7 @@ int main (int argc, char **argv)
 {
   int status;
 
+  rrd_thread_init();
   status = read_options (argc, argv);
   if (status != 0)
   {

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -4589,6 +4589,7 @@ rrd_info_t *rrd_graph_v(
     image_desc_t im;
     rrd_info_t *grinfo;
     struct optparse options;
+    rrd_thread_init();
     rrd_graph_init(&im);
     /* a dummy surface so that we can measure text sizes for placements */
     rrd_graph_options(argc, argv, &options, &im);

--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -116,6 +116,7 @@ int rrd_tune(
     struct optparse options;
     int opt;
 
+    rrd_thread_init();
     /* Fix CWE-457 */
     memset(&rrd, 0, sizeof(rrd_t));
 

--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -682,6 +682,7 @@ int rrd_update(
     int       rc = -1;
     char     *opt_daemon = NULL;
 
+    rrd_thread_init();
     optparse_init(&options, argc, argv);
     while ((opt = optparse_long(&options,longopts,NULL)) != -1) {
         switch (opt) {

--- a/src/rrd_utils.c
+++ b/src/rrd_utils.c
@@ -25,6 +25,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -281,3 +282,10 @@ const char * rrd_scaled_duration (const char * token,
     return NULL;
 }
 
+void rrd_thread_init(void)
+{
+#if !GLIB_CHECK_VERSION(2, 32, 0)
+    if (!g_thread_supported())
+        g_thread_init(NULL);
+#endif
+}

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -76,6 +76,7 @@ int rrd_xport(
         {0}
     };
 
+    rrd_thread_init();
     rrd_graph_init(&im);
 
     rrd_parsetime("end-24h", &start_tv);


### PR DESCRIPTION
Older GLib versions (< 2.32, e.g. the ones shipped with CentOS 5 and 6,
SLES11, Debian 6) need an explicit initialization to make things
thread-safe, see:

  https://developer.gnome.org/glib/stable/glib-Deprecated-Thread-APIs.html#g-thread-init

RRDtools didn't do that, so you get random crashes in clients and the
rrdcached on those systems.  Now we make sure that GLib is properly
initialized before calling into it.