### PR TITLE
Fix rc compiler redefinition warnings (nmake)

### DIFF
--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -126,10 +126,16 @@
 
 #include "mkstemp.h"
 
+/* _MSC_VER is not defined, when using the resource compiler (rc).
+ * See: https://docs.microsoft.com/en-us/windows/desktop/menurc/predefined-macros
+ * for how to conditionally compile the code with the RC compiler using RC_INVOKED
+*/
+#ifndef RC_INVOKED
 #if _MSC_VER < 1900
 #define isinf(a) (_fpclass(a) == _FPCLASS_NINF || _fpclass(a) == _FPCLASS_PINF)
 #define isnan _isnan
 #define snprintf _snprintf
+#endif
 #endif
 
 #define finite _finite


### PR DESCRIPTION
- Surround code in win32/rrd_config.h that causes warnings by rc with
  #ifndef RC_INVOKED and #endif. Remark: _MSC_VER is unknown to rc
- Fixes the following warnings for .rc files, e.g.:
  rc /nologo /I./src /fo./win32/rrdtool.res ./win32\rrdtool.rc
  ./win32\rrd_config.h(130) : warning RC4005: 'isinf' : redefinition
  ./win32\rrd_config.h(131) : warning RC4005: 'isnan' : redefinition
- This concerns: librrd-4.rc, rrdtool.rc, rrdupdate.rc, rrdcgi.rc,
  when using the resource compiler (rc) via nmake under Windows