### PR TITLE
Fix 64-bit time_t in fprintf, printf (MSVC)

### DIFF
--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -1459,7 +1459,7 @@ static int parse_shift(enum gf_en gf,parsedargs_t* pa,image_desc_t *const im) {
   if (gdp->shidx>=0) {
     dprintf("SHIFTBY : %s (%i)\n",im->gdes[gdp->shidx].vname,gdp->shidx);
   } else {
-#ifdef __MINGW64__
+#if defined _WIN32 && SIZEOF_TIME_T == 8    /* in case of __MINGW64__, _WIN64 and _MSC_VER >= 1400 (ifndef _USE_32BIT_TIME_T) */
     dprintf("SHIFTBY : %lli\n",gdp->shval); /* argument 3 has type 'time_t {aka long long int}' */
 #else
     dprintf("SHIFTBY : %li\n",gdp->shval);

--- a/src/rrd_lastupdate.c
+++ b/src/rrd_lastupdate.c
@@ -77,8 +77,8 @@ int rrd_lastupdate (int argc, char **argv)
         printf(" %s", ds_names[i]);
     printf ("\n\n");
 
-#ifdef __MINGW64__
-    printf ("%10llu:", last_update);    /* argument 2 has type 'time_t {aka long long int} */
+#if defined _WIN32 && SIZEOF_TIME_T == 8    /* in case of __MINGW64__, _WIN64 and _MSC_VER >= 1400 (ifndef _USE_32BIT_TIME_T) */
+    printf ("%10llu:", last_update);        /* argument 2 has type 'time_t {aka long long int} */
 #else
     printf ("%10lu:", last_update);
 #endif

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -717,11 +717,19 @@ static int HandleInputLine(
     else if (strcmp("resize", argv[1]) == 0)
         rrd_resize(argc - 1, &argv[1]);
     else if (strcmp("last", argv[1]) == 0)
+#if defined _WIN32 && SIZEOF_TIME_T == 8    /* in case of __MINGW64__, _WIN64 and _MSC_VER >= 1400 (ifndef _USE_32BIT_TIME_T) */
+        printf("%lld\n", rrd_last(argc - 1, &argv[1]));
+#else
         printf("%ld\n", rrd_last(argc - 1, &argv[1]));
+#endif
     else if (strcmp("lastupdate", argv[1]) == 0) {
         rrd_lastupdate(argc - 1, &argv[1]);
     } else if (strcmp("first", argv[1]) == 0)
+#if defined _WIN32 && SIZEOF_TIME_T == 8    /* in case of __MINGW64__, _WIN64 and _MSC_VER >= 1400 (ifndef _USE_32BIT_TIME_T) */
+        printf("%lld\n", rrd_first(argc - 1, &argv[1]));
+#else
         printf("%ld\n", rrd_first(argc - 1, &argv[1]));
+#endif
     else if (strcmp("update", argv[1]) == 0)
         rrd_update(argc - 1, &argv[1]);
     else if (strcmp("fetch", argv[1]) == 0) {
@@ -739,7 +747,11 @@ static int HandleInputLine(
                 printf("%20s", ds_namv[i]);
             printf("\n\n");
             for (ti = start + step; ti <= end; ti += step) {
+#if defined _WIN32 && SIZEOF_TIME_T == 8    /* in case of __MINGW64__, _WIN64 and _MSC_VER >= 1400 (ifndef _USE_32BIT_TIME_T) */
+                printf("%10llu:", ti);
+#else
                 printf("%10lu:", ti);
+#endif
                 for (ii = 0; ii < ds_cnt; ii++)
                     printf(" %0.10e", *(datai++));
                 printf("\n");


### PR DESCRIPTION
- In VS2005 and later, the default size for time_t is 64-bit, unless
  _USE_32BIT_TIME_T has been defined to use a 32-bit time_t ...

- Fixes MSVC compiler warnings:
  ./src\rrd_graph_helper.c(1465): warning C4477: 'fprintf' :
  format string '%li' requires an argument of type 'long',
  but variadic argument 1 has type 'time_t'

  ./src\rrd_lastupdate.c(83): warning C4477: 'printf' :
  format string '%10lu' requires an argument of type 'unsigned long',
  but variadic argument 1 has type 'time_t'

  ./src\rrd_tool.c(720): warning C4477: 'printf' : format string '%ld'
  requires an argument of type 'long', but variadic argument 1 has type
  'time_t'
  ./src\rrd_tool.c(724): warning C4477: 'printf' : format string '%ld'
  requires an argument of type 'long', but variadic argument 1 has type
  'time_t'
  ./src\rrd_tool.c(742): warning C4477: 'printf' : format string
  '%10lu' requires an argument of type 'unsigned long', but variadic
  argument 1 has type 'time_t'