### PR TITLE
add read locking through rrd_open()

### DIFF
--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -842,7 +842,8 @@ int rrd_create_r2(
         rrd_t trrd;
 
         rrd_init(&trrd);
-        rrd_file_t *tf = rrd_open(template, &trrd, RRD_READONLY | RRD_READAHEAD | RRD_READVALUES);
+        rrd_file_t *tf = rrd_open(template, &trrd, RRD_READONLY | RRD_LOCK |
+                                                   RRD_READAHEAD | RRD_READVALUES);
         if (tf == NULL) {
             rrd_set_error("Cannot open template RRD %s", template);
             goto done;
@@ -989,8 +990,8 @@ int rrd_create_r2(
             }
         
             rrd_init(srrd);
-            rrd_file_t *sf = rrd_open(*s, srrd, RRD_READONLY | RRD_READAHEAD | RRD_READVALUES);
-
+            rrd_file_t *sf = rrd_open(*s, srrd, RRD_READONLY | RRD_LOCK |
+                                                RRD_READAHEAD | RRD_READVALUES);
             if (sf == NULL) {
                 rrd_set_error("Cannot open source RRD %s", *s);
                 goto done;

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -1665,7 +1665,7 @@ static int handle_request_update (HANDLER_PROTO) /* {{{ */
 
     rrd_clear_error();
     rrd_init(&rrd);
-    rrd_file = rrd_open(file, &rrd, RRD_READONLY);
+    rrd_file = rrd_open(file, &rrd, RRD_READONLY | RRD_LOCK);
     if (!rrd_file)
     {
       rrd_free(&rrd);
@@ -2276,7 +2276,7 @@ static int handle_request_last (HANDLER_PROTO) /* {{{ */
   }
   rrd_clear_error();
   rrd_init(&rrd);
-  rrd_file = rrd_open(file,&rrd,RRD_READONLY);
+  rrd_file = rrd_open(file, &rrd, RRD_READONLY | RRD_LOCK);
   if(!rrd_file) {
     rrd_free(&rrd);
     rc = send_response(sock, RESP_ERR, "RRD Error: %s\n", rrd_get_error());

--- a/src/rrd_dump.c
+++ b/src/rrd_dump.c
@@ -90,7 +90,8 @@ int rrd_dump_cb_r(
 
     rrd_init(&rrd);
 
-    rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_READAHEAD);
+    rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_LOCK |
+                                        RRD_READAHEAD);
     if (rrd_file == NULL) {
         rrd_free(&rrd);
         return (-1);

--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -318,7 +318,7 @@ int rrd_fetch_fn(
     }
 
     rrd_init(&rrd);
-    rrd_file = rrd_open(filename, &rrd, RRD_READONLY);
+    rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_LOCK);
     if (rrd_file == NULL)
         goto err_free;
 

--- a/src/rrd_first.c
+++ b/src/rrd_first.c
@@ -91,7 +91,7 @@ time_t rrd_first_r(
     rrd_file_t *rrd_file;
 
     rrd_init(&rrd);
-    rrd_file = rrd_open(filename, &rrd, RRD_READONLY);
+    rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_LOCK);
     if (rrd_file == NULL) {
         goto err_free;
     }

--- a/src/rrd_info.c
+++ b/src/rrd_info.c
@@ -164,7 +164,7 @@ rrd_info_t *rrd_info_r(
     enum dst_en current_ds;
 
     rrd_init(&rrd);
-    rrd_file = rrd_open(filename, &rrd, RRD_READONLY);
+    rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_LOCK);
     if (rrd_file == NULL)
         goto err_free;
 

--- a/src/rrd_last.c
+++ b/src/rrd_last.c
@@ -77,7 +77,7 @@ time_t rrd_last_r(
     rrd_t     rrd;
 
     rrd_init(&rrd);
-    rrd_file = rrd_open(filename, &rrd, RRD_READONLY);
+    rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_LOCK);
     if (rrd_file != NULL) {
         lastup = rrd.live_head->last_up;
         rrd_close(rrd_file);

--- a/src/rrd_lastupdate.c
+++ b/src/rrd_lastupdate.c
@@ -98,7 +98,7 @@ int rrd_lastupdate_r(const char *filename,
     rrd_file_t *rrd_file;
 
     rrd_init(&rrd);
-    rrd_file = rrd_open(filename, &rrd, RRD_READONLY);
+    rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_LOCK);
     if (rrd_file == NULL) {
         rrd_free(&rrd);
         return (-1);

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -6,15 +6,21 @@
  * $Id$
  *****************************************************************************/
 
-#include "rrd_tool.h"
-#include "unused.h"
-
 #ifdef WIN32
-#include <stdlib.h>
-#include <fcntl.h>
-#include <sys/stat.h>
+#include <windows.h>
+#if _WIN32_MAXVER >= 0x0602 /* _WIN32_WINNT_WIN8 */
+#include <synchapi.h>
 #endif
 
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <limits.h>
+#endif /* WIN32 */
+
+#include "rrd_tool.h"
+#include "unused.h"
 
 #ifdef HAVE_BROKEN_MS_ASYNC
 #include <sys/types.h>
@@ -31,8 +37,8 @@
 #define	_LK_UNLCK	0	/* Unlock */
 #define	_LK_LOCK	1	/* Lock */
 #define	_LK_NBLCK	2	/* Non-blocking lock */
-#define	_LK_RLCK	3	/* Lock for read only */
-#define	_LK_NBRLCK	4	/* Non-blocking lock for read only */
+#define	_LK_RLCK	3	/* "Same as _LK_NBLCK" */
+#define	_LK_NBRLCK	4	/* "Same as _LK_LOCK" */
 
 
 #define	LK_UNLCK	_LK_UNLCK
@@ -124,6 +130,9 @@
 #endif
 #endif
 
+static int rrd_rwlock(rrd_file_t *rrd_file, int writelock);
+static int close_and_unlock(int fd);
+
 /* Open a database file, return its header and an open filehandle,
  * positioned to the first cdp in the first rra.
  * In the error path of rrd_open, only rrd_free(&rrd) has to be called
@@ -201,6 +210,14 @@ rrd_file_t *rrd_open(
       if (rrd_file->rados == NULL)
           goto out_free;
 
+      if (rdwr & RRD_LOCK) {
+          /* Note: rados read lock is not implemented.  See rrd_lock(). */
+          if (rrd_rwlock(rrd_file, rdwr & RRD_READWRITE) != 0) {
+              rrd_set_error("could not lock RRD");
+              goto out_close;
+          }
+      }
+
       if (rdwr & RRD_CREAT)
           goto out_done;
 
@@ -269,6 +286,13 @@ rrd_file_t *rrd_open(
     }
 #endif    
 #endif
+
+    if (rdwr & RRD_LOCK) {
+        if (rrd_rwlock(rrd_file, rdwr & RRD_READWRITE) != 0) {
+            rrd_set_error("could not lock RRD");
+            goto out_close;
+        }
+    }
 
     /* Better try to avoid seeks as much as possible. stat may be heavy but
      * many concurrent seeks are even worse.  */
@@ -478,10 +502,9 @@ read_check:
       
     }
 
-    
-    
   out_done:
     return (rrd_file);
+
   out_close:
 #ifdef HAVE_MMAP
     if (data != MAP_FAILED)
@@ -491,8 +514,18 @@ read_check:
     if (rrd_file->rados)
       rrd_rados_close(rrd_file->rados);
 #endif
-    if (rrd_simple_file->fd >= 0)
-      close(rrd_simple_file->fd);
+    if (rrd_simple_file->fd >= 0) {
+      /* keep the original error */
+      char *e = strdup(rrd_get_error());
+
+      close_and_unlock(rrd_simple_file->fd);
+
+      if (e) {
+        rrd_set_error(e);
+        free(e);
+      } else
+        rrd_set_error("error message was lost (out of memory)");
+    }
   out_free:
     free(rrd_file->pvt);
     free(rrd_file);
@@ -556,37 +589,146 @@ void mincore_print(
 int rrd_lock(
     rrd_file_t *rrd_file)
 {
+    return rrd_rwlock(rrd_file, 1);
+}
+
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
+#define USE_WINDOWS_LOCK 1
+#endif
+
+#ifdef USE_WINDOWS_LOCK
+static
+int rrd_windows_lock(
+    int fd)
+{
+    int ret;
+    long pos;
+
+    /*
+     * _locking() is relative to fd position.
+     * We need to consistently lock bytes starting from 0,
+     * so we can successfully unlock on close.
+     *
+     * Note rrd_lock() API doesn't set a specific error message.
+     * Knowing that rrd_lock() (or even rrd_open()) failed should
+     * be specific enough, if someone manages to invoke rrdtool
+     * on something silly like a named pipe or COM1.
+     */
+    pos = tell(fd);
+    if (pos < 0)
+        return -1;
+
+    if (lseek(fd, 0, SEEK_SET) < 0)
+        return -1;
+
+    while (1) {
+        ret = _locking(fd, _LK_NBLCK, LONG_MAX);
+        if (ret == 0)
+            break; /* success */
+        if (errno != EACCES)
+            break; /* failure */
+        /* EACCES: someone else has the lock. */
+
+        /*
+         * Wait 0.01 seconds before trying again.  _locking()
+         * with _LK_LOCK would work similarly but waits 1 second
+         * between tries, which seems less desirable.
+         */
+        Sleep(10);
+    }
+
+    /* restore saved fd position */
+    if (lseek(fd, pos, SEEK_SET) < 0)
+        return -1;
+
+    return ret;
+}
+#endif
+
+static
+int close_and_unlock(
+    int fd)
+{
+    int ret = 0;
+
+#ifdef USE_WINDOWS_LOCK
+    /*
+     * "If a process closes a file that has outstanding locks, the locks are
+     *  unlocked by the operating system. However, the time it takes for the
+     *  operating system to unlock these locks depends upon available system
+     *  resources. Therefore, it is recommended that your process explicitly
+     *  unlock all files it has locked when it terminates."  (?!)
+     */
+
+    if (lseek(fd, 0, SEEK_SET) < 0) {
+        rrd_set_error("lseek: %s", rrd_strerror(errno));
+        ret = -1;
+        goto out_close;
+    }
+
+    ret = _locking(fd, LK_UNLCK, LONG_MAX);
+    if (ret != 0 && errno == EACCES)
+        /* fd was not locked - this is entirely possible, ignore the error */
+        ret = 0;
+
+    if (ret != 0)
+        rrd_set_error("unlock file: %s", rrd_strerror(errno));
+out_close:
+#endif
+
+    if (close(fd) != 0) {
+        ret = -1;
+        rrd_set_error("closing file: %s", rrd_strerror(errno));
+    }
+
+    return ret;
+}
+
+static
+int rrd_rwlock(
+    rrd_file_t *rrd_file,
+    int writelock)
+{
 #ifdef DISABLE_FLOCK
     (void)rrd_file;
     return 0;
 #else
 #ifdef HAVE_LIBRADOS
-    if (rrd_file->rados)
-      return rrd_rados_lock(rrd_file->rados);
+    if (rrd_file->rados) {
+        /*
+         * No read lock on rados.  It would be complicated by the
+         * use of a short finite lock duration in rrd_rados_lock().
+         * Also rados does not provide blocking locks.
+         *
+         * Rados users may use snapshots if they need to
+         * e.g. obtain a consistent backup.
+         */
+        if (writelock)
+            return rrd_rados_lock(rrd_file->rados);
+        else
+            return 0;
+    }
 #endif
     int       rcstat;
     rrd_simple_file_t *rrd_simple_file;
     rrd_simple_file = (rrd_simple_file_t *)rrd_file->pvt;
-    {
-#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
-        struct _stat st;
-
-        if (_fstat(rrd_simple_file->fd, &st) == 0) {
-            rcstat = _locking(rrd_simple_file->fd, _LK_NBLCK, st.st_size);
-        } else {
-            rcstat = -1;
-        }
+#ifdef USE_WINDOWS_LOCK
+    /* _locking() does not support read locks; we always take a write lock */
+    rcstat = rrd_windows_lock(rrd_simple_file->fd);
 #else
+    {
         struct flock lock;
 
-        lock.l_type = F_WRLCK;  /* exclusive write lock */
+        lock.l_type = writelock ?
+                          F_WRLCK: /* exclusive write lock or */
+                          F_RDLCK; /* shared read lock */
         lock.l_len = 0; /* whole file */
         lock.l_start = 0;   /* start of file */
         lock.l_whence = SEEK_SET;   /* end of file */
 
         rcstat = fcntl(rrd_simple_file->fd, F_SETLK, &lock);
-#endif
     }
+#endif
 
     return (rcstat);
 #endif
@@ -682,6 +824,12 @@ int rrd_close(
     rrd_simple_file = (rrd_simple_file_t *)rrd_file->pvt;
     int       ret = 0;
 
+#ifdef HAVE_LIBRADOS
+    if (rrd_file->rados) {
+        if (rrd_rados_close(rrd_file->rados) != 0)
+            ret = -1;
+    }
+#endif
 #ifdef HAVE_MMAP
     if (rrd_simple_file->file_start != NULL) {
         if (munmap(rrd_simple_file->file_start, rrd_file->file_len) != 0) {
@@ -690,17 +838,9 @@ int rrd_close(
         }
     }
 #endif
-#ifdef HAVE_LIBRADOS
-    if (rrd_file->rados) {
-        if (rrd_rados_close(rrd_file->rados) != 0)
-            ret = -1;
-    }
-#endif
     if (rrd_simple_file->fd >= 0) {
-        if (close(rrd_simple_file->fd) != 0) {
+        if (close_and_unlock(rrd_simple_file->fd) != 0)
             ret = -1;
-            rrd_set_error("closing file: %s", rrd_strerror(errno));
-        }
     }
     free(rrd_file->pvt);
     free(rrd_file);

--- a/src/rrd_tool.h
+++ b/src/rrd_tool.h
@@ -133,6 +133,7 @@ typedef int (*rrd_fetch_cb_t)(
 #define RRD_COPY        (1<<4)
 #define RRD_EXCL        (1<<5)
 #define RRD_READVALUES  (1<<6)
+#define RRD_LOCK        (1<<7)
 
     enum cf_en rrd_cf_conv(
     const char *string);

--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -174,7 +174,8 @@ int rrd_tune(
     }
 
     rrd_init(&rrd);
-    rrd_file = rrd_open(in_filename, &rrd, RRD_READWRITE | RRD_READAHEAD | RRD_READVALUES);
+    rrd_file = rrd_open(in_filename, &rrd, RRD_READWRITE | RRD_LOCK |
+                                           RRD_READAHEAD | RRD_READVALUES);
     if (rrd_file == NULL) {
 	goto done;
     }

--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -366,7 +366,7 @@ static char *rrd_get_file_template(const char *filename) /* {{{ */
 
 	/* open file */
 	rrd_init(&rrd);
-	rrd_file = rrd_open(filename, &rrd, RRD_READONLY);
+	rrd_file = rrd_open(filename, &rrd, RRD_READONLY | RRD_LOCK);
 	if (rrd_file == NULL)
 		goto err_free;
 
@@ -858,7 +858,8 @@ static int _rrd_updatex(
     }
 
     rrd_init(&rrd);
-    if ((rrd_file = rrd_open(filename, &rrd, RRD_READWRITE)) == NULL) {
+    rrd_file = rrd_open(filename, &rrd, RRD_READWRITE | RRD_LOCK);
+    if (rrd_file == NULL) {
         goto err_free;
     }
     /* We are now at the beginning of the rra's */
@@ -867,14 +868,6 @@ static int _rrd_updatex(
     version = atoi(rrd.stat_head->version);
 
     initialize_time(&current_time, &current_time_usec, version);
-
-    /* get exclusive lock to whole file.
-     * lock gets removed when we close the file.
-     */
-    if (rrd_lock(rrd_file) != 0) {
-        rrd_set_error("could not lock RRD");
-        goto err_close;
-    }
 
     if (allocate_data_structures(&rrd, &updvals,
                                  &pdp_temp, tmplt, &tmpl_idx, &tmpl_cnt,


### PR DESCRIPTION
> I guess since writes and reads may not be atomic in any event a
sensible locking for fetch might make sense in any way ...
>
> your patches are welcome ...
>
> cheers
> tobi

The implementation is shaped slightly differently to the first plan in #799.  Please disregard the first plan, you can just read the messages for the commits with `RRD_LOCK` in the title.

I have not addressed the 2 already existing issues at the end of the #799 description.

This series is affected by numerous #ifdefs.  I have _not_ tested it beyond `make` on my machine.  If you want to look at the preparatory commits first, that's cool (it should be trivial to rebase though, so I'm presenting this together for initial review).

---

Highlighted excerpt:

So `RRD_LOCK|RRD_READONLY` is intended to take a read lock, however I must
admit to limitations of this new code:
    
* On the Windows _locking() function, read locks are treated the same as
  write locks.
    
  https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/locking
    
* On rados, our write lock expires after 2 seconds.  This write-lock is
  probably useful as a way to detect conflicts.  However I would not want
  to rely on a lock that works like this to guarantee consistent reads for
  a backup.  Fortunately rados implements snapshots, and when we *write* to
  RRDs, we use a single atomic operation.