### PR TITLE
Update rrd_open.c, fix issues

### DIFF
--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -35,18 +35,18 @@
 #define MEMBLK 8192
 
 #ifdef _WIN32
-#define	_LK_UNLCK	0   /* Unlock */
-#define	_LK_LOCK	1   /* Lock */
-#define	_LK_NBLCK	2   /* Non-blocking lock */
-#define	_LK_RLCK	3   /* "Same as _LK_NBLCK" */
-#define	_LK_NBRLCK	4   /* "Same as _LK_LOCK" */
+#define    _LK_UNLCK    0   /* Unlock */
+#define    _LK_LOCK     1   /* Lock */
+#define    _LK_NBLCK    2   /* Non-blocking lock */
+#define    _LK_RLCK     3   /* "Same as _LK_NBLCK" */
+#define    _LK_NBRLCK   4   /* "Same as _LK_LOCK" */
 
 
-#define	LK_UNLCK	_LK_UNLCK
-#define	LK_LOCK		_LK_LOCK
-#define	LK_NBLCK	_LK_NBLCK
-#define	LK_RLCK		_LK_RLCK
-#define	LK_NBRLCK	_LK_NBRLCK
+#define    LK_UNLCK    _LK_UNLCK
+#define    LK_LOCK     _LK_LOCK
+#define    LK_NBLCK    _LK_NBLCK
+#define    LK_RLCK     _LK_RLCK
+#define    LK_NBRLCK   _LK_NBRLCK
 #endif
 
 /* DEBUG 2 prints information obtained via mincore(2) */
@@ -61,60 +61,61 @@
    versions of gcc: 'cast increases required alignment of target type'
 */
 #define __rrd_read_mmap(dst, dst_t, cnt) { \
-	size_t wanted = sizeof(dst_t)*(cnt); \
-	if (offset + wanted > rrd_file->file_len) { \
-		rrd_set_error("reached EOF while loading header " #dst); \
-		goto out_close; \
-	} \
-	(dst) = (dst_t*)(void*) (data + offset); \
-	offset += wanted; \
+    size_t wanted = sizeof(dst_t)*(cnt); \
+    if (offset + wanted > rrd_file->file_len) { \
+        rrd_set_error("reached EOF while loading header " #dst); \
+        goto out_close; \
+    } \
+    (dst) = (dst_t*)(void*) (data + offset); \
+    offset += wanted; \
     }
 #else
 #define __rrd_read_seq(dst, dst_t, cnt) { \
-	size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted = sizeof(dst_t)*(cnt); \
         size_t got; \
-	if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
-		rrd_set_error(#dst " malloc"); \
-		goto out_close; \
-	} \
+    if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
+        rrd_set_error(#dst " malloc"); \
+        goto out_close; \
+    } \
         got = read (rrd_simple_file->fd, dst, wanted); \
-	if (got != wanted) { \
-		rrd_set_error("short read while reading header " #dst); \
-                goto out_close; \
-	} \
-	offset += got; \
+    if (got != wanted) { \
+        rrd_set_error("short read while reading header " #dst); \
+        goto out_close; \
+    } \
+    offset += got; \
     }
 #endif
 
 #ifdef HAVE_LIBRADOS
 #define __rrd_read_rados(dst, dst_t, cnt) { \
-	size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted = sizeof(dst_t)*(cnt); \
         size_t got; \
-	if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
-		rrd_set_error(#dst " malloc"); \
-		goto out_close; \
-	} \
+    if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
+        rrd_set_error(#dst " malloc"); \
+        goto out_close; \
+    } \
         got = rrd_rados_read(rrd_file->rados, dst, wanted, offset); \
-	if (got != wanted) { \
-		rrd_set_error("short read while reading header " #dst); \
-                goto out_close; \
-	} \
-	offset += got; \
+    if (got != wanted) { \
+        rrd_set_error("short read while reading header " #dst); \
+        goto out_close; \
+    } \
+    offset += got; \
     }
 #endif
 
 #if defined(HAVE_LIBRADOS) && defined(HAVE_MMAP)
 #define __rrd_read(dst, dst_t, cnt) { \
     if (rrd_file->rados) \
-      __rrd_read_rados(dst, dst_t, cnt) \
+        __rrd_read_rados(dst, dst_t, cnt) \
     else \
-      __rrd_read_mmap(dst, dst_t, cnt) \
+        __rrd_read_mmap(dst, dst_t, cnt) \
     }
 #elif defined(HAVE_LIBRADOS) && !defined(HAVE_MMAP)
-if (rrd_file->rados)
-    __rrd_read_rados(dst, dst_t, cnt)
-        else
-    __rrd_read_seq(dst, dst_t, cnt)
+#define __rrd_read(dst, dst_t, cnt) { \
+    if (rrd_file->rados) \
+        __rrd_read_rados(dst, dst_t, cnt) \
+    else \
+        __rrd_read_seq(dst, dst_t, cnt) \
     }
 #elif defined(HAVE_MMAP)
 #define __rrd_read(dst, dst_t, cnt) \

--- a/win32/librrd-4.vcxproj
+++ b/win32/librrd-4.vcxproj
@@ -37,23 +37,23 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
**Add missing #define and indent rrd_open.c**

- Add missing `#define __rrd_read(dst, dst_t, cnt) { \` after
  `#elif defined(HAVE_LIBRADOS) && !defined(HAVE_MMAP)`
- This fixes:
    `indent: src/rrd_open.c:77: Error:Unmatched 'else'`
    `indent: src/rrd_open.c:79: Error:Stmt nesting error.`
    and errors in case of defined(HAVE_LIBRADOS) && !defined(HAVE_MMAP)
- indent src/rrd_open.c using GNU indent 2.2.12
- Replace all remaining tabs by four spaces

**Consider flags for CreateFileA(), Windows**

- Implement dwDesiredAccess and dwCreationDisposition based on
  the flags O_RDONLY, O_RDWR, O_CREAT | O_TRUNC and O_EXCL
- This updates how a file handle is created using CreateFileA()
  under Windows, considering the flags. Use e.g.
  DesiredAccess = GENERIC_READ | GENERIC_WRITE
  dwCreationDisposition = OPEN_EXISTING
- CreateFileA(): Check for INVALID_HANDLE_VALUE and add output of error
  messages using GetLastError() and FormatMessage()
- The error message provides correct output now, which error occurs.
  e.g.: rrdtool.exe info not_existing_file.rrd
    `ERROR: opening 'not_existing_file.rrd':`
    `The system cannot find the file specified.`
  Previously, the following error occurred later in the code:
    `ERROR: short read while reading header rrd->stat_head`
  And also empty files were left behind:
  e.g. rrdtool.exe resize not_existing_file.rrd 0 GROW 5200
- Use `<CharacterSet>MultiByte</CharacterSet>` consistently
  in .vcxproj files. There were 4 occurrences of
  `<CharacterSet>Unicode</CharacterSet>` in librrd-4.vcxproj.
  Using MultiByte or NotSet instead of Unicode is required for
  printing `(LPTSTR) lpMsgBuf` from `FormatMessage()` using `%s`, to avoid
  unnecessary wide characters.
- This commit is an update to a9671a7
