### PR TITLE
Use fabs() for floating point, labs() for long

### DIFF
--- a/src/rrd_hw.c
+++ b/src/rrd_hw.c
@@ -516,7 +516,7 @@ static unsigned long MyMod(
     unsigned long new_val;
 
     if (val < 0)
-        new_val = ((unsigned long) abs(val)) % mod;
+        new_val = ((unsigned long) labs(val)) % mod;
     else
         new_val = (val % mod);
 

--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -996,7 +996,7 @@ short rpn_calc(
 		if (rpnp[rpi].op == OP_PREDICTPERC) {
 		    stackunderflow(1);
 		    percentile = rpnstack->s[--stptr];
-		    if (abs(percentile) > 100) {
+		    if (fabs(percentile) > 100) {
 		        rrd_set_error("unsupported percentile: %f",percentile);
 			return -1;
 		    }
@@ -1100,7 +1100,7 @@ short rpn_calc(
 			/* get the percentile selected */
 			double idxf = percentile * ((float)count-1.0);
 			if (percentile < 0) { /* take the next best */
-			    int idx = round(abs(idxf));
+			    int idx = round(fabs(idxf));
 			    val = extra[idx];
 			} else { /* interpolate */
 			    int idx = floor(idxf);


### PR DESCRIPTION
- Fixes the following clang compiler warnings:
<pre>
  rrd_rpncalc.c:999:11: warning: using integer absolute value function
  'abs' when argument is of floating point type [-Wabsolute-value]
    if (abs(percentile) > 100) {
  rrd_rpncalc.c:1103:24: warning: using integer absolute value function
  'abs' when argument is of floating point type [-Wabsolute-value]
    int idx = round(abs(idxf));
  rrd_hw.c:519:36: warning: absolute value function 'abs' given an
  argument of type 'long' but has parameter of type 'int' which may
  cause truncation of value [-Wabsolute-value]
    new_val = ((unsigned long) abs(val)) % mod;
</pre>