### PR TITLE
Quiets warning

### DIFF
--- a/src/rrd_parsetime.c
+++ b/src/rrd_parsetime.c
@@ -691,7 +691,7 @@ static char *day(
     case YESTERDAY:
         ptv->tm.  tm_mday--;
 
-        /* FALLTRHU */
+        /* FALLTHRU */
     case TODAY:        /* force ourselves to stay in today - no further processing */
         token();
         break;


### PR DESCRIPTION
gcc using -Wimplicit-fallthrough emits warning because of the typo