### PR TITLE
Avoid pragma comment warning under MinGW

### DIFF
--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -28,8 +28,10 @@
 #ifdef _WIN32
 
 #include <ws2tcpip.h> // contain #include <winsock2.h>
+#ifdef _MSC_VER
 // Need to link with Ws2_32.lib
 #pragma comment(lib, "ws2_32.lib")
+#endif
 #include <time.h>
 #include <io.h>
 #include <fcntl.h>


### PR DESCRIPTION
- Removes the following MinGW compiler warning:
<pre>
  rrd_client.c:32: warning: ignoring #pragma comment
  [-Wunknown-pragmas] #pragma comment(lib, "ws2_32.lib")
</pre>
- This #pragma comment is only relevant for MSVC