### PR TITLE
Use _WIN32 instead of WIN32 preprocessor macro

### DIFF
--- a/bindings/perl-shared/RRDs.xs
+++ b/bindings/perl-shared/RRDs.xs
@@ -24,7 +24,7 @@ extern "C" {
  */
 #define VERSION_SAVED VERSION
 #undef VERSION
-#ifndef WIN32
+#ifndef _WIN32
 #include "rrd_config.h"
 #endif
 #include "rrd_tool.h"
@@ -105,7 +105,7 @@ extern "C" {
 
 /*
  * should not be needed if libc is linked (see ntmake.pl)
-#ifdef WIN32
+#ifdef _WIN32
  #define free free
  #define malloc malloc
  #define realloc realloc

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -10,7 +10,7 @@
 
 int mutex_init(mutex_t *mutex)
 {
-#ifdef WIN32
+#ifdef _WIN32
   *mutex = CreateMutex(NULL, FALSE, NULL);
   return (*mutex == NULL);
 #else
@@ -20,7 +20,7 @@ int mutex_init(mutex_t *mutex)
 
 int mutex_lock(mutex_t *mutex)
 {
-#ifdef WIN32
+#ifdef _WIN32
   if (*mutex == NULL) { /* static initializer? */
     HANDLE p = CreateMutex(NULL, FALSE, NULL);
     if (InterlockedCompareExchangePointer((PVOID*)mutex, (PVOID)p, NULL) != NULL)
@@ -34,7 +34,7 @@ int mutex_lock(mutex_t *mutex)
 
 int mutex_unlock(mutex_t *mutex)
 {
-#ifdef WIN32
+#ifdef _WIN32
   return (ReleaseMutex(*mutex) == 0);
 #else
   return pthread_mutex_unlock(mutex);
@@ -43,7 +43,7 @@ int mutex_unlock(mutex_t *mutex)
 
 int mutex_cleanup(mutex_t *mutex)
 {
-#ifdef WIN32
+#ifdef _WIN32
   return (CloseHandle(mutex) == 0);
 #else
   return pthread_mutex_destroy(mutex);

--- a/src/mutex.h
+++ b/src/mutex.h
@@ -5,14 +5,14 @@
 #ifndef MUTEX_H_B13C67AB432C4C39AF823A339537CA40
 #define MUTEX_H_B13C67AB432C4C39AF823A339537CA40
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #include <process.h>
 #else
 #include <pthread.h>
 #endif
 
-#ifndef WIN32
+#ifndef _WIN32
 #define mutex_t            pthread_mutex_t
 #define MUTEX_INITIALIZER  PTHREAD_MUTEX_INITIALIZER
 #else

--- a/src/plbasename.c
+++ b/src/plbasename.c
@@ -1,4 +1,4 @@
-#ifdef WIN32
+#ifdef _WIN32
 /*
  *
  * Cross-platform basename/dirname 

--- a/src/plbasename.h
+++ b/src/plbasename.h
@@ -1,4 +1,4 @@
-#ifdef WIN32
+#ifdef _WIN32
 /*
  *
  * Cross-platform basename/dirname

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -54,7 +54,7 @@ extern    "C" {
 
 #include <sys/types.h>  /* for off_t */
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>     /* for off_t */
 #else
 #ifdef _MSC_VER
@@ -345,7 +345,7 @@ struct rrd_t;
 /* returns the current per-thread rrd_context */
     rrd_context_t *rrd_get_context(void);
 
-#ifdef WIN32
+#ifdef _WIN32
 /* this was added by the win32 porters Christof.Wegmann@exitgames.com */
     rrd_context_t *rrd_force_new_context(void);
 #endif

--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -25,7 +25,7 @@
  *   Sebastian tokkee Harl <sh at tokkee.org>
  **/
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #include <ws2tcpip.h> // contain #include <winsock2.h>
 // Need to link with Ws2_32.lib
@@ -53,7 +53,7 @@
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <strings.h>
 #include <pthread.h>
 #include <sys/socket.h>
@@ -342,7 +342,7 @@ static int parse_value_array_header (char *line, /* {{{ */
 static void close_socket(rrd_client_t *client)
 {
   if (client->sd >= 0) {
-#ifdef WIN32
+#ifdef _WIN32
     closesocket(client->sd);
     WSACleanup();
 #else
@@ -743,7 +743,7 @@ int rrdc_ping(void) /* {{{ */
 
 static int connect_unix(rrd_client_t *client, const char *path) /* {{{ */
 {
-#ifdef WIN32
+#ifdef _WIN32
   return (WSAEPROTONOSUPPORT);
 #else
   struct sockaddr_un sa;
@@ -835,7 +835,7 @@ static int connect_network(rrd_client_t *client, const char *addr_orig) /* {{{ *
     }
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   WORD wVersionRequested;
   WSADATA wsaData;
 

--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -44,7 +44,7 @@
 
 #include "unused.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 # include <process.h>
 #endif
 
@@ -1461,7 +1461,7 @@ int write_rrd(
                WILL NOT take care of any ACLs that may be set. Go
                figure. */
             if (stat(outfilename, &stat_buf) != 0) {
-#ifdef WIN32
+#ifdef _WIN32
                 stat_buf.st_mode = _S_IREAD | _S_IWRITE;    // have to test it is 
 #else
                 /* an error occurred (file not found, maybe?). Anyway:
@@ -1481,7 +1481,7 @@ int write_rrd(
                 rrd_clear_error();
             }
 
-#ifdef WIN32
+#ifdef _WIN32
 /* In Windows, renaming to an existing file is not allowed. Even, if the file
  * is deleted before, using _unlink() here. Furthermore the FILE_SHARE_DELETE
  * flag is required, which is used in CreateFileA in rrd_open.c

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -73,7 +73,7 @@
 #  include <stdint.h>
 #endif
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #include <strings.h>
 #include <inttypes.h>

--- a/src/rrd_dump.c
+++ b/src/rrd_dump.c
@@ -47,7 +47,7 @@
 #include "rrd_snprintf.h"
 
 
-#if !(defined(NETWARE) || defined(WIN32))
+#if !(defined(NETWARE) || defined(_WIN32))
 extern char *tzname[2];
 #endif
 

--- a/src/rrd_format.c
+++ b/src/rrd_format.c
@@ -4,7 +4,7 @@
  * rrd_format.c  RRD Database Format helper functions
  *****************************************************************************/
 #include "rrd_tool.h"
-#ifdef WIN32
+#ifdef _WIN32
 #include "stdlib.h"
 #endif
 

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -9,7 +9,7 @@
 
 
 
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32) && !defined(__MINGW32__)
 #include "strftime.h"
 #endif
 
@@ -37,7 +37,7 @@
 #include "plbasename.h"
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
 #include <io.h>
 #include <fcntl.h>
 #endif

--- a/src/rrd_modify.c
+++ b/src/rrd_modify.c
@@ -19,7 +19,7 @@
 
 #include <locale.h>
 #include "rrd_config.h"
-#ifdef WIN32
+#ifdef _WIN32
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -6,7 +6,7 @@
  * $Id$
  *****************************************************************************/
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #if _WIN32_MAXVER >= 0x0602 /* _WIN32_WINNT_WIN8 */
 #include <synchapi.h>
@@ -33,7 +33,7 @@
 
 #define MEMBLK 8192
 
-#ifdef WIN32
+#ifdef _WIN32
 #define	_LK_UNLCK	0   /* Unlock */
 #define	_LK_LOCK	1   /* Lock */
 #define	_LK_NBLCK	2   /* Non-blocking lock */

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -23,7 +23,7 @@
 #include <libxml/xmlreader.h>
 #include <locale.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #	include <unistd.h>     /* for off_t */
 #else
 #ifndef __MINGW32__     /* MinGW-w64 has ssize_t and off_t */

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -6,7 +6,7 @@
 
 #include "rrd_config.h"
 
-#if defined(WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <io.h>
@@ -449,7 +449,7 @@ int main(
        according to localeconv(3) */       
     setlocale(LC_ALL, "");
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     setmode(fileno(stdout), O_BINARY);
     setmode(fileno(stdin), O_BINARY);
 #endif

--- a/src/rrd_utils.c
+++ b/src/rrd_utils.c
@@ -34,7 +34,7 @@
 #include <libgen.h>
 #include <unistd.h>
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #	define random() rand()
 #	define srandom(x) srand(x)
 #	define getpid() 0


### PR DESCRIPTION
- _WIN32 is the recommended preprocessor macro
- Substitute occurrences of WIN32 with _WIN32 using:
<pre>
git grep -lw -e '#ifdef WIN32' -e '#ifndef WIN32' -e 'defined(WIN32)' \
-- '*.c' '*.h' '*.xs' | xargs \
sed -i -e 's/#ifdef WIN32/#ifdef _WIN32/g' \
-e 's/#ifndef WIN32/#ifndef _WIN32/g' \
-e 's/defined(WIN32)/defined(_WIN32)/g'
</pre>