### PR TITLE
Include winsdkver.h for _WIN32_MAXVER

### DIFF
--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -8,6 +8,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <winsdkver.h>  /* Defines _WIN32_MAXVER */
 #if _WIN32_MAXVER >= 0x0602 /* _WIN32_WINNT_WIN8 */
 #include <synchapi.h>
 #endif


### PR DESCRIPTION
- _WIN32_MAXVER is defined in winsdkver.h
  The include is required in case of MinGW-w64 builds
- Fixes rrd_open.c:11:5: warning:
  "_WIN32_MAXVER" is not defined, evaluates to 0 [-Wundef]
  #if _WIN32_MAXVER >= 0x0602 /* _WIN32_WINNT_WIN8 */