### PR TITLE
Add windows-default-manifest to README-MinGW-w64

### DIFF
--- a/win32/README-MinGW-w64
+++ b/win32/README-MinGW-w64
@@ -11,7 +11,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
  - i686 (32-bit)
    Install the required dependencies:
 
-   sudo dnf install mingw32-cairo mingw32-expat mingw32-fontconfig mingw32-freetype mingw32-gettext mingw32-glib2 mingw32-libpng mingw32-libxml2 mingw32-pango mingw32-pkg-config mingw32-zlib perl-Pod-Html
+   sudo dnf install mingw32-cairo mingw32-expat mingw32-fontconfig mingw32-freetype mingw32-gettext mingw32-glib2 mingw32-libpng mingw32-libxml2 mingw32-pango mingw32-pkg-config mingw32-windows-default-manifest mingw32-zlib perl-Pod-Html
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
@@ -21,7 +21,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 - x86_64 (64-bit)
    Install the required dependencies:
 
-   sudo dnf install mingw64-cairo mingw64-expat mingw64-fontconfig mingw64-freetype mingw64-gettext mingw64-glib2 mingw64-libpng mingw64-libxml2 mingw64-pango mingw64-pkg-config mingw64-zlib perl-Pod-Html
+   sudo dnf install mingw64-cairo mingw64-expat mingw64-fontconfig mingw64-freetype mingw64-gettext mingw64-glib2 mingw64-libpng mingw64-libxml2 mingw64-pango mingw64-pkg-config mingw64-windows-default-manifest mingw64-zlib perl-Pod-Html
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap


### PR DESCRIPTION
- windows-default-manifest is available for Fedora in the meantime.
  This adds a default manifest to the compiled binaries and prevents
  unnecessary elevated privileges, e.g. for 32-bit rrdupdate.exe