### PR TITLE
Define HAVE_UINTPTR_T in rrd_config.h for Windows

### DIFF
--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -94,6 +94,9 @@
 /* Define to 1 if you have the `tzset' function. */
 #define HAVE_TZSET 1
 
+/* Define to 1 if you have the `uniptr_t' standard type. */
+#define HAVE_UINTPTR_T 1
+
 /* Misc Missing Windows defines */
 #undef PATH_MAX /* PATH_MAX is defined in win32/dirent.h too. Relevant, if included before rrd_config.h */
 #define PATH_MAX 1024


### PR DESCRIPTION
- Fixes compilation error, when building for x64 under Windows (MSVC):
  ./src\rrd_snprintf.c(901): warning C4311: 'type cast':
  pointer truncation from 'const char *' to 'unsigned long'
- uintptr_t is a defined standard type in Visual Studio:
  https://msdn.microsoft.com/en-us/library/323b6b3k.aspx