### PR TITLE
Add glob.h to configure.ac AC_CHECK_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,7 @@ CONFIGURE_PART(Checking for Header Files)
 dnl Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_DIRENT
-AC_CHECK_HEADERS(langinfo.h stdint.h inttypes.h libgen.h features.h sys/stat.h sys/types.h fcntl.h fp_class.h malloc.h unistd.h ieeefp.h math.h sys/times.h sys/param.h sys/resource.h signal.h float.h stdio.h stdlib.h errno.h string.h ctype.h grp.h pwd.h)
+AC_CHECK_HEADERS(langinfo.h stdint.h inttypes.h libgen.h features.h sys/stat.h sys/types.h fcntl.h fp_class.h malloc.h unistd.h ieeefp.h math.h sys/times.h sys/param.h sys/resource.h signal.h float.h stdio.h stdlib.h errno.h string.h ctype.h grp.h pwd.h glob.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST


### PR DESCRIPTION
- Adds check for glob.h
- Provides HAVE_GLOB_H