### PR TITLE
Fix macro redefinition warnings, update win32 build tips, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ Makefile
 # Windows build files
 /bindings/dotnet/*.suo
 /contrib
+/contrib-x64
 /win32/*.VC.db
 /win32/*.VC.opendb
 /win32/*.opensdf

--- a/WIN32-BUILD-TIPS.txt
+++ b/WIN32-BUILD-TIPS.txt
@@ -35,6 +35,8 @@ version 1.4.5 and newer with Microsoft Visual Studio 2013 (12.0.x) and newer.
     
     - expat:    http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/expat_2.1.0-1_win32.zip
 
+    - gettext:  http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/gettext-runtime_0.18.1.1-2_win32.zip
+
     - pcre:     https://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-bin.zip
                 https://downloads.sourceforge.net/project/gnuwin32/pcre/7.0/pcre-7.0-lib.zip
 

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -102,14 +102,14 @@ clean:
 $(TOP)/win32/$(RRD_LIB_NAME).dll $(TOP)/win32/$(RRD_LIB_NAME).lib: \
         $(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
         $(RRD_LIB_OBJ_LIST)
-    cl /nologo /MT /LD /Zi /Fe$(TOP)/win32/$(RRD_LIB_NAME).dll \
+    cl /nologo /MD /LD /Zi /Fe$(TOP)/win32/$(RRD_LIB_NAME).dll \
         /Fd$(TOP)/win32/$(RRD_LIB_NAME).pdb \
         $(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
         $(RRD_LIB_OBJ_LIST) /link $(THIRD_PARTY_LIB) $(LD_FLAGS)
 
 $(TOP)/win32/rrdtool.exe: $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
         $(TOP)/win32/$(RRD_LIB_NAME).lib
-    cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
+    cl /nologo /MD /Zi /Fe$@ $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
         $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
 #Just waiting for antivirus program to finished check tasks
     -@ping 1.1.1.1 -n 1 -w 1000 > NUL
@@ -117,7 +117,7 @@ $(TOP)/win32/rrdtool.exe: $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
 
 $(TOP)/win32/rrdupdate.exe: $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
         $(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib
-    cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
+    cl /nologo /MD /Zi /Fe$@ $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
         $(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
 #Just waiting for antivirus program to finished check tasks
     -@ping 1.1.1.1 -n 1 -w 1000 > NUL
@@ -126,7 +126,7 @@ $(TOP)/win32/rrdupdate.exe: $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj 
 $(TOP)/win32/rrdcgi.exe: $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
         $(TOP)/src/optparse.obj \
         $(TOP)/win32/$(RRD_LIB_NAME).lib
-    cl /nologo /MT /Zi /Fe$@ $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
+    cl /nologo /MD /Zi /Fe$@ $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
         $(TOP)/src/optparse.obj \
         $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
 #Just waiting for antivirus program to finished check tasks
@@ -134,10 +134,10 @@ $(TOP)/win32/rrdcgi.exe: $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
     -mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdcgi.exe;#1
 
 {$(TOP)/src}.c{$(TOP)/src}.obj:
-    cl /nologo /MT /DWIN32 /c $(CPPFLAGS) /Fo$@ $<
+    cl /nologo /MD /DWIN32 /c $(CPPFLAGS) /Fo$@ $<
 
 {$(TOP)/win32}.rc{$(TOP)/win32}.res:
     rc /nologo /I./src /fo$@ $<
 
 {$(TOP)/win32}.c{$(TOP)/win32}.obj:
-    cl /nologo /MT /DWIN32 /c $(CPPFLAGS) /Fo$@ $<
+    cl /nologo /MD /DWIN32 /c $(CPPFLAGS) /Fo$@ $<

--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -95,13 +95,8 @@
 #define HAVE_TZSET 1
 
 /* Misc Missing Windows defines */
+#undef PATH_MAX /* PATH_MAX is defined in win32/dirent.h too. Relevant, if included before rrd_config.h */
 #define PATH_MAX 1024
-
-/*
- * Windows Sockets errors redefined as regular Berkeley error constants.
- */
-#define ENOBUFS WSAENOBUFS
-#define ENOTCONN WSAENOTCONN
 
 
 #include <ctype.h>
@@ -114,15 +109,24 @@
 #include <stdlib.h>
 #include <WinSock.h>
 
+#include <errno.h>  /* errno.h has to be included before the redefinitions of ENOBUFS and ENOTCONN below */
+/*
+ * Windows Sockets errors redefined as regular Berkeley error constants.
+ */
+#undef ENOBUFS  /* undefine first, because this is defined in errno.h and redefined here */
+#define ENOBUFS WSAENOBUFS
+#undef ENOTCONN /* undefine first, because this is defined in errno.h and redefined here */
+#define ENOTCONN WSAENOTCONN
 
-#include <errno.h>
 #include "mkstemp.h"
 
-
+#if _MSC_VER < 1900
 #define isinf(a) (_fpclass(a) == _FPCLASS_NINF || _fpclass(a) == _FPCLASS_PINF)
 #define isnan _isnan
-#define finite _finite
 #define snprintf _snprintf
+#endif
+
+#define finite _finite
 #define rrd_realloc(a,b) ( (a) == NULL ? malloc( (b) ) : realloc( (a) , (b) ))
 #define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
 #define strcasecmp _stricmp
@@ -131,6 +135,7 @@
 
 // in MSVC++ 12.0 / Visual Studio 2013 is a definition of round in math.h
 // some values of _MSC_VER
+//MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
 //MSVC++ 12.0 _MSC_VER == 1800 (Visual Studio 2013)
 //MSVC++ 11.0 _MSC_VER == 1700 (Visual Studio 2012)
 //MSVC++ 10.0 _MSC_VER == 1600 (Visual Studio 2010)


### PR DESCRIPTION
**.gitignore**

Add /contrib-x64 to .gitignore

**WIN32-BUILD-TIPS.txt**

Add gettext dependency to WIN32-BUILD-TIPS.txt

- Provides intl.dll

**win32/Makefile.msc**

Use /MD instead of /MT for Windows builds

- Change "Use Run-Time Library" to /MD like in the .vcxproj files
- This fixes png display issues of "rrdtool.exe graph" within Cacti

**win32/rrd_config.h**

Fix macro redefinition warnings (MSVC)

- Move inclusion of errno.h before the redefinition of ENOBUFS and ENOTCONN
  undef ENOBUFS and ENOTCONN before redefinition
- undef PATH_MAX before definition or redefinition
- Make definition of isinf, isnan and snprintf conditional
  if _MSC_VER < 1900
  These are supported since Visual Studio 2015
- Add comments and Visual Studio version details
