### PR TITLE
correct the note in the perl binding about the empty filename

### DIFF
--- a/bindings/perl-shared/RRDs.pm
+++ b/bindings/perl-shared/RRDs.pm
@@ -104,7 +104,7 @@ the values of the properties.
 B<RRDs::graphv> takes the same parameters as B<RRDs::graph> but it returns a
 pointer to hash. The hash returned contains meta information about the
 graph. Like its size as well as the position of the graph area on the image.
-When calling with and empty filename than the contents of the graph will be
+When calling with '-' as the filename then the contents of the graph will be
 returned in the hash as well (key 'image').
 
 B<RRDs::updatev> also returns a pointer to hash. The keys of the hash


### PR DESCRIPTION
passing an empty filename to graphv does not work anymore, but the
documentation of the perl-shared binding still said so

correctly note that you have to pass '-'

Signed-off-by: Dominik Csapak <d.csapak@proxmox.com>