### PR TITLE
Fix compiler warning: label defined but not used

### DIFF
--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -384,7 +384,9 @@ rrd_file_t *rrd_open(
             goto out_close;
         }
     }
+#ifdef HAVE_POSIX_FALLOCATE
   no_lseek_necessary:
+#endif
 
 #ifdef HAVE_MMAP
 #ifndef HAVE_POSIX_FALLOCATE


### PR DESCRIPTION
- The label 'no_lseek_necessary' is only relevant,
  if HAVE_POSIX_FALLOCATE is defined.
- Fixes the following compiler warning on systems, where
  HAVE_POSIX_FALLOCATE is not defined:
<pre>
  rrd_open.c:387:3: warning: label 'no_lseek_necessary' defined but not
  used [-Wunused-label]
</pre>
