### PR TITLE
Fix build errors (MinGW-w64)

### DIFF
--- a/src/rrd.h
+++ b/src/rrd.h
@@ -63,9 +63,11 @@ extern    "C" {
 #endif
 	#define strtoll _strtoi64 
 #endif
+#ifndef __MINGW32__     /* MinGW-w64 has ssize_t and off_t */
 	typedef size_t ssize_t;
 	typedef long off_t;
-#endif 
+#endif
+#endif
 
 #include <time.h>
 #include <stdio.h>      /* for FILE */

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -26,9 +26,11 @@
 #ifndef WIN32
 #	include <unistd.h>     /* for off_t */
 #else
+#ifndef __MINGW32__     /* MinGW-w64 has ssize_t and off_t */
 	typedef size_t ssize_t;
 	typedef long off_t;
-#endif 
+#endif
+#endif
 
 #include <fcntl.h>
 #if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)

--- a/src/rrd_utils.c
+++ b/src/rrd_utils.c
@@ -217,7 +217,7 @@ int rrd_mkdir_p(const char *pathname_unsafe, mode_t mode)
     free(base_dir);
 
     /* keep errno as set by mkdir() */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
     if (0 != mkdir(pathname)) {
         free(pathname);
         return -1;


### PR DESCRIPTION
- rrd.h, fixed build error:
  rrd.h:66:17: error: conflicting types for 'ssize_t'
  typedef size_t ssize_t;
  Remark: MinGW-w64 has ssize_t and off_t
- rrd_restore.c, fixed build error:
  rrd_restore.c:29:17: error: conflicting types for 'ssize_t'
  typedef size_t ssize_t;
- rrd_utils.c, fixed build error:
  rrd_utils.c:226:10: error: too many arguments to function 'mkdir'
     if ((mkdir(pathname, mode) != 0) && (errno != EEXIST)) {