### PR TITLE
fix segfault on non-existent RRD file when using rrdcached

### DIFF
--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -265,7 +265,7 @@ static int rrd_xport_fn(
 
 
     /* pull the data from the rrd files ... */
-    if (data_fetch(im) == -1)
+    if (data_fetch(im) != 0)
         return -1;
 
     /* evaluate CDEF  operations ... */


### PR DESCRIPTION
fix segfault on non-existent RRD file when using rrdcached + rrdtool xport
(like 814ca69a3329ccc88040ed184a413e4e5adf604c does for rrdtool graph)