### PR TITLE
Fix noise encountered in testing

### DIFF
--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -574,7 +574,7 @@ static int response_read(rrd_client_t *client, rrdc_response_t **ret_response) /
   if (ret->status <= 0)
   {
     if (ret->status < 0)
-      rrd_set_error("rrdcached@%S: %s", client->sd_path, ret->message);
+      rrd_set_error("rrdcached@%s: %s", client->sd_path, ret->message);
     goto out;
   }
 

--- a/tests/list1
+++ b/tests/list1
@@ -88,7 +88,7 @@ if is_cached; then
 
         # rrdcached-specific tests
         ( cd "$LIST_DIR"; ln -s /tmp ./; )
-        list_count=`$RRDTOOL list "$CACHED_DIR" | grep -c '^tmp$'`
+        list_count=`$RRDTOOL list "/$CACHED_DIR" | grep -c '^tmp$'`
         test $list_count -eq 0
         report "escape from cached basedir via symlink denied"
 


### PR DESCRIPTION
Fix noise encountered in testing #800.
```

OK: recursive list only lists rrd files
ERROR: rrdcached@������������������������������������������������������������������������������������������������������正1: Usage: LIST [RECURSIVE] /[<path>]
OK: escape from cached basedir via symlink denied
```