### PR TITLE
Cast lua_tostring return value to char *

### DIFF
--- a/bindings/lua/rrdlua.c
+++ b/bindings/lua/rrdlua.c
@@ -66,7 +66,7 @@ static char **make_argv(const char *cmd, lua_State * L)
   for (i=1; i<argc; i++) {
     /* accepts string or number */
     if (lua_isstring(L, i) || lua_isnumber(L, i)) {
-      if (!(argv[i] = lua_tostring (L, i))) {
+      if (!(argv[i] = (char *) lua_tostring (L, i))) {
         /* raise an error and never return */
         luaL_error(L, "%s - error duplicating string area for arg #%d",
                    cmd, i);


### PR DESCRIPTION
- Fixes the following gcc compiler warning:
<pre>
  rrdlua.c:69:21: warning: assignment discards ‘const’ qualifier from
  pointer target type [-Wdiscarded-qualifiers]
  if (!(argv[i] = lua_tostring (L, i))) {
</pre>
