### PR TITLE
Check for MinGW-w64 build, add win32-glob files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,8 +26,7 @@ EXTRA_DIST = COPYRIGHT CHANGES TODO CONTRIBUTORS THREADS VERSION LICENSE \
              win32/Makefile.msc win32/RCa02816 win32/README win32/README-MinGW-w64 win32/rrdcgi.rc win32/rrd_config.h \
              win32/rrd.sln win32/rrdtool.rc win32/rrdtool.sln win32/rrdtool.vcxproj win32/rrdupdate.rc \
              win32/rrdupdate.sln win32/rrdupdate.vcxproj win32/uac.manifest \
-             win32/asprintf.c win32/asprintf.h win32/dirent.h win32/vasprintf-msvc.c \
-             win32/win32-glob.c win32/win32-glob.h
+             win32/asprintf.c win32/asprintf.h win32/dirent.h win32/vasprintf-msvc.c
 
 CLEANFILES = config.cache
 

--- a/configure.ac
+++ b/configure.ac
@@ -433,7 +433,7 @@ AC_DEFINE(NO_NULL_REALLOC)
 fi
 
 AC_LANG_PUSH(C)
-dnl solaris has some odd defines it needs in order to propperly compile ctime_r
+dnl solaris has some odd defines it needs in order to properly compile ctime_r
 AC_MSG_CHECKING([if ctime_r need special care to act posixly correct])
 AC_LINK_IFELSE(
     [AC_LANG_PROGRAM(
@@ -981,6 +981,21 @@ if test -z "$RRDDOCDIR"; then
    RRDDOCDIR='${datadir}/doc/${PACKAGE}-${VERSION}'; fi
 
 fi
+
+# Check for MinGW-w64 build and pass to automake
+build_mingw_w64=no
+AC_MSG_CHECKING([for MinGW-w64 build])
+case "$host" in
+    *w64-mingw32*)
+        AC_MSG_RESULT([yes])
+        build_mingw_w64=yes
+    ;;
+    *)
+        AC_MSG_RESULT([no])
+    ;;
+esac
+# Pass the conditional to automake
+AM_CONDITIONAL([MINGW_W64], [test "$build_mingw_w64" = "yes"])
 
 # systemd check
 PKG_PROG_PKG_CONFIG

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-#AUTOMAKE_OPTIONS   = foreign
+AUTOMAKE_OPTIONS   = subdir-objects
 #
 #ACLOCAL_M4	   = $(top_srcdir)/config/aclocal.m4
 #AUTOHEADER = @AUTOHEADER@ --localdir=$(top_srcdir)/config
@@ -69,9 +69,9 @@ endif
 
 noinst_HEADERS = \
 	unused.h \
-        gettext.h \
+	gettext.h \
 	mutex.h \
-        rrd_strtod.h \
+	rrd_strtod.h \
 	rrd_snprintf.h \
 	rrd_parsetime.h \
 	rrd_config_bottom.h rrd_i18n.h \
@@ -92,9 +92,14 @@ UPD_C_FILES += rrd_rados.c
 noinst_HEADERS += rrd_rados.h
 endif
 
+if MINGW_W64
+RRD_C_FILES += ../win32/win32-glob.c
+noinst_HEADERS += ../win32/win32-glob.h
+endif
+
 noinst_LTLIBRARIES        = librrdupd.la
 
-lib_LTLIBRARIES           = librrd.la 
+lib_LTLIBRARIES           = librrd.la
 
 librrdupd_la_SOURCES      = $(UPD_C_FILES)
 librrdupd_la_LIBADD       = $(CORE_LIBS)
@@ -138,7 +143,7 @@ rrdcached_LDADD = librrd.la librrdupd.la $(ALL_LIBS)
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = librrd.pc
 
-# strftime is here because we do not usually need it. unices have propper
+# strftime is here because we do not usually need it. unices have proper
 # iso date support
 EXTRA_DIST= librrd.pc.in strftime.c strftime.h \
 	win32comp.c  rrd_thread_safe_nt.c get_ver.awk librrd.sym plbasename.c plbasename.h


### PR DESCRIPTION
- configure.ac: Add check for MinWG-w64 build during configure.
  Pass the conditional MINGW_W64 to automake
- src/Makefile.am: Add win32-glob.c to RRD_C_FILES and
  win32-glob.h to noinst_HEADERS in case of MINGW_W64
- Makefile.am: win32/win32-glob.c and win32/win32-glob.h are mentioned
  in src/Makefile.am now. Removed from EXTRA_DIST
- Enables out of the box configure and make for MinGW-w64 builds
