### PR TITLE
Remove LINKTYPE from perl-piped/Makefile.PL

### DIFF
--- a/bindings/perl-piped/Makefile.PL
+++ b/bindings/perl-piped/Makefile.PL
@@ -5,6 +5,5 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     'NAME'         => 'RRDp',
     'VERSION'      => '0.99.0', # finds $VERSION
-    'linkext'   => {LINKTYPE => ''},
     'dist'    =>    {COMPRESS=>'gzip', SUFFIX=>'gz'},
 );


### PR DESCRIPTION
- Remove line:
  `'linkext'   => {LINKTYPE => ''},`
  Since version 5.00 of MakeMaker such a line can be deleted safely.
  MakeMaker recognizes when there's nothing to be linked.
  See: https://perldoc.perl.org/ExtUtils/MakeMaker.html
- Fixes Warning:
  `LINKTYPE set to '', no longer necessary`