### PR TITLE
lua: don't include rrd_restore if it wasn't included

### DIFF
--- a/bindings/lua/rrdlua.c
+++ b/bindings/lua/rrdlua.c
@@ -170,12 +170,14 @@ lua_rrd_resize (lua_State * L)
   return 0;
 }
 
+#ifdef HAVE_RRD_RESTORE
 static int
 lua_rrd_restore (lua_State * L)
 {
   rrd_common_call(L, "restore", rrd_restore);
   return 0;
 }
+#endif
 
 static int
 lua_rrd_tune (lua_State * L)
@@ -366,7 +368,9 @@ static const struct luaL_Reg rrd[] = {
 #endif
   {"last", lua_rrd_last},
   {"resize", lua_rrd_resize},
+#ifdef HAVE_RRD_RESTORE
   {"restore", lua_rrd_restore},
+#endif
   {"tune", lua_rrd_tune},
   {"update", lua_rrd_update},
   {"flushcached", lua_rrd_flushcached},


### PR DESCRIPTION
The lua module compiles ok, but fails to load.

> rrd=require("rrd")
error loading module 'rrd' from file '/usr/lib/lua/rrd.so':
	Error relocating /usr/lib/lua/rrd.so: rrd_restore: symbol not found
stack traceback:
	[C]: ?
	[C]: in function 'require'

Signed-off-by: Karl Palsson <karlp@etactica.com>