### PR TITLE
Fix rrdtool.graph python binding

### DIFF
--- a/bindings/python/rrdtoolmodule.c
+++ b/bindings/python/rrdtoolmodule.c
@@ -595,7 +595,7 @@ _rrdtool_graph(PyObject *Py_UNUSED(self), PyObject *args)
     PyObject *ret;
     int xsize, ysize, i, status;
     double ymin, ymax;
-    char **calcpr;
+    char **calcpr = NULL;
 
     if (convert_args("graph", args, &rrdtool_argv, &rrdtool_argc) == -1)
         return NULL;


### PR DESCRIPTION
It was failing with 'munmap_chunk(): invalid pointer' error in python 3.6.3