### PR TITLE
Fix warning strncpy bound equals destination size

### DIFF
--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -957,7 +957,8 @@ int rrd_create_r2(
     // parsing went well. ONLY THEN are we allowed to produce
     // additional side effects.
     if (require_version != NULL) {
-        strncpy(rrd.stat_head->version, require_version, 5);
+        strncpy(rrd.stat_head->version, require_version, 4);
+        rrd.stat_head->version[4] = '\0';
     }
 
     if (rrd.stat_head->rra_cnt < 1) {

--- a/src/rrd_modify.c
+++ b/src/rrd_modify.c
@@ -1215,7 +1215,8 @@ static int add_rras(const rrd_t *in, rrd_t *out, const int *ds_map,
     }
 
     if (require_version != NULL && atoi(require_version) < atoi(out->stat_head->version)) {
-        strncpy(out->stat_head->version, require_version, 5);
+        strncpy(out->stat_head->version, require_version, 4);
+        out->stat_head->version[4] = '\0';
     }
 
     if (last_rra_cnt < out->stat_head->rra_cnt) {


### PR DESCRIPTION
- Reduce num from 5 to 4 in strncpy and add null terminator.
  Remark: Version strings consist of 4 chars, e.g. RRD_VERSION5 "0005"

- Fixes the following GCC 8 warnings:
  rrd_create.c:960:9: warning:
    ‘strncpy’ specified bound 5 equals destination size
    [-Wstringop-truncation]
    strncpy(rrd.stat_head->version, require_version, 5);

  rrd_modify.c:1218:9: warning:
    ‘strncpy’ specified bound 5 equals destination size
    [-Wstringop-truncation]
    strncpy(out->stat_head->version, require_version, 5);