### PR TITLE
Use #ifdef instead of #if for HAVE_...

### DIFF
--- a/src/rrd_dump.c
+++ b/src/rrd_dump.c
@@ -415,7 +415,7 @@ int rrd_dump_cb_r(
                 + (timer * (long)rrd.rra_def[i].pdp_cnt * (long)rrd.stat_head->pdp_step);
 
             timer++;
-#if HAVE_STRFTIME
+#ifdef HAVE_STRFTIME
             localtime_r(&now, &tm);
             strftime(somestring, 255, "%Y-%m-%d %H:%M:%S %Z", &tm);
 #else

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -3035,7 +3035,7 @@ void vertical_grid(
         /* are we inside the graph ? */
         if (tilab < im->start || tilab > im->end)
             continue;
-#if HAVE_STRFTIME
+#ifdef HAVE_STRFTIME
         localtime_r(&tilab, &tm);
         strftime(graph_label, 99, im->xlab_user.stst, &tm);
 #else

--- a/src/rrd_snprintf.c
+++ b/src/rrd_snprintf.c
@@ -332,7 +332,7 @@
 #ifdef VA_SHIFT
 #undef VA_SHIFT
 #endif	/* defined(VA_SHIFT) */
-#if HAVE_STDARG_H
+#ifdef HAVE_STDARG_H
 #include <stdarg.h>
 #define VA_START(ap, last) va_start(ap, last)
 #define VA_SHIFT(ap, value, type) /* No-op for ANSI C. */

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -465,7 +465,7 @@ int main(
     }
 
     if (((argc == 2) || (argc == 3)) && !strcmp("-", argv[1])) {
-#if HAVE_GETRUSAGE
+#ifdef HAVE_GETRUSAGE
         struct rusage myusage;
         struct timeval starttime;
         struct timeval currenttime;
@@ -520,7 +520,7 @@ int main(
                 printf("ERROR: creating arguments\n");
             } else {
                 if ( HandleInputLine(argc, myargv, stdout) == 0 ){
-#if HAVE_GETRUSAGE
+#ifdef HAVE_GETRUSAGE
                     getrusage(RUSAGE_SELF, &myusage);
                     gettimeofday(&currenttime, NULL);
                     printf("OK u:%1.2f s:%1.2f r:%1.2f\n",


### PR DESCRIPTION
- Harmonizes usage of #ifdef also for:
  HAVE_STRFTIME, HAVE_STDARG_H, HAVE_GETRUSAGE
- Fixes compiler warnings like:
  rrd_tool.c:468:5: warning: "HAVE_GETRUSAGE" is not defined,
  evaluates to 0 [-Wundef]