### PR TITLE
Define realpath for MinGW builds

### DIFF
--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -38,6 +38,10 @@
 
 #endif
 
+#ifdef __MINGW32__
+#define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
+#endif
+
 #include "rrd_strtod.h"
 #include "rrd.h"
 #include "rrd_tool.h"
@@ -103,11 +107,9 @@ static char *get_path(rrd_client_t *client, const char *path) /* {{{ */
   if ((client == NULL) || (path == NULL) || (client->sd_path == NULL))
     return (NULL);
 
-#ifndef __MINGW32__
   if ((*client->sd_path == '/')
       || (strncmp ("unix:", client->sd_path, strlen ("unix:")) == 0))
     is_unix = 1;
-#endif
 
   if (is_unix)
   {


### PR DESCRIPTION
- Define realpath the same way as in win32/rrd_config.h
- Fixes the following compiler warnings in rrd_client.c:
<pre>
  115:11: warning: implicit declaration of function 'realpath';
  [-Wimplicit-function-declaration] ret = realpath(path, NULL);
  115:11: warning: nested extern declaration of 'realpath'
  [-Wnested-externs]
  115:9: warning: assignment to 'char *' from 'int' makes pointer from
  integer without a cast [-Wint-conversion] ret = realpath(path, NULL);
  132:22: warning: assignment to 'char *' from 'int' makes pointer from
  integer without a cast [-Wint-conversion]
  dir_path = realpath(dir, NULL);
</pre>