### PR TITLE
Check for gobject-2.0 in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -615,6 +615,7 @@ dnl EX_CHECK_ALL(cairo,      cairo_svg_surface_create,      cairo-svg.h,        
 dnl EX_CHECK_ALL(cairo,      cairo_pdf_surface_create,      cairo-pdf.h,            cairo-pdf,   1.10.2,  http://cairographics.org/releases/, "")
 dnl EX_CHECK_ALL(cairo,      cairo_ps_surface_create,       cairo-ps.h,             cairo-ps,    1.10.2,  http://cairographics.org/releases/, "")
 EX_CHECK_ALL(pangocairo-1.0,  pango_cairo_context_set_font_options,  pango/pango.h,  pangocairo,  1.28.4,    http://ftp.gnome.org/pub/GNOME/sources/pango/1.28, "")
+EX_CHECK_ALL(gobject-2.0,     g_object_unref,                        glib-object.h,  gobject-2.0, 2.58.1,    https://download.gnome.org/sources/glib/2.58/, "")
 
 AC_CHECK_FUNCS(pango_font_map_create_context)
 fi


### PR DESCRIPTION
- Since pango version 1.43.0, -lgobject-2.0 is not added automatically
  any more during configure. Remark: pango.pc uses Requires.private
  now for gobject-2.0 instead of formerly Requires: gobject-2.0
- Check for gobject-2.0 in configure to make sure, that -lgobject-2.0
  is added to ALL_LIBS
- Fixes the following linker errors:
<pre>.libs/librrd_la-rrd_graph.o: In function `im_free':
src/rrd_graph.c:465: undefined reference to `g_object_unref'
.libs/librrd_la-rrd_graph.o: In function `rrd_graph_init':
src/rrd_graph.c:4840: undefined reference to `g_object_unref'
</pre>