### PR TITLE
Fix missing double values in rrdinfo.

### DIFF
--- a/bindings/python/rrdtoolmodule.c
+++ b/bindings/python/rrdtoolmodule.c
@@ -214,7 +214,7 @@ _rrdtool_util_info2dict(const rrd_info_t *data)
                     Py_INCREF(Py_None);
                     val = Py_None;
                 } else
-                    PyFloat_FromDouble(data->value.u_val);
+                    val = PyFloat_FromDouble(data->value.u_val);
                 break;
 
             case RD_I_CNT:


### PR DESCRIPTION
The double values of rrd info were never properly converted to the
python dictionary causing some keys (e.g. xff) to be missing.