### PR TITLE
Define HAVE_G_REGEX_NEW, remove PCRE deps (MSVC)

### DIFF
--- a/WIN32-BUILD-TIPS.txt
+++ b/WIN32-BUILD-TIPS.txt
@@ -37,8 +37,6 @@ version 1.4.5 and newer with Microsoft Visual Studio 2013 (12.0.x) and newer.
 
     - gettext:  http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/gettext-runtime_0.18.1.1-2_win32.zip
 
-    - pcre:     http://win-builds.org/next/packages/windows_32/pcre-8.38-1-i686-w64-mingw32.txz
-
 (3) Extract all of the .zip files into the contrib folder. Do not extract each library into it's own
     directory. We want all of the files merged into a structure consisting of "bin, include, lib..."
     etc folders.

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -35,7 +35,7 @@ THIRD_PARTY_LIB = /LIBPATH:$(ARCH_PATH)\lib \
         libpng.lib libxml2.lib \
         glib-2.0.lib gobject-2.0.lib \
         pango-1.0.lib pangocairo-1.0.lib cairo.lib \
-        Ws2_32.lib zdll.lib gthread-2.0.lib libpcre-1.lib
+        Ws2_32.lib zdll.lib gthread-2.0.lib
 
 RRD_LIB_OBJ_LIST = \
         $(TOP)/src/hash_32.obj \

--- a/win32/librrd-4.vcxproj
+++ b/win32/librrd-4.vcxproj
@@ -114,7 +114,7 @@
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;libpcre-1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile />
     </Lib>
@@ -136,7 +136,7 @@
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;libpcre-1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Lib>
   </ItemDefinitionGroup>
@@ -157,7 +157,7 @@
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>cairo.lib;glib-2.0.lib;gobject-2.0.lib;libpng.lib;libxml2.lib;pango-1.0.lib;pangocairo-1.0.lib;gthread-2.0.lib;libpcre-1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cairo.lib;glib-2.0.lib;gobject-2.0.lib;libpng.lib;libxml2.lib;pango-1.0.lib;pangocairo-1.0.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>librrd-4.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -180,7 +180,7 @@
       <ProgramDataBaseFileName>$(IntDir)librrd-4.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
-      <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;libpcre-1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBCMTD.lib;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Lib>
@@ -203,7 +203,7 @@
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>cairo.lib;glib-2.0.lib;gobject-2.0.lib;libpng.lib;libxml2.lib;pango-1.0.lib;ws2_32.lib;pangocairo-1.0.lib;gthread-2.0.lib;libpcre-1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cairo.lib;glib-2.0.lib;gobject-2.0.lib;libpng.lib;libxml2.lib;pango-1.0.lib;ws2_32.lib;pangocairo-1.0.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>librrd-4.def</ModuleDefinitionFile>
     </Link>

--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -64,8 +64,8 @@
 /* Define to 1 if you have the `isnan' function. */
 #define HAVE_ISNAN 1
 
-/* Define to 1 if you have the <pcre.h> header file. */
-#define HAVE_PCRE_COMPILE 1
+/* glib has g_regex_new since 2.14 */
+#define HAVE_G_REGEX_NEW 1
 
 /* is rrd_graph supported by this install */
 #define HAVE_RRD_GRAPH /**/

--- a/win32/rrdtool.vcxproj
+++ b/win32/rrdtool.vcxproj
@@ -102,7 +102,6 @@ copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpcre-1.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
 </Command>
     </PostBuildEvent>
@@ -144,7 +143,6 @@ copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpcre-1.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
 </Command>
     </PostBuildEvent>
@@ -187,7 +185,6 @@ copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpcre-1.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
 </Command>
     </PostBuildEvent>

--- a/win32/rrdupdate.vcxproj
+++ b/win32/rrdupdate.vcxproj
@@ -103,7 +103,6 @@ copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpcre-1.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
 </Command>
     </PostBuildEvent>
@@ -145,7 +144,6 @@ copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpcre-1.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
 </Command>
     </PostBuildEvent>
@@ -188,7 +186,6 @@ copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpcre-1.dll $(TargetDir)\
 copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
 </Command>
     </PostBuildEvent>


### PR DESCRIPTION
- Define HAVE_G_REGEX_NEW 1 in rrd_config.h
  glib has g_regex_new since 2.14
- Remove dependency on PCRE, which is not required any more