### PR TITLE
Define _POSIX_THREAD_SAFE_FUNCTIONS (MinGW-w64)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -448,7 +448,7 @@ AC_LINK_IFELSE(
     [ AC_LINK_IFELSE(
           [AC_LANG_PROGRAM(
                 [[#ifdef __MINGW32__
-#include <pthread.h>
+#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L
 #endif
 #include <time.h>]],
                 [[ctime_r(NULL,NULL)]])],

--- a/src/rrd_config_bottom.h
+++ b/src/rrd_config_bottom.h
@@ -68,6 +68,13 @@
 # include <unistd.h>
 #endif
 
+/* for MinGW-w64 */
+#if (defined(__MINGW32__) && !defined(_POSIX_THREAD_SAFE_FUNCTIONS))
+/* time.h of MinGW-w64 requires _POSIX_THREAD_SAFE_FUNCTIONS to be defined
+ * in order to provide ctime_r, gmtime_r or localtime_r. */
+#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L
+#endif
+
 #ifdef TIME_WITH_SYS_TIME
 # include <sys/time.h>
 # include <time.h>

--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -7,17 +7,8 @@
 #include <limits.h>
 #include <locale.h>
 #include <stdlib.h>
-#ifdef __MINGW32__
-#include <pthread.h>
-/* time.h of MinGW-w64 requires _POSIX_THREAD_SAFE_FUNCTIONS to be defined in order to provide
- * localtime_r. _POSIX_THREAD_SAFE_FUNCTIONS is defined in pthread_unistd.h (included from pthread.h).
- * Alternatives here would be to either include "rrd_tool.h" before <time.h> or remove include of <time.h>
- * from rrd_rpncalc.c, because time.h is included via rrd_tool.h ...
- * However, let's do it this way, by including pthread.h here, only if __MINGW32__ is defined,
- * in order to avoid any changes concerning other systems. */
-#endif
-#include <time.h>
 #include "rrd_tool.h"
+#include <time.h>
 
 #ifdef HAVE_LANGINFO_H
 #include <langinfo.h>


### PR DESCRIPTION
- time.h of MinGW-w64 requires _POSIX_THREAD_SAFE_FUNCTIONS to be
  defined in order to provide ctime_r, gmtime_r or localtime_r.
- In newer versions of winpthreads (e.g. git-7.0.0.5447.a2d94c81),
  _POSIX_THREAD_SAFE_FUNCTIONS is not defined any more in
  pthread_unistd.h. Hence define it here directly.
- This is a follow-up to commit:
  https://github.com/oetiker/rrdtool-1.x/commit/603de9a