### PR TITLE
Fix further build errors (MinGW-w64)

### DIFF
--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -103,9 +103,11 @@ static char *get_path(rrd_client_t *client, const char *path) /* {{{ */
   if ((client == NULL) || (path == NULL) || (client->sd_path == NULL))
     return (NULL);
 
+#ifndef __MINGW32__
   if ((*client->sd_path == '/')
       || (strncmp ("unix:", client->sd_path, strlen ("unix:")) == 0))
     is_unix = 1;
+#endif
 
   if (is_unix)
   {

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -9,7 +9,7 @@
 
 
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 #include "strftime.h"
 #endif
 

--- a/src/rrd_list.c
+++ b/src/rrd_list.c
@@ -1,12 +1,17 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "rrd_config.h"
 #ifdef _MSC_VER
 #include "win32-glob.h"    /* from https://sourceforge.net/projects/sox/ */
 #include "dirent.h"        /* from https://github.com/tronkko/dirent */
 #include "asprintf.h"      /* from http://asprintf.insanecoding.org */
 #else
+#if defined(__MINGW32__) && !defined(HAVE_GLOB_H)   /* MinGW has glob.h, MinGW-w64 not (yet?) */
+#include "win32/win32-glob.h"    /* from https://sourceforge.net/projects/sox/ */
+#else
 #include <glob.h>
+#endif
 #include <dirent.h>
 #endif
 #include <sys/types.h>

--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -7,6 +7,15 @@
 #include <limits.h>
 #include <locale.h>
 #include <stdlib.h>
+#ifdef __MINGW32__
+#include <pthread.h>
+/* time.h of MinGW-w64 requires _POSIX_THREAD_SAFE_FUNCTIONS to be defined in order to provide
+ * localtime_r. _POSIX_THREAD_SAFE_FUNCTIONS is defined in pthread_unistd.h (included from pthread.h).
+ * Alternatives here would be to either include "rrd_tool.h" before <time.h> or remove include of <time.h>
+ * from rrd_rpncalc.c, because time.h is included via rrd_tool.h ...
+ * However, let's do it this way, by including pthread.h here, only if __MINGW32__ is defined,
+ * in order to avoid any changes concerning other systems. */
+#endif
 #include <time.h>
 #include "rrd_tool.h"
 

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -575,7 +575,8 @@ static int HandleInputLine(
             }
             exit(0);
         }
-#if defined(HAVE_OPENDIR) && defined(HAVE_READDIR) && defined(HAVE_CHDIR) && defined(HAVE_SYS_STAT_H)
+/* MinGW-w64 has not got getuid() and only 1 argument for mkdir() */
+#if defined(HAVE_OPENDIR) && defined(HAVE_READDIR) && defined(HAVE_CHDIR) && defined(HAVE_SYS_STAT_H) && !defined(__MINGW32__)
         if (argc > 1 && strcmp("cd", argv[1]) == 0) {
             if (argc != 3) {
                 printf("ERROR: invalid parameter count for cd\n");

--- a/src/rrd_tool.h
+++ b/src/rrd_tool.h
@@ -14,7 +14,7 @@ extern    "C" {
 
 #include "rrd.h"
 
-#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__) && !defined(__MINGW32__)
 
 /* Win32 only includes */
 

--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -30,7 +30,8 @@
 
 #include "rrd_strtod.h"
 
-#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__) && !defined(__MINGW32__)
+/* Remark: HAVE_GETTIMEOFDAY could be used here alternatively */
 
 /*
  * WIN32 does not have gettimeofday	and struct timeval. This is a quick and dirty


### PR DESCRIPTION
- rrd_list.c: MinGW-w64 does not provide glob.h (yet?)
  include win32/win32-glob.h using HAVE_GLOB_H. Fixes:
  rrd_list.c:9:10: fatal error: glob.h: No such file or directory
    #include <glob.h>
- rrd_update.c: MinGW has gettimeofday() in time.h. Fixes:
  rrd_update.c:46:12: error: conflicting types for 'gettimeofday'
    static int gettimeofday(
- rrd_tool.c: MinGW has not got getuid and mkdir only one argument.
  Fixes:
  rrd_tool.c:585:17: warning: nested extern declaration of 'getuid'
  rrd_tool.c:632:16: error: too many arguments to function 'mkdir'
    if(mkdir(argv[2], 0777)!=0){
- rrd_tool.h:
  MinGW-w64 provides localtime_r, ctime_r, gmtime_r, strtok_r
- rrd_graph.c: MinGW has strftime and tzname.
  Due to the resulting later include of time.h, fixes also:
  rrd_graph.c:1558: undefined reference to 'localtime_r'
- rrd_client.c: MinGW does not provide realpath, "is_unix" excluded.
  Fixes:
  rrd_client.c:113: undefined reference to 'realpath'
  rrd_client.c:130: undefined reference to 'realpath'
- rrd_rpncalc.c: include pthread.h. Fixes e.g.:
  rrd_rpncalc.c:708: undefined reference to 'localtime_r'