### PR TITLE
Update snprintf.m4, add _HW_FUNC_XPRINTF_REPLACE

### DIFF
--- a/m4/snprintf.m4
+++ b/m4/snprintf.m4
@@ -215,4 +215,17 @@ AC_DEFUN([HW_FUNC_ASPRINTF],
     _HW_FUNC_XPRINTF_REPLACE])
 ])# HW_FUNC_ASPRINTF
 
+# _HW_FUNC_XPRINTF_REPLACE
+# ------------------------
+# Arrange for building rrd_snprintf.c.  Must be called if one or more of the
+# functions provided by rrd_snprintf.c are needed.
+AC_DEFUN([_HW_FUNC_XPRINTF_REPLACE],
+[
+  AS_IF([test "x$_hw_cv_func_xprintf_replace_done" != xyes],
+    [AC_C_CONST
+    HW_HEADER_STDARG_H
+    AC_LIBOBJ([rrd_snprintf])
+    _hw_cv_func_xprintf_replace_done=yes])
+])# _HW_FUNC_XPRINTF_REPLACE
+
 dnl vim: set joinspaces textwidth=80:


### PR DESCRIPTION
- Add `_HW_FUNC_XPRINTF_REPLACE` again to snprintf.m4, in a modified way.
  Use `AC_LIBOBJ([rrd_snprintf])` instead of original `AC_LIBOBJ([snprintf])`
- Fixes the following configure messages under MinGW-w64:
  `./configure: line 14694: _HW_FUNC_XPRINTF_REPLACE: command not found`
  `./configure: line 14752: _HW_FUNC_XPRINTF_REPLACE: command not found`