### PR TITLE
Remove librrd-4.vcxproj.user

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ EXTRA_DIST = COPYRIGHT CHANGES TODO CONTRIBUTORS THREADS VERSION LICENSE \
              m4/snprintf.m4 \
              etc/rrdcached-default-redhat etc/rrdcached-init-redhat \
              win32/build-rrdtool.dot win32/build-rrdtool.pdf win32/build-rrdtool.svg \
-             win32/librrd-4.def win32/librrd-4.rc win32/librrd-4.vcxproj win32/librrd-4.vcxproj.user \
+             win32/librrd-4.def win32/librrd-4.rc win32/librrd-4.vcxproj \
              win32/Makefile.msc win32/README win32/README-MinGW-w64 win32/rrdcgi.rc win32/rrd_config.h \
              win32/rrd.sln win32/rrdtool.rc win32/rrdtool.sln win32/rrdtool.vcxproj win32/rrdupdate.rc \
              win32/rrdupdate.sln win32/rrdupdate.vcxproj win32/uac.manifest \

--- a/win32/librrd-4.vcxproj.user
+++ b/win32/librrd-4.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>


### PR DESCRIPTION
- Remove file from git source control, because
  .vcxproj.user files typically contain user-specific settings
  or overrides