### PR TITLE
Fix error 'optind': undeclared identifier

### DIFF
--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -407,7 +407,7 @@ int rrd_tune(
             }
     }
 
-    optind = handle_modify(&rrd, in_filename, options.argc, options.argv, options.optind + 1, opt_newstep);
+    options.optind = handle_modify(&rrd, in_filename, options.argc, options.argv, options.optind + 1, opt_newstep);
     rc = 0;
 done:
     if (in_filename && rrdc_is_any_connected()) {


### PR DESCRIPTION
- Fixes compilation error, when building under Windows (e.g. VS2015):
  ..\src\rrd_tune.c(410): error C2065: 'optind': undeclared identifier
- Use options.optind instead of optind
  optind is a member of the struct options