### PR TITLE
Added -o option for logging into a file instead of using syslog.

### DIFF
--- a/doc/rrdcached.pod
+++ b/doc/rrdcached.pod
@@ -18,6 +18,7 @@ B<rrdcached>
 [B<-l>E<nbsp>I<address>]
 [B<-m>E<nbsp>I<mode>]
 [B<-O>]
+[B<-o>E<nbsp>I<log_file>]
 [B<-P>E<nbsp>I<permissions>]
 [B<-p>E<nbsp>I<pid_file>]
 [B<-R>]
@@ -171,6 +172,10 @@ LOG_EMERG, LOG_ALERT, LOG_CRIT, LOG_ERR, LOG_WARNING, LOG_NOTICE, LOG_INFO, LOG_
 Default log level when this flag is I<NOT> present: B<LOG_ERR>
 
 See also: L<syslog.h>
+
+=item B<-o> I<log_file>
+
+Log to the given file instead of syslog.
 
 =item B<-w> I<timeout>
 


### PR DESCRIPTION
For some use cases it is better to keep log output separated from the normal
syslog. To handle such scenarios, a new -o option has been added.

Fixed foreground logging on the way, too: There was a missing mutex for
avoiding intermingled output.