### PR TITLE
Fix _errno inconsistent dll linkage (Windows)

### DIFF
--- a/src/rrd_snprintf.c
+++ b/src/rrd_snprintf.c
@@ -580,7 +580,9 @@ static UINTMAX_T cast(LDOUBLE);
 static UINTMAX_T myround(LDOUBLE);
 static LDOUBLE mypow10(int);
 
+#ifndef _WIN32  /* Avoid warning under Windows */
 extern int errno;
+#endif
 
 int
 rpl_vsnprintf(char *str, size_t size, const char *format, va_list args)


### PR DESCRIPTION
- Exclude in case of _WIN32 in rrd_snprintf.c:
  extern int errno;
- Fixes warnings:
  MSVC:
  rrd_snprintf.c(583): warning C4273:
  '_errno': inconsistent dll linkage
  errno.h(19): note: see previous definition of '_errno'
  MinGW-w64 (gcc):
  rrd_snprintf.c:583:12: warning: '_errno' redeclared without
  dllimport attribute: previous dllimport ignored [-Wattributes]