### PR TITLE
Fix further build errors under Windows

### DIFF
--- a/src/rrd_strtod.c
+++ b/src/rrd_strtod.c
@@ -40,6 +40,9 @@
 #include <stdlib.h>
 
 #include "rrd.h"
+#ifdef _MSC_VER
+#include "rrd_config.h" /* for strncasecmp _strnicmp */
+#endif
 #include "rrd_strtod.h"
 
 static int parse_special(const char *str, double *d) {

--- a/src/strftime.c
+++ b/src/strftime.c
@@ -20,6 +20,9 @@
 /* Define your own defaults in config.h if necessary */
 #if defined(TZNAME_STD) && defined(TZNAME_DST)
 char     *tzname_[2] = { TZNAME_STD, TZNAME_DST };
+#elif defined(_MSC_VER)
+/* VS defines these variables with a leading underscore */
+#define tzname_ _tzname
 #else
 #define tzname_ tzname
 #endif

--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -64,6 +64,9 @@
 /* Define to 1 if you have the `isnan' function. */
 #define HAVE_ISNAN 1
 
+/* Define to 1 if you have the <pcre.h> header file. */
+#define HAVE_PCRE_COMPILE 1
+
 /* is rrd_graph supported by this install */
 #define HAVE_RRD_GRAPH /**/
 
@@ -123,7 +126,8 @@
 #define rrd_realloc(a,b) ( (a) == NULL ? malloc( (b) ) : realloc( (a) , (b) ))
 #define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
 #define strcasecmp _stricmp
-#define strcasencmp _strnicmp
+#define strncasecmp _strnicmp
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 
 // in MSVC++ 12.0 / Visual Studio 2013 is a definition of round in math.h
 // some values of _MSC_VER


### PR DESCRIPTION
**src/strftime.c**

Define tzname_ for Windows builds (MSC)

- Fixes compilation error, when building under Windows (e.g. VS2015):
  ..\src\strftime.c(248): error C2065: 'tzname': undeclared identifier
- VS defines these variables with a leading underscore: _tzname

**src/rrd_strtod.c**

Include win32/rrd_config.h for def of strncasecmp

- Fixes error, when building under Windows (e.g. VS2015):
  error LNK2001: unresolved external symbol _strncasecmp

**win32/rrd_config.h**

Update win32/rrd_config.h, fix VS build errors

- Fix typo: strcasencmp -> strncasecmp
  Fixes error, when building under Windows (e.g. VS2015):
  error LNK2001: unresolved external symbol _strncasecmp
- Define S_ISREG(m)
  Fixes error, when building under Windows (e.g. VS2015):
  error LNK2001: unresolved external symbol _S_ISREG
- Define HAVE_PCRE_COMPILE for Windows builds
  Fixes compilation error, when building under Windows (e.g. VS2015):
  ..\src\rrd_create.c(30): fatal error C1189: #error:
  "you must have either glib with regexp support or libpcre"