### PR TITLE
Update Makefile.msc, Windows build updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,11 +62,18 @@ Makefile
 /doc/*.3
 /doc/pod2*.tmp
 /doc/RRD?.pod
+
+# Windows build files
+/bindings/dotnet/*.suo
 /contrib
+/win32/*.VC.db
+/win32/*.VC.opendb
+/win32/*.opensdf
+/win32/*.sdf
+/win32/*.suo
+/win32/.vs
 /win32/Debug
+/win32/DebugDLL
 /win32/Release
 /win32/ReleaseDLL
-/win32/*.suo
-/win32/*.sdf
-/bindings/dotnet/*.suo
-/win32/*.opensdf
+/win32/Static\ Debug

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -1,3 +1,12 @@
+# Makefile for rrdtool using Microsoft (Visual) C
+#
+# Usage:
+#   nmake -f win32/Makefile.msc                 (for 32 bit Windows target)
+#   nmake -f win32/Makefile.msc USE_64BIT=1     (for 64 bit Windows target)
+#   nmake -f win32/Makefile.msc clean           (to remove all generated files)
+
+# The toplevel directory of the source tree
+#
 TOP = .
 RRD_LIB_NAME=librrd-4
 ARCH_PATH_X86=contrib
@@ -13,7 +22,7 @@ LD_FLAGS=/RELEASE /MACHINE:X64
 ARCH_PATH=$(ARCH_PATH_X64)
 !endif
 
-CPPFLAGS = $(CCPFLAGS) /TP /EHsc /O2 /Zi /Fd$(TOP)/win32/vc.pdb \
+CPPFLAGS = $(CPPFLAGS) /TC /EHsc /O2 /Zi /Fd$(TOP)/win32/vc.pdb \
         /I $(TOP)/win32 /I $(TOP)/src \
         /I $(ARCH_PATH)\include \
         /I $(ARCH_PATH)\include\cairo \
@@ -26,24 +35,26 @@ THIRD_PARTY_LIB = /LIBPATH:$(ARCH_PATH)\lib \
         libpng.lib libxml2.lib \
         glib-2.0.lib gobject-2.0.lib \
         pango-1.0.lib pangocairo-1.0.lib cairo.lib \
-		Ws2_32.lib
+        Ws2_32.lib zdll.lib gthread-2.0.lib pcre.lib
 
 RRD_LIB_OBJ_LIST = \
         $(TOP)/src/hash_32.obj \
+        $(TOP)/src/mkstemp.obj \
         $(TOP)/src/mutex.obj \
+        $(TOP)/src/optparse.obj \
         $(TOP)/src/plbasename.obj \
         $(TOP)/src/pngsize.obj \
+        $(TOP)/src/quicksort.obj \
         $(TOP)/src/rrd_client.obj \
         $(TOP)/src/rrd_create.obj \
         $(TOP)/src/rrd_diff.obj \
         $(TOP)/src/rrd_dump.obj \
         $(TOP)/src/rrd_error.obj \
         $(TOP)/src/rrd_fetch.obj \
+        $(TOP)/src/rrd_fetch_cb.obj \
         $(TOP)/src/rrd_first.obj \
         $(TOP)/src/rrd_flushcached.obj \
         $(TOP)/src/rrd_format.obj \
-        $(TOP)/src/rrd_getopt.obj \
-        $(TOP)/src/rrd_getopt1.obj \
         $(TOP)/src/rrd_gfx.obj \
         $(TOP)/src/rrd_graph.obj \
         $(TOP)/src/rrd_graph_helper.obj \
@@ -53,68 +64,80 @@ RRD_LIB_OBJ_LIST = \
         $(TOP)/src/rrd_info.obj \
         $(TOP)/src/rrd_last.obj \
         $(TOP)/src/rrd_lastupdate.obj \
+        $(TOP)/src/rrd_list.obj \
+        $(TOP)/src/rrd_modify.obj \
         $(TOP)/src/rrd_nan_inf.obj \
         $(TOP)/src/rrd_open.obj \
         $(TOP)/src/rrd_parsetime.obj \
         $(TOP)/src/rrd_resize.obj \
         $(TOP)/src/rrd_restore.obj \
         $(TOP)/src/rrd_rpncalc.obj \
+        $(TOP)/src/rrd_snprintf.obj \
+        $(TOP)/src/rrd_strtod.obj \
         $(TOP)/src/rrd_thread_safe_nt.obj \
         $(TOP)/src/rrd_tune.obj \
         $(TOP)/src/rrd_update.obj \
         $(TOP)/src/rrd_utils.obj \
         $(TOP)/src/rrd_version.obj \
         $(TOP)/src/rrd_xport.obj \
-        $(TOP)/src/strftime.obj
+        $(TOP)/src/strftime.obj \
+        $(TOP)/win32/asprintf.obj \
+        $(TOP)/win32/vasprintf-msvc.obj \
+        $(TOP)/win32/win32-glob.obj
+# win32comp.obj is not added to RRD_LIB_OBJ_LIST, because definitions are already in rrd_thread_safe_nt.obj
 
 all: $(TOP)/win32/$(RRD_LIB_NAME).dll $(TOP)/win32/rrdtool.exe \
-		$(TOP)/win32/rrdupdate.exe $(TOP)/win32/rrdcgi.exe
+        $(TOP)/win32/rrdupdate.exe $(TOP)/win32/rrdcgi.exe
 
 clean:
-	-@del /F /Q $(TOP)\src\*.obj 2>NUL
-	-@del /F /Q $(TOP)\win32\*.res 2>NUL
-	-@del /F /Q $(TOP)\win32\*.exe 2>NUL
-	-@del /F /Q $(TOP)\win32\*.pdb 2>NUL
-	-@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).dll 2>NUL
-	-@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).exp 2>NUL
-	-@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).lib 2>NUL
-	
+    -@del /F /Q $(TOP)\src\*.obj 2>NUL
+    -@del /F /Q $(TOP)\win32\*.obj 2>NUL
+    -@del /F /Q $(TOP)\win32\*.res 2>NUL
+    -@del /F /Q $(TOP)\win32\*.exe 2>NUL
+    -@del /F /Q $(TOP)\win32\*.pdb 2>NUL
+    -@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).dll 2>NUL
+    -@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).exp 2>NUL
+    -@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).lib 2>NUL
+
 $(TOP)/win32/$(RRD_LIB_NAME).dll $(TOP)/win32/$(RRD_LIB_NAME).lib: \
-		$(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
-		$(RRD_LIB_OBJ_LIST)
-	cl /nologo /MT /LD /Zi /Fe$(TOP)/win32/$(RRD_LIB_NAME).dll \
-		/Fd$(TOP)/win32/$(RRD_LIB_NAME).pdb \
-		$(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
-		$(RRD_LIB_OBJ_LIST) /link $(THIRD_PARTY_LIB) $(LD_FLAGS)
+        $(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
+        $(RRD_LIB_OBJ_LIST)
+    cl /nologo /MT /LD /Zi /Fe$(TOP)/win32/$(RRD_LIB_NAME).dll \
+        /Fd$(TOP)/win32/$(RRD_LIB_NAME).pdb \
+        $(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
+        $(RRD_LIB_OBJ_LIST) /link $(THIRD_PARTY_LIB) $(LD_FLAGS)
 
 $(TOP)/win32/rrdtool.exe: $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
-		$(TOP)/win32/$(RRD_LIB_NAME).lib
-	cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
-		$(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
+        $(TOP)/win32/$(RRD_LIB_NAME).lib
+    cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
+        $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
 #Just waiting for antivirus program to finished check tasks
-	-@ping 1.1.1.1 -n 1 -w 1000 > NUL
-	-mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdtool.exe;#1
+    -@ping 1.1.1.1 -n 1 -w 1000 > NUL
+    -mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdtool.exe;#1
 
 $(TOP)/win32/rrdupdate.exe: $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
-		$(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib
-	cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
-		$(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
+        $(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib
+    cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
+        $(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
 #Just waiting for antivirus program to finished check tasks
-	-@ping 1.1.1.1 -n 1 -w 1000 > NUL
-	-mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdupdate.exe;#1
+    -@ping 1.1.1.1 -n 1 -w 1000 > NUL
+    -mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdupdate.exe;#1
 
 $(TOP)/win32/rrdcgi.exe: $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
-		$(TOP)/src/rrd_getopt.obj $(TOP)/src/rrd_getopt1.obj \
-		$(TOP)/win32/$(RRD_LIB_NAME).lib
-	cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
-		$(TOP)/src/rrd_getopt.obj $(TOP)/src/rrd_getopt1.obj \
-		$(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
+        $(TOP)/src/optparse.obj \
+        $(TOP)/win32/$(RRD_LIB_NAME).lib
+    cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
+        $(TOP)/src/optparse.obj \
+        $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
 #Just waiting for antivirus program to finished check tasks
-	-@ping 1.1.1.1 -n 1 -w 1000 > NUL
-	-mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdcgi.exe;#1
+    -@ping 1.1.1.1 -n 1 -w 1000 > NUL
+    -mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdcgi.exe;#1
 
 {$(TOP)/src}.c{$(TOP)/src}.obj:
-	cl /nologo /MT /DWIN32 /c $(CPPFLAGS) /Fo$@ $<
+    cl /nologo /MT /DWIN32 /c $(CPPFLAGS) /Fo$@ $<
 
 {$(TOP)/win32}.rc{$(TOP)/win32}.res:
-	rc /nologo /fo$@ $<
+    rc /nologo /I./src /fo$@ $<
+
+{$(TOP)/win32}.c{$(TOP)/win32}.obj:
+    cl /nologo /MT /DWIN32 /c $(CPPFLAGS) /Fo$@ $<

--- a/win32/librrd-4.vcxproj
+++ b/win32/librrd-4.vcxproj
@@ -100,7 +100,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libpng12;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -123,7 +123,7 @@
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libpng12;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USE_32BIT_TIME_T;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -143,7 +143,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libpng12;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -161,13 +161,12 @@
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>librrd-4.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalOptions>/FORCE:MULTIPLE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libpng12;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -183,14 +182,13 @@
     <Lib>
       <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;pcre.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <ModuleDefinitionFile />
       <IgnoreSpecificDefaultLibraries>LIBCMTD.lib;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libpng12;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;../contrib/include/cairo;../contrib/include/pango-1.0;../contrib/include/glib-2.0;../contrib/lib/glib-2.0/include;../contrib/include;../contrib/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -208,7 +206,6 @@
       <AdditionalDependencies>cairo.lib;glib-2.0.lib;gobject-2.0.lib;libpng.lib;libxml2.lib;pango-1.0.lib;ws2_32.lib;pangocairo-1.0.lib;gthread-2.0.lib;pcre.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>librrd-4.def</ModuleDefinitionFile>
-      <AdditionalOptions>/FORCE:MULTIPLE %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -255,7 +252,6 @@
     <ClCompile Include="..\src\rrd_version.c" />
     <ClCompile Include="..\src\rrd_xport.c" />
     <ClCompile Include="..\src\strftime.c" />
-    <ClCompile Include="..\src\win32comp.c" />
     <ClCompile Include="asprintf.c" />
     <ClCompile Include="vasprintf-msvc.c" />
     <ClCompile Include="win32-glob.c" />

--- a/win32/rrdtool.vcxproj
+++ b/win32/rrdtool.vcxproj
@@ -81,7 +81,6 @@
       <AdditionalDependencies>librrd-4.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <AdditionalLibraryDirectories>$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <IgnoreSpecificDefaultLibraries>LIBCMTD.lib;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>

--- a/win32/rrdupdate.vcxproj
+++ b/win32/rrdupdate.vcxproj
@@ -154,6 +154,7 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>


### PR DESCRIPTION
**Add further Windows build files to .gitignore**

- Added the following lines, sorted alphabetically:
```
  /win32/*.VC.db
  /win32/*.VC.opendb
  /win32/.vs
  /win32/DebugDLL
  /win32/Static\ Debug
```

**win32/Makefile.msc**

Update Makefile.msc for Windows builds with nmake

- Added comment with usage information on top of the file
- Fixed typo CCPFlags -> CPPFLAGS
- Changed from /TP (specifies C++ source files)
  to /TC (specifies C source files)
- Added zdll.lib gthread-2.0.lib pcre.lib to THIRD_PARTY_LIB
- Removed rrd_getopt.obj and rrd_getopt1.obj from RRD_LIB_OBJ_LIST
  added optparse.obj instead
- Added further required .obj files to RRD_LIB_OBJ_LIST
- Added deletion of win32\*.obj to the clean section
- Building of rrdcgi.exe: changed from rrd_getopt.obj
  and rrd_getopt1.obj to optparse.obj
- rc: include ./src, fixes:
  ./win32\rrd_config.h(119) : fatal error RC1015:
  cannot open include file 'mkstemp.h'.
- Added compilation of .c files in ./win32 folder

**win32/librrd-4.vcxproj**

Update librrd-4.vcxproj

- Removed ../contrib/include/libpng12 from AdditionalIncludeDirectories
  libpng12 has been updated to libpng14, but the include is not
  necessary, because png.h is found in ../contrib/include too
- Removed <ClCompile Include="..\src\win32comp.c" />
  definitions are already in rrd_thread_safe_nt.c
  Fixes win32comp.obj :
  error LNK2005: _localtime_r, _gmtime_r, _ctime_r, _strtok_r
  already defined in rrd_thread_safe_nt.obj
- Removed /FORCE:MULTIPLE, which is not required any more after removal
  of win32comp.c from compilation

**win32/rrdtool.vcxproj**

Update rrdtool.vcxproj

- Removed: IgnoreSpecificDefaultLibraries LIBCMTD.lib;LIBCMT.lib
  Fixes failing build in case of 'Debug|Win32'

**win32/rrdupdate.vcxproj**

Update rrdupdate.vcxproj

- Added . to AdditionalIncludeDirectories for 'Static Debug|Win32'
