### PR TITLE
Update strftime.c and use it under MinGW

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -93,8 +93,8 @@ noinst_HEADERS += rrd_rados.h
 endif
 
 if MINGW_W64
-RRD_C_FILES += ../win32/win32-glob.c
-noinst_HEADERS += ../win32/win32-glob.h
+RRD_C_FILES += ../win32/win32-glob.c strftime.c
+noinst_HEADERS += ../win32/win32-glob.h strftime.h
 endif
 
 noinst_LTLIBRARIES        = librrdupd.la

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -10,6 +10,17 @@
 #include "rrd_strtod.h"
 
 #include "rrd_tool.h"
+
+/* MinGW and MinGW-w64 use the format codes from msvcrt.dll,
+ * which does not support e.g. %F, %T or %V. Here we need %V for "Week %V".
+ * Remark: include of "strftime.h" and use of strftime.c is not required for
+ * MSVC builds (VS2015 and newer), where strftime format codes are from
+ * ucrtbase.dll, which supports C99, and therefore %F, %T, %V etc. */
+#if defined(__MINGW32__)
+#include "strftime.h"   /* This has to be included after rrd_tool.h */
+#define strftime strftime_
+#endif
+
 #include "unused.h"
 
 

--- a/src/strftime.c
+++ b/src/strftime.c
@@ -10,6 +10,8 @@
  * modified 21-Oct-89 by Rob Duff
  *
  * modified 08-Dec-04 by Tobi Oetiker (added %V)
+ * updated 2019-03-28 by Wolfgang Stöggl (added %F and %T)
+ *
 **/
 
 #include <stddef.h>     /* for size_t */
@@ -84,6 +86,7 @@ static void strfmt(
  *              %b      abbreviated month name (Jan)
  *              %c      standard date and time representation
  *              %d      day-of-month (01-31)
+ *              %F      equivalent to "%Y-%m-%d" (ISO 8601 date format, C99)
  *              %H      hour (24 hour clock) (00-23)
  *              %I      hour (12 hour clock) (01-12)
  *              %j      day-of-year (001-366)
@@ -91,6 +94,7 @@ static void strfmt(
  *              %m      month (01-12)
  *              %p      local equivalent of AM or PM
  *              %S      second (00-59)
+ *              %T      equivalent to "%H:%M:%S" (ISO 8601 time format, C99)
  *              %U      week-of-year, first day sunday (00-53)
  *              %W      week-of-year, first day monday (00-53)
  *              %V      ISO 8601 Week number 
@@ -166,6 +170,10 @@ size_t strftime_(
                 strfmt(r, "%2", t->tm_mday);
                 break;
 
+            case 'F':
+                strfmt(r, "%4-%2-%2", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday);
+                break;
+
             case 'H':
                 strfmt(r, "%2", t->tm_hour);
                 break;
@@ -192,6 +200,10 @@ size_t strftime_(
 
             case 'S':
                 strfmt(r, "%2", t->tm_sec);
+                break;
+
+            case 'T':
+                strfmt(r, "%2:%2:%2", t->tm_hour, t->tm_min, t->tm_sec);
                 break;
 
             case 'U':


### PR DESCRIPTION
- Add %F and %T to strftime.c
  These format codes are commonly used, part of C99 and used in the
  test vformatter1
- rrd_graph.c: Include local strftime.h and use strftime_ from
  strftime.c in case of MinGW or MinGW-w64 builds.
- This allows test vformatter1 to pass under MSYS2 (MinGW-w64)