### PR TITLE
Define mkdir for Windows and require HAVE_GETUID

### DIFF
--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -582,7 +582,7 @@ static int HandleInputLine(
                 printf("ERROR: invalid parameter count for cd\n");
                 return (1);
             }
-#if ! defined(HAVE_CHROOT) || ! defined(HAVE_GETUID)
+#if ! defined(HAVE_CHROOT) && defined(HAVE_GETUID)
             if (getuid() == 0 && !ChangeRoot) {
                 printf
                     ("ERROR: chdir security problem - rrdtool is running as "
@@ -622,7 +622,7 @@ static int HandleInputLine(
                 printf("ERROR: invalid parameter count for mkdir\n");
                 return (1);
             }
-#if ! defined(HAVE_CHROOT) || ! defined(HAVE_GETUID)
+#if ! defined(HAVE_CHROOT) && defined(HAVE_GETUID)
             if (getuid() == 0 && !ChangeRoot) {
                 printf
                     ("ERROR: mkdir security problem - rrdtool is running as "

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #include <io.h>
 #include <fcntl.h>
+#define mkdir(A, B) mkdir(A)    /* mkdir() has only got one argument under Windows */
 #endif
 
 #include "rrd_tool.h"
@@ -575,8 +576,7 @@ static int HandleInputLine(
             }
             exit(0);
         }
-/* MinGW-w64 has not got getuid() and only 1 argument for mkdir() */
-#if defined(HAVE_OPENDIR) && defined(HAVE_READDIR) && defined(HAVE_CHDIR) && defined(HAVE_SYS_STAT_H) && !defined(__MINGW32__)
+#if defined(HAVE_OPENDIR) && defined(HAVE_READDIR) && defined(HAVE_CHDIR) && defined(HAVE_SYS_STAT_H)
         if (argc > 1 && strcmp("cd", argv[1]) == 0) {
             if (argc != 3) {
                 printf("ERROR: invalid parameter count for cd\n");


### PR DESCRIPTION
- Use macro for Windows: #define mkdir(A, B) mkdir(A)
  mkdir() has only got one argument under Windows
- Call getuid() only if HAVE_GETUID is defined
- This is an update of: cc1256a
  concerning rrd_tool.c, getuid and mkdir
- Fixes the following MinGW-w64 compiler warnings [-Wunused-variable]:
  rrd_tool.c: In function 'HandleInputLine':
  rrd_tool.c:565:20: warning: unused variable 'dent'
  rrd_tool.c:564:15: warning: unused variable 'curdir'
