### PR TITLE
Fix valgrind usage in tests

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -4008,11 +4008,13 @@ static void open_listen_sockets_traditional(void) /* {{{ */
 {
  if (config_listen_address_list_len > 0)
   {
-    for (size_t i = 0; i < config_listen_address_list_len; i++)
+    for (size_t i = 0; i < config_listen_address_list_len; i++) {
       open_listen_socket (config_listen_address_list[i]);
+      free_listen_socket (config_listen_address_list[i]);
+    }
 
-    rrd_free_ptrs((void ***) &config_listen_address_list,
-                  &config_listen_address_list_len);
+    free(config_listen_address_list);
+    config_listen_address_list = NULL;
   }
   else
   {

--- a/tests/functions
+++ b/tests/functions
@@ -28,7 +28,9 @@ function blank {
 # we set some env. vars to work around them:
 
 VALGRIND_ERR_FILE="${BASEDIR}/$(basename $0)-valgrind-err.tmp"
-rm "$VALGRIND_ERR_FILE"
+if [ -e "$VALGRIND_ERR_FILE" ]; then
+  rm "$VALGRIND_ERR_FILE"
+fi
 
 function valgrind {
   # use a sub shell, so setting environment variables only affects the current

--- a/tests/functions
+++ b/tests/functions
@@ -27,6 +27,9 @@ function blank {
 # https://stackoverflow.com/questions/4254610/valgrind-reports-memory-possibly-lost-when-using-glib-data-types)
 # we set some env. vars to work around them:
 
+VALGRIND_ERR_FILE="${BASEDIR}/$(basename $0)-valgrind-err.tmp"
+rm "$VALGRIND_ERR_FILE"
+
 function valgrind {
   # use a sub shell, so setting environment variables only affects the current
   # rrdtool run and not subsequent ones
@@ -70,7 +73,12 @@ function valgrind {
     exit $RC
   )
   #    - second: by returning the subshell exit code to the function caller
-  return $?
+  #   Also create a file, in case the caller has difficulty testing the rc.
+  local RC=$?
+  if [ "$RC" == 111 ]; then
+    touch "$VALGRIND_ERR_FILE"
+  fi
+  return $RC
 }
 
 function verbose_rrdtool {
@@ -79,7 +87,9 @@ function verbose_rrdtool {
 }
 
 function fail {
-	RC=$?
+	RC="$1"
+	shift
+
 	echo >&2 "FAILED: (rc=$RC)" "$@"
 	if [ -n "$CONTINUE" ] ; then
 		return
@@ -87,10 +97,10 @@ function fail {
 	if [ -n "$INTERACTIVE" ] ; then
 		read -p "Continue? (y/n)" YN
 		if [ "$YN" != 'y' ] ; then 
-			exit $RC
+			exit 1
 		fi
 	else
-		exit $RC
+		exit 1
 	fi
 }
 
@@ -100,11 +110,18 @@ function ok {
 
 function report {
 	RC=$?
+	if [ -e "$VALGRIND_ERR_FILE" ]; then
+		RC="valgrind error"
+		rm "$VALGRIND_ERR_FILE"
+	fi
+
 	if [ "$RC" = 0 ] ; then
 		ok "$@"
 	else
-		fail "$@"
+		fail "$RC" "$@"
 	fi
+
+
 }
 
 function run_cached {
@@ -160,12 +177,10 @@ if [ -z "$RRDTOOL" ] ; then
                         STANDARD_RRDCACHED="$RRDCACHED"
                         ;;
                 valgrind)
-                        echo >&2 "# Note: exit code 111 indicates a valgrind detected memory problem" 
                         RRDTOOL="valgrind $TOP_BUILDDIR/src/rrdtool"
                         RRDCACHED="valgrind $TOP_BUILDDIR/src/rrdcached"
                         ;;
                 valgrind-logfile)
-                        echo >&2 "# Note: exit code 111 indicates a valgrind detected memory problem" 
                         RRDTOOL="valgrind $TOP_BUILDDIR/src/rrdtool"
                         RRDCACHED="valgrind $TOP_BUILDDIR/src/rrdcached"
                         VALGRIND_LOGFILE="${BASEDIR}/$(basename $0)"-valgrind.log

--- a/tests/valgrind-supressions
+++ b/tests/valgrind-supressions
@@ -19,3 +19,21 @@
    fun:g_once_init_leave
    ...
 }
+{
+   g_type_register
+   Memcheck:Leak
+   fun:*alloc
+   ...
+   fun:g_type_register_*
+}
+{
+    gobject_early_calloc
+    Memcheck:Leak
+    fun:calloc
+    fun:g_malloc0
+    ...
+    obj:*/libgobject-*
+    ...
+    fun:_dl_init
+    ...
+}


### PR DESCRIPTION
The memory error shown in #801 sneaked past the tests (and hence Travis CI didn't notice it).  Fix the test suite so it actually catches valgrind errors :).

This also caught one memory leak.