### PR TITLE
2 fixes for rrdtool list

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -2576,7 +2576,8 @@ static int handle_request_list (HANDLER_PROTO) /* {{{ */
     }
 
     /* Absolute path MUST be starting with base_dir; if not skip the entry. */
-    if (memcmp(absolute, base, strlen(base)) != 0) {
+    if (strlen(absolute) < strlen(base) ||
+        memcmp(absolute, base, strlen(base)) != 0) {
       goto loop_next;
   }
     add_response_info(sock, "%s\n", current);


### PR DESCRIPTION
* src/rrd_list.c: fix errno

rrd_daemon expected zero errno iff there was not an error
(but we forgot to provide it).

  list = rrd_list_r(recursive, fullpath);

  if (list == NULL) {
    /* Empty directory listing */
    if (errno == 0) {
      goto out_send_response;
    }

* src/rrd_daemon.c: never compare uninitialized bytes

I don't think this caused the valgrind error in CI either.  It looks wrong
though.