### PR TITLE
Update doc/rrdruby.pod

### DIFF
--- a/doc/rrdruby.pod
+++ b/doc/rrdruby.pod
@@ -1,3 +1,5 @@
+=encoding utf8
+
 =head1 NAME
 
 rrdruby - About the RRD Ruby bindings
@@ -57,7 +59,7 @@ to the other B<rrdtool> documentation for functions and valid arguments.
     "--title", " RubyRRD Demo",
     "--start", "#{start+3600}",
     "--end", "start + 1000 min",
-    "--interlace",
+    "--interlaced",
     "--imgformat", "PNG",
     "--width=450",
     "DEF:a=#{rrd}:a:AVERAGE",
@@ -81,6 +83,6 @@ rrdxport, rrdinfo
 
 =head1 AUTHOR
 
-Loïs Lherbier E<lt>lois.lherbier@covadis.chE<gt>
+LoÃ¯s Lherbier E<lt>lois.lherbier@covadis.chE<gt>
 
 Miles Egan E<lt>miles@caddr.comE<gt>


### PR DESCRIPTION
- Fixes: https://github.com/oetiker/rrdtool-1.x/issues/885
  Typo: `--interlace` -> `--interlaced`
- Change encoding of file from ANSI to UTF-8
  add to pod file: =encoding utf8
  Fixes podchecker error:
  `*** ERROR: Non-ASCII character seen before =encoding in 'Loïs'.`
  `Assuming CP1252 at line 84 in file doc/rrdruby.pod`
  `doc/rrdruby.pod has 1 pod syntax error.`