### PR TITLE
Fix ctime_r configure error (MinGW-w64)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -450,7 +450,10 @@ AC_LINK_IFELSE(
     ],
     [ AC_LINK_IFELSE(
           [AC_LANG_PROGRAM(
-                [[#include <time.h>]],
+                [[#ifdef __MINGW32__
+#include <pthread.h>
+#endif
+#include <time.h>]],
                 [[ctime_r(NULL,NULL)]])],
           [AC_MSG_RESULT(no)],
           [AC_MSG_ERROR([Can't figure how to compile ctime_r])]


### PR DESCRIPTION
- configure.ac: include pthread.h inside AC_LANG_PROGRAM
  for ctime_r check if `__MINGW32__` is defined
  Fixes:
  checking if ctime_r need special care to act posixly correct...
  configure: error: Can't figure how to compile ctime_r