### PR TITLE
Add -lws2_32 for MinGW builds by configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -272,6 +272,10 @@ AC_CHECK_FUNCS(fsync)
 
 dnl check for socket and nsl solaris again ... we need this for the new rrd_daemon stuff
 
+dnl link with ws2_32 (Winsock2 library) in case of MinGW or MinGW-w64 builds
+case "${target}" in
+  *mingw*) LIBS="${LIBS} -lws2_32";;
+esac
 AC_CHECK_FUNCS(socket, [],  AC_CHECK_LIB(socket, socket, [LIBS="${LIBS} -lsocket"; AC_DEFINE(HAVE_SOCKET)],[]))
 AC_CHECK_FUNCS(getaddrinfo, [],  AC_CHECK_LIB(nsl, getaddrinfo, [LIBS="${LIBS} -lnsl"; AC_DEFINE(HAVE_GETADDRINFO)],[]))
 AC_CHECK_FUNCS(sigwaitinfo, [],  AC_CHECK_LIB(rt, sigwaitinfo, [LIBS="${LIBS} -lrt"; AC_DEFINE(HAVE_SIGWAITINFO)],[]))

--- a/win32/README-MinGW-w64
+++ b/win32/README-MinGW-w64
@@ -15,7 +15,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
-   ./configure --host=i686-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=i686-w64-mingw32-pkg-config LIBS='-lws2_32'
+   ./configure --host=i686-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=i686-w64-mingw32-pkg-config
    make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 - x86_64 (64-bit)
@@ -25,7 +25,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
-   ./configure --host=x86_64-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=x86_64-w64-mingw32-pkg-config LIBS='-lws2_32'
+   ./configure --host=x86_64-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=x86_64-w64-mingw32-pkg-config
    make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 
@@ -37,7 +37,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
-   ./configure --host=i686-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix LIBS='-lws2_32'
+   ./configure --host=i686-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix
    make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 - x86_64 (64-bit)
@@ -47,7 +47,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
-   ./configure --host=x86_64-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix LIBS='-lws2_32'
+   ./configure --host=x86_64-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix
    make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 3) MXE (http://mxe.cc/ https://github.com/mxe/mxe)


### PR DESCRIPTION
- Add -lws2_32 to LIBS in case of MinGW or MinGW-w64 builds.
  This makes building Windows executables more straightforward using
  configure.
- Update README-MinGW-w64, remove LIBS='-lws2_32' from configure
  instructions.