### PR TITLE
Set fallback first_weekday to 0 (fix #1012)

### DIFF
--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -1568,7 +1568,7 @@ static int find_first_weekday(
         }
         first_weekday = (week_1stday + first_weekday - 1) % 7;
 #else
-        first_weekday = 1;
+        first_weekday = 0;
 #endif
     }
     return first_weekday;

--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -564,7 +564,7 @@ static int find_first_weekday(void){
         }
         first_weekday=(week_1stday + first_weekday - 1) % 7;
 #else
-        first_weekday = 1;
+        first_weekday = 0;
 #endif
     }
     return first_weekday;


### PR DESCRIPTION
- Set first_weekday to 0 (Sunday), when `HAVE__NL_TIME_WEEK_1STDAY`
  is not defined
- Fixes: https://github.com/oetiker/rrdtool-1.x/issues/1012