### PR TITLE
Include unistd.h only if HAVE_UNISTD_H is defined

### DIFF
--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -15,7 +15,9 @@
 
 #include <sys/types.h>      // stat()
 #include <sys/stat.h>       // stat()
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>         // stat()
+#endif
 
 #include "rrd_strtod.h"
 #include "rrd_tool.h"


### PR DESCRIPTION
- Fixes compilation error, when building under Windows (e.g. VS2015):
  ..\src\rrd_create.c(18): fatal error C1083: Cannot open include file:
  'unistd.h': No such file or directory