### PR TITLE
Update etc/Makefile.am

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,5 +1,5 @@
-EXTRA_DIST = rrdcached-default-redhat rrdcached-init-redhat rrdcached-default-lsb.in \ 
-	rrdcached.socket.in rrdcached.service.in
+EXTRA_DIST = rrdcached-default-redhat rrdcached-init-redhat rrdcached-default-lsb.in \
+	rrdcached-init-lsb rrdcached.socket.in rrdcached.service.in
 
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = \


### PR DESCRIPTION
- Add rrdcached-init-lsb to EXTRA_DIST
- Trim trailing space after backslash. Fixes:
  etc/Makefile.am:1: warning: whitespace following trailing backslash