### PR TITLE
Update vcxproj files, fix debug builds (MSVC)

### DIFF
--- a/win32/rrdtool.vcxproj
+++ b/win32/rrdtool.vcxproj
@@ -70,7 +70,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <ProgramDataBaseFileName>$(IntDir)rrdtool.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -170,22 +170,22 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>
-      <Command>copy $(ProjectDir)\..\contrib\bin\freetype6.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\intl.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libcairo-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libexpat-1.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libfontconfig-1.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libglib-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libgmodule-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libgobject-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libgthread-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpango-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpangocairo-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
+      <Command>copy $(ProjectDir)\..\contrib\bin\freetype6.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\intl.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libcairo-2.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libexpat-1.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libfontconfig-1.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libglib-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libgmodule-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libgobject-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libgthread-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpango-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpangocairo-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\zlib1.dll "$(TargetDir)"\
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/win32/rrdupdate.vcxproj
+++ b/win32/rrdupdate.vcxproj
@@ -71,7 +71,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USE_32BIT_TIME_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <ProgramDataBaseFileName>$(IntDir)rrdupdate.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
@@ -171,22 +171,22 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>
-      <Command>copy $(ProjectDir)\..\contrib\bin\freetype6.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\intl.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libcairo-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libexpat-1.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libfontconfig-1.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libglib-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libgmodule-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libgobject-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libgthread-2.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpango-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpangocairo-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll $(TargetDir)\
-copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
+      <Command>copy $(ProjectDir)\..\contrib\bin\freetype6.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\intl.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libcairo-2.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libexpat-1.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libfontconfig-1.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libglib-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libgmodule-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libgobject-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libgthread-2.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpango-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpangocairo-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpangoft2-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpangowin32-1.0-0.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libpng14-14.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\libxml2-2.dll "$(TargetDir)"\
+copy $(ProjectDir)\..\contrib\bin\zlib1.dll "$(TargetDir)"\
 </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
- Solution configuration Debug|Win32: Changed MultiThreadedDebug to
  MultiThreadedDebugDLL in rrdtool.vcxproj and rrdupdate.vcxproj.
  Now the RuntimeLibrary setting is the same as in librrd-4.vcxproj.
- Solution configuration Static Debug|Win32: Added double quotes around
  $(TargetDir), because there is a space in "Static Debug". Fixes
  failing copy commands of dlls by using "$(TargetDir)" now.