### PR TITLE
Fix expansion-to-defined warnings (GCC 7)

### DIFF
--- a/src/gettext.h
+++ b/src/gettext.h
@@ -169,9 +169,11 @@ npgettext_aux (const char *domain,
 
 #include <string.h>
 
-#define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS \
-  (((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__) \
-   /* || __STDC_VERSION__ >= 199901L */ )
+#if ((__GNUC__ >= 3 || __GNUG__ >= 2) && !defined __STRICT_ANSI__)
+#define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 1
+#else
+#define _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS 0
+#endif
 
 #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
 #include <stdlib.h>


### PR DESCRIPTION
- Fixed compiler warnings:
  gettext.h:176:6: warning: this use of "defined" may not be portable
  [-Wexpansion-to-defined] #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
  gettext.h:200:5: warning: this use of "defined" may not be portable
  [-Wexpansion-to-defined] #if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
  gettext.h:215:6: warning: this use of "defined" may not be portable
  [-Wexpansion-to-defined] #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
  gettext.h:246:5: warning: this use of "defined" may not be portable
  [-Wexpansion-to-defined] #if _LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS
  gettext.h:261:6: warning: this use of "defined" may not be portable
  [-Wexpansion-to-defined] #if !_LIBGETTEXT_HAVE_VARIABLE_SIZE_ARRAYS