### PR TITLE
Fix madvise (and fadvise)

### DIFF
--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -374,7 +374,11 @@ rrd_file_t *rrd_open(
     }
 #endif
 #if !defined(HAVE_MMAP) && defined(HAVE_POSIX_FADVISE)
-    posix_fadvise(rrd_simple_file->fd, 0, 0, POSIX_FADV_RANDOM);
+    if (rdwr & RRD_COPY) {
+        posix_fadvise(rrd_simple_file->fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+    } else {
+        posix_fadvise(rrd_simple_file->fd, 0, 0, POSIX_FADV_RANDOM);
+    }
 #endif
 
 #ifdef HAVE_LIBRADOS

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -360,6 +360,11 @@ rrd_file_t *rrd_open(
     if (rdwr & RRD_CREAT)
         goto out_done;
 
+    if (rdwr & RRD_READAHEAD) {
+        /* If perfect READAHEAD is not achieved for whatever reason, caller
+           will not thank us for advising the kernel of RANDOM access below.*/
+        rdwr |= RRD_COPY;
+    }
     /* In general we need no read-ahead when dealing with rrd_files.
        When we stop reading, it is highly unlikely that we start up again.
        In this manner we actually save time and disk access (and buffer cache).
@@ -367,7 +372,7 @@ rrd_file_t *rrd_open(
 #ifdef USE_MADVISE
     if (rdwr & RRD_COPY) {
         /* We will read everything in a moment (copying) */
-        madvise(data, rrd_file->file_len, MADV_SEQUENTIAL );
+        madvise(data, rrd_file->file_len, MADV_SEQUENTIAL);
     } else {
         /* We do not need to read anything in for the moment */
         madvise(data, rrd_file->file_len, MADV_RANDOM);


### PR DESCRIPTION
Excerpt:

Passing RRD_READAHEAD to rrd_open() had no effect on current linux.

Test:

```
for i in $(seq 50); do
  dd if=dns.rrd of=x/$i.rrd bs=1M oflag=direct 2>/dev/null
done
/usr/bin/time sh -c 'for i in x/*.rrd; do
  rrdtool dump $i >/dev/null
done'
```

Before:

```
6.52user 0.74system 0:09.46elapsed 76%CPU
(0avgtext+0avgdata 9796maxresident)k
204800inputs+0outputs (25600major+25112minor)pagefaults 0swaps
```

After:

```
5.82user 0.27system 0:06.57elapsed 92%CPU
(0avgtext+0avgdata 9740maxresident)k
204800inputs+0outputs (600major+27020minor)pagefaults 0swaps
```