### PR TITLE
Define HAVE_RRD_RESTORE (MSVC)

### DIFF
--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -70,6 +70,9 @@
 /* is rrd_graph supported by this install */
 #define HAVE_RRD_GRAPH /**/
 
+/* is rrd_restore supported by this install */
+#define HAVE_RRD_RESTORE /**/
+
 /* Define to 1 if you have the `snprintf' function. */
 #define HAVE_SNPRINTF 1
 


### PR DESCRIPTION
- Enables restore functionality on Windows MSVC builds
- Fixes ERROR: the instance of rrdtool has been compiled without XML
  import functions