### PR TITLE
Remove fdatasync, fsync from rrd_config_bottom.h

### DIFF
--- a/src/rrd_config_bottom.h
+++ b/src/rrd_config_bottom.h
@@ -230,13 +230,5 @@ char *strchr (), *strrchr ();
 #error "Can't compile without isinf function"
 #endif
 
-#if (! defined(HAVE_FDATASYNC) && defined(HAVE_FSYNC))
-#define fdatasync fsync
-#endif
-
-#if (!defined(HAVE_FDATASYNC) && !defined(HAVE_FSYNC))
-#error "Can't compile with without fsync and fdatasync"
-#endif
-
 #endif /* RRD_CONFIG_BOTTOM_H */
 


### PR DESCRIPTION
- fdatasync() has been removed since RRDtool v1.4.0.
  See commit: fc968dd
- fixes "Can't compile with without fsync and fdatasync" error
  on systems, where HAVE_FDATASYNC or HAVE_FSYNC are not defined