### PR TITLE
Fix tests to support Windows time zone name

### DIFF
--- a/tests/functions
+++ b/tests/functions
@@ -11,8 +11,9 @@ TOP_BUILDDIR="${TOP_BUILDDIR:-${BASEDIR}/..}"
 DIFF="diff -u"
 DIFF9=seddif
 
+# On Windows, names of times zones are different. Substitute 'W. Europe Standard Time' with 'CET'
 function seddif {
-   perl -p -e 's/([-+]?\d\.\d+e[-+]\d+)/sprintf("%0.7e",$1)/ge' | $DIFF $@
+   perl -p -e 's/([-+]?\d\.\d+e[-+]\d+)/sprintf("%0.7e",$1)/ge; s/W. Europe Standard Time/CET/g' | $DIFF $@
 }
 
 BLANK=blank


### PR DESCRIPTION
- On Windows, names of times zones are different.
  Substitute 'W. Europe Standard Time' with 'CET' by function seddif
- Removes unnecessary diff output and fixes therefore failing tests
  under Windows
