### PR TITLE
Add missing files from win32 to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,12 +21,16 @@ EXTRA_DIST = COPYRIGHT CHANGES TODO CONTRIBUTORS THREADS VERSION LICENSE \
              libtool \
              m4/snprintf.m4 \
              etc/rrdcached-default-redhat etc/rrdcached-init-redhat \
-             win32/README win32/Makefile.msc
+             win32/build-rrdtool.dot win32/build-rrdtool.pdf win32/build-rrdtool.svg \
+             win32/librrd-4.def win32/librrd-4.rc win32/librrd-4.vcxproj win32/librrd-4.vcxproj.user \
+             win32/Makefile.msc win32/RCa02816 win32/README win32/rrdcgi.rc win32/rrd_config.h \
+             win32/rrd.sln win32/rrdtool.rc win32/rrdtool.sln win32/rrdtool.vcxproj win32/rrdupdate.rc \
+             win32/rrdupdate.sln win32/rrdupdate.vcxproj win32/uac.manifest
 
 CLEANFILES = config.cache
 
 # use relaxed rules when building dists
-AUTOMAKE_OPTIONS= foreign 
+AUTOMAKE_OPTIONS= foreign
 
 # where we keep local rules for automake
 ACLOCAL_AMFLAGS=-I m4
@@ -71,5 +75,5 @@ dist-hook: VERSION
 	$(AM_V_GEN)cd $(distdir) && $(PERL) -i -p -e 's/^Version:.+/Version: '$(PACKAGE_VERSION)'/' rrdtool.spec
 	$(AM_V_GEN)$(PERL) -i -p -e 's/rrdtool-[\.\d]+\d(-[a-z0-9]+)?/rrdtool-'$(PACKAGE_VERSION)'/g' doc/rrdbuild.pod
 	$(AM_V_GEN)(cd doc && $(MAKE)) && cp -p doc/rrdbuild.* $(distdir)/doc
-                
+
 ##END##


### PR DESCRIPTION
- Missing files were added in the Makefile.am to EXTRA_DIST
- The extra files will be included in the tarball
- See [rrd-users] message:
  https://lists.oetiker.ch/pipermail/rrd-users/2016-August/020443.html