### PR TITLE
Use g_list_free_full instead of g_list_foreach

### DIFF
--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -233,8 +233,7 @@ done:
     }
     if (sources != NULL) {
         // this will free the list elements as well
-        g_list_foreach( sources, (GFunc)free, NULL );
-        g_list_free( sources );
+        g_list_free_full ( sources, (GDestroyNotify) free );
         sources = NULL;
     }
     if (template != NULL) {
@@ -1019,8 +1018,7 @@ int rrd_create_r2(
     rc = write_rrd(filename, &rrd);
     
 done:
-        g_list_foreach( sources_rrd_files, (GFunc) cleanup_source_file, NULL );
-        g_list_free( sources_rrd_files );
+        g_list_free_full ( sources_rrd_files, (GDestroyNotify) cleanup_source_file );
             
     if (mappings) {
         int ii;


### PR DESCRIPTION
- Fixes the following compiler warnings in rrd_create.c:
<pre>
  236:34: warning: cast between incompatible function types from
  'void (*)(void *)' to 'void (*)(void *, void *)'
  [-Wcast-function-type] g_list_foreach( sources, (GFunc)free, NULL );

  1022:44: warning: cast between incompatible function types from
  'void (*)(rrd_file_t *)' {aka 'void (*)(struct rrd_file_t *)'} to
  'void (*)(void *, void *)' [-Wcast-function-type]
  g_list_foreach(sources_rrd_files, (GFunc) cleanup_source_file, NULL);
</pre>