### PR TITLE
Fix formal parameter different from declaration

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -306,7 +306,7 @@ struct rrd_t;
             char ***ret_last_ds);
     time_t    rrd_first_r(
     const char *filename,
-    int rraindex);
+    const int rraindex);
 
     int rrd_dump_cb_r(
     const char *filename,

--- a/src/rrd_graph.h
+++ b/src/rrd_graph.h
@@ -464,7 +464,7 @@ void      rrd_graph_options(
 void      rrd_graph_script(
     int,
     char **,
-    image_desc_t *,
+    image_desc_t *const,
     int);
 int       rrd_graph_color(
     image_desc_t *,

--- a/src/rrd_modify.h
+++ b/src/rrd_modify.h
@@ -70,7 +70,7 @@ typedef int candidate_selectfunc_t(const rra_def_t *tofill, const rra_def_t *may
 
 candidate_t *find_candidate_rras(const rrd_t *rrd, const rra_def_t *rra, int *cnt,
 				 candidate_extra_t extra,
-                                 candidate_selectfunc_t);
+                                 candidate_selectfunc_t *select_func);
 
 #endif
 


### PR DESCRIPTION
- Fixes compiler warnings C4028 (MSVC):
  formal parameter 2 different from declaration src\rrd_first.c 87
  formal parameter 3 different from declaration src\rrd_graph_helper.c 1500
  formal parameter 5 different from declaration src\rrd_modify.c 90