### PR TITLE
Fixed declaration and export of rrd_dump_opt_r.

### DIFF
--- a/src/librrd.sym
+++ b/src/librrd.sym
@@ -11,6 +11,7 @@ rrd_dontneed
 rrd_dump
 rrd_dump_r
 rrd_dump_cb_r
+rrd_dump_opt_r
 rrd_fetch
 rrd_fetch_r
 rrd_fetch_cb_register

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -292,6 +292,9 @@ struct rrd_t;
             unsigned long *ds_cnt,
             char ***ds_namv,
             rrd_value_t **data);
+    int rrd_dump_opt_r(const char *filename,
+                       char *outname,
+                       int opt_noheader);
     int       rrd_dump_r(
     const char *filename,
     char *outname);


### PR DESCRIPTION
The previous state of affairs regarding rrd_dump_opt_r was a bit
inconsistent: The dynamic library didn't export it, while the static one
did.  So the right way to fix it will be exporting it in both variants,
because removing it from the static library would require a major version
change.  Furthermore, rrd_dump_opt_r is mentioned in the documentation at
librrd.pod, so this is another hint for the fix.

In addition, a C prototype was wmissing, so GCC complained about it.