### PR TITLE
Fix GCC string truncation warnings

### DIFF
--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -335,7 +335,7 @@ int rrd_fetch_fn(
             rrd_set_error("malloc fetch ds_namv entry");
             goto err_free_ds_namv;
         }
-        strncpy((*ds_namv)[i], rrd.ds_def[i].ds_nam, DS_NAM_SIZE - 1);
+        strncpy((*ds_namv)[i], rrd.ds_def[i].ds_nam, DS_NAM_SIZE);
         (*ds_namv)[i][DS_NAM_SIZE - 1] = '\0';
 
     }

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -2279,7 +2279,7 @@ int leg_place(
             }
 
             if(calc_width){
-                strncpy(im->gdes[i].legend, saved_legend, sizeof im->gdes[0].legend - 1);
+                strncpy(im->gdes[i].legend, saved_legend, sizeof im->gdes[0].legend);
                 im->gdes[i].legend[sizeof im->gdes[0].legend - 1] = '\0';
             }
         }

--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -281,7 +281,7 @@ int rrd_tune(
             if ((ds = ds_match(&rrd, ds_nam)) == -1) {
 		goto done;
             }
-            strncpy(rrd.ds_def[ds].ds_nam, ds_new, DS_NAM_SIZE - 1);
+            strncpy(rrd.ds_def[ds].ds_nam, ds_new, DS_NAM_SIZE);
             rrd.ds_def[ds].ds_nam[DS_NAM_SIZE - 1] = '\0';
             break;
         case 'p':


### PR DESCRIPTION
- Fixes the following GCC compiler warnings:
<pre>
  rrd_fetch.c:338:9: warning: 'strncpy' output may be truncated copying
  19 bytes from a string of length 19 [-Wstringop-truncation]
    strncpy((*ds_namv)[i], rrd.ds_def[i].ds_nam, DS_NAM_SIZE - 1);
  rrd_tune.c:284:13: warning: 'strncpy' output may be truncated copying
  19 bytes from a string of length 19 [-Wstringop-truncation]
    strncpy(rrd.ds_def[ds].ds_nam, ds_new, DS_NAM_SIZE - 1);
  rrd_graph.c:2282:17: warning: 'strncpy' output may be truncated
    copying 204 bytes from a string of length 204
    [-Wstringop-truncation] strncpy(im->gdes[i].legend, saved_legend,
    sizeof im->gdes[0].legend - 1);
</pre>
