### PR TITLE
Fix failed to expand Py_UNUSED (rrdtoolmodule.c)

### DIFF
--- a/bindings/python/rrdtoolmodule.c
+++ b/bindings/python/rrdtoolmodule.c
@@ -53,7 +53,7 @@
 #ifdef __GNUC__
  #define Py_UNUSED(name) _unused_ ## name __attribute__((unused))
 #else
- #define Py_UNUSED(name) _unused_ ## -name
+ #define Py_UNUSED(name) _unused_ ## name
 #endif
 #endif
 


### PR DESCRIPTION
- Fix: `failed to expand 'Py_UNUSED', Invalid ## usage when expanding`
  `'Py_UNUSED'.`
- Fixes: https://github.com/oetiker/rrdtool-1.x/issues/903