### PR TITLE
Update MinGW-w64 build instructions

### DIFF
--- a/win32/README-MinGW-w64
+++ b/win32/README-MinGW-w64
@@ -1,13 +1,17 @@
 MinGW-w64 Build Instructions:
 
 Here you will find instructions on how to build RRDtool using MinGW-w64.
-Examples are given for building Windows binaries under Fedora, MSYS2 and MXE
+Examples are given for building Windows binaries under Fedora, MSYS2 and MXE.
+
+After a successful build, the RRDtool Windows binaries are found in the following folder:
+src/.libs/
+Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 
 1) Fedora
  - i686 (32-bit)
    Install the required dependencies:
 
-   sudo dnf install mingw32-cairo mingw32-expat mingw32-fontconfig mingw32-freetype mingw32-gettext mingw32-glib2 mingw32-libpng mingw32-libxml2 mingw32-pango mingw32-pkg-config mingw32-zlib
+   sudo dnf install mingw32-cairo mingw32-expat mingw32-fontconfig mingw32-freetype mingw32-gettext mingw32-glib2 mingw32-libpng mingw32-libxml2 mingw32-pango mingw32-pkg-config mingw32-zlib perl-Pod-Html
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
@@ -17,7 +21,7 @@ Examples are given for building Windows binaries under Fedora, MSYS2 and MXE
 - x86_64 (64-bit)
    Install the required dependencies:
 
-   sudo dnf install mingw64-cairo mingw64-expat mingw64-fontconfig mingw64-freetype mingw64-gettext mingw64-glib2 mingw64-libpng mingw64-libxml2 mingw64-pango mingw64-pkg-config mingw64-zlib
+   sudo dnf install mingw64-cairo mingw64-expat mingw64-fontconfig mingw64-freetype mingw64-gettext mingw64-glib2 mingw64-libpng mingw64-libxml2 mingw64-pango mingw64-pkg-config mingw64-zlib perl-Pod-Html
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
@@ -29,7 +33,7 @@ Examples are given for building Windows binaries under Fedora, MSYS2 and MXE
  - i686 (32-bit)
    Install the required dependencies:
 
-   pacman -Sy --needed mingw-w64-i686-gcc mingw-w64-i686-cairo mingw-w64-i686-expat mingw-w64-i686-freetype mingw-w64-i686-gettext mingw-w64-i686-glib2 mingw-w64-i686-libpng mingw-w64-i686-libxml2 mingw-w64-i686-pango mingw-w64-i686-zlib mingw-w64-i686-pkg-config
+   pacman -Sy --needed base-devel mingw-w64-i686-gcc mingw-w64-i686-cairo mingw-w64-i686-expat mingw-w64-i686-freetype mingw-w64-i686-gettext mingw-w64-i686-glib2 mingw-w64-i686-libpng mingw-w64-i686-libxml2 mingw-w64-i686-pango mingw-w64-i686-zlib mingw-w64-i686-pkg-config
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
@@ -39,7 +43,7 @@ Examples are given for building Windows binaries under Fedora, MSYS2 and MXE
 - x86_64 (64-bit)
    Install the required dependencies:
 
-   pacman -Sy --needed mingw-w64-x86_64-gcc mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkg-config
+   pacman -Sy --needed base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkg-config
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap


### PR DESCRIPTION
- Info added, where to find compiled binaries:
  src/.libs/
- Added perl-Pod-Html to Fedora dependencies
- Added base-devel to MSYS2 build instructions