### PR TITLE
Update rrdtool-release script

### DIFF
--- a/rrdtool-release
+++ b/rrdtool-release
@@ -1,12 +1,21 @@
 #!/bin/sh
+# shellcheck disable=SC2086,SC2046,SC2029
 set -e
-VERSION=`cat VERSION`
-NUMVERS=`perl -n -e 'm/NUMVERS=(\d+\.\d+)/ && print $1' configure`
+VERSION=$(cat VERSION)
+NUMVERS=$(perl -n -e 'm/NUMVERS=(\d+\.\d+)/ && print $1' configure)
+CURRENT_YEAR=$(date +"%Y")
 set -x
 perl -i -p -e 's/^\$VERSION.+/\$VERSION='$NUMVERS';/' bindings/perl-*/*.pm
-perl -i -p -e 's/RRDtool 1\S+/RRDtool '$VERSION'/ && s/Copyright.+?Oetiker.+\d{4}/Copyright by Tobi Oetiker, 1997-2019/' src/*.h src/*.c
+perl -i -p -e 's/RRDtool \d\S+/RRDtool '$VERSION'/; s/Copyright.+?Oetiker.+\d{4}/Copyright by Tobi Oetiker, 1997-'$CURRENT_YEAR'/' src/*.h src/*.c
 perl -i -p -e 's/^Version:.+/Version: '$VERSION'/' rrdtool.spec
 perl -i -p -e 's/rrdtool-[\.\d]+\d(pre\d+)?(rc\d+)?/rrdtool-'$VERSION'/g' doc/rrdbuild.pod
+# Update version and Copyright years for MSVC builds
+perl -i -p -e 's/Copyright \(c\).+?Oetiker/Copyright (c) 1997-'$CURRENT_YEAR' Tobias Oetiker/' win32/*.rc
+perl -i -p -e 's/PACKAGE_MAJOR.+\d{1}/PACKAGE_MAJOR       '$(echo $VERSION | cut -d. -f1)'/;
+               s/PACKAGE_MINOR.+\d{1}/PACKAGE_MINOR       '$(echo $VERSION | cut -d. -f2)'/;
+               s/PACKAGE_REVISION.+\d{1}/PACKAGE_REVISION    '$(echo $VERSION | cut -d. -f3)'/;
+               s/PACKAGE_VERSION.+\d{1}\"/PACKAGE_VERSION     \"'$VERSION'\"/;
+               s/NUMVERS.+\d{1}/NUMVERS             '$NUMVERS'/' win32/rrd_config.h
 ./bootstrap
 ./configure --enable-maintainer-mode
 make dist
@@ -17,8 +26,7 @@ make
 src/rrdtool
 cd ..
 echo READY TO DIST ... press ENTER
-read x
+read -r
 scp CHANGES rrdtool-$VERSION.tar.gz  oposs@james:public_html/rrdtool/pub
 ssh oposs@james "cd public_html/rrdtool/pub/;rm rrdtool.tar.gz;ln -s rrdtool-$VERSION.tar.gz rrdtool.tar.gz"
 cd ..
-

--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -6,7 +6,7 @@
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "rrdtool"
 
-/* Define to the version of this package. */
+/* Version numbers are updated by the rrdtool-release script. */
 #define PACKAGE_MAJOR       1
 #define PACKAGE_MINOR       7
 #define PACKAGE_REVISION    2


### PR DESCRIPTION
- Update version numbers for MSVC builds too. These are defined in
  win32/rrd_config.h
- Update Copyright info and years in win32/*.rc files
- Use a variable for the current year
- Make script compatible with rrdtool major versions > 1
  (use \d instead of 1)
- Minor updates to the script considering recommendations from
  ShellCheck, e.g.:
  ``Use $(...) notation instead of legacy backticked `...`.``