### PR TITLE
Fix compiler warnings, llu lli 64bit (MinGW-w64)

### DIFF
--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -5,6 +5,10 @@
  *                     this code initially written by Alex van den Bogaerdt
  ****************************************************************************/
 
+#ifdef __MINGW64__
+#define __USE_MINGW_ANSI_STDIO 1    /* for %lli */
+#endif
+
 #include <locale.h>
 #include "rrd_config.h"
 #ifdef HAVE_STDINT_H
@@ -1455,7 +1459,11 @@ static int parse_shift(enum gf_en gf,parsedargs_t* pa,image_desc_t *const im) {
   if (gdp->shidx>=0) {
     dprintf("SHIFTBY : %s (%i)\n",im->gdes[gdp->shidx].vname,gdp->shidx);
   } else {
+#ifdef __MINGW64__
+    dprintf("SHIFTBY : %lli\n",gdp->shval); /* argument 3 has type 'time_t {aka long long int}' */
+#else
     dprintf("SHIFTBY : %li\n",gdp->shval);
+#endif
   }
   dprintf("=================================\n");
   /* and return */

--- a/src/rrd_lastupdate.c
+++ b/src/rrd_lastupdate.c
@@ -5,6 +5,10 @@
  * rrd_lastupdate  Get the last datum entered for each DS
  *****************************************************************************/
 
+#ifdef __MINGW64__
+#define __USE_MINGW_ANSI_STDIO 1    /* for %10llu */
+#endif
+
 #include "rrd_tool.h"
 #include "rrd_rpncalc.h"
 #include "rrd_client.h"
@@ -73,7 +77,11 @@ int rrd_lastupdate (int argc, char **argv)
         printf(" %s", ds_names[i]);
     printf ("\n\n");
 
+#ifdef __MINGW64__
+    printf ("%10llu:", last_update);    /* argument 2 has type 'time_t {aka long long int} */
+#else
     printf ("%10lu:", last_update);
+#endif
     for (i = 0; i < ds_count; i++) {
         printf(" %s", last_ds[i]);
         free(last_ds[i]);


### PR DESCRIPTION
- time_t is of type 'long long int', when compiled for 64 bit Windows
  (x86_64-w64-mingw32). Use %10llu instead of %10lu in printf and
  %lli instead of %li in dprintf. Requires __USE_MINGW_ANSI_STDIO 1

- Fixes: rrd_lastupdate.c: In function 'rrd_lastupdate':
  rrd_lastupdate.c:76:18:
  warning: format '%lu' expects argument of type 'long unsigned int',
  but argument 2 has type 'time_t {aka long long int}' [-Wformat=]

- Fixes: rrd_graph_helper.c: In function 'parse_shift':
  rrd_graph_helper.c:1458:13:
  warning: format '%li' expects argument of type 'long int',
  but argument 3 has type 'time_t {aka long long int}' [-Wformat=]
  dprintf("SHIFTBY : %li\n",gdp->shval);