### PR TITLE
Remove strftime.c and strftime.h from MSVC builds

### DIFF
--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -7,12 +7,6 @@
 
 #include <sys/stat.h>
 
-
-
-#if defined(_WIN32) && !defined(__MINGW32__)
-#include "strftime.h"
-#endif
-
 #include "rrd_strtod.h"
 
 #include "rrd_tool.h"

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -80,7 +80,6 @@ RRD_LIB_OBJ_LIST = \
         $(TOP)/src/rrd_utils.obj \
         $(TOP)/src/rrd_version.obj \
         $(TOP)/src/rrd_xport.obj \
-        $(TOP)/src/strftime.obj \
         $(TOP)/win32/asprintf.obj \
         $(TOP)/win32/vasprintf-msvc.obj \
         $(TOP)/win32/win32-glob.obj

--- a/win32/librrd-4.vcxproj
+++ b/win32/librrd-4.vcxproj
@@ -251,7 +251,6 @@
     <ClCompile Include="..\src\rrd_utils.c" />
     <ClCompile Include="..\src\rrd_version.c" />
     <ClCompile Include="..\src\rrd_xport.c" />
-    <ClCompile Include="..\src\strftime.c" />
     <ClCompile Include="asprintf.c" />
     <ClCompile Include="vasprintf-msvc.c" />
     <ClCompile Include="win32-glob.c" />
@@ -283,7 +282,6 @@
     <ClInclude Include="..\src\rrd_tool.h" />
     <ClInclude Include="..\src\rrd_update.h" />
     <ClInclude Include="..\src\rrd_xport.h" />
-    <ClInclude Include="..\src\strftime.h" />
     <ClInclude Include="..\src\unused.h" />
     <ClInclude Include="rrd_config.h" />
     <ClInclude Include="win32-glob.h" />


### PR DESCRIPTION
- Recent versions of MSVC (VS2015 and newer) properly support strftime
  including formatting codes like %F, %T or %V (ISO 8601)