### PR TITLE
Add vcpkg support for MSVC builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Makefile
 /bindings/dotnet/*.suo
 /contrib
 /contrib-x64
+/vcpkg
 /win32/*.VC.db
 /win32/*.VC.opendb
 /win32/*.opensdf

--- a/WIN32-BUILD-TIPS.txt
+++ b/WIN32-BUILD-TIPS.txt
@@ -6,6 +6,28 @@ Compiling RRDtool on Win32 with Microsoft Visual C++:
 
 Here are step by step instructions for building librrd-4.dll and rrdtool.exe
 version 1.4.5 and newer with Microsoft Visual Studio 2013 (12.0.x) and newer.
+I you would like to build RRDtool using MinGW-w64, please have a look at
+win32/README-MinGW-w64
+
+# Installation of up-to-date, required third party headers and libraries
+
+An efficient way, to obtain headers and libraries required by RRDtool is using vcpkg from:
+https://github.com/microsoft/vcpkg
+
+(1) Follow the vcpkg installation instructions found in README.md and clone vcpkg e.g. to a folder named "vcpkg"
+    in the top directory of rrdtool.
+    cd vcpkg
+
+(2) Install the headers and libraries the following way for 32-bit or 64-bit:
+    .\vcpkg install cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib --triplet x86-windows
+    .\vcpkg install cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib --triplet x64-windows
+
+Information, how to compile using nmake, can be found here: win32/README
+
+# Legacy instructions
+
+Libraries mentioned in the section below are outdated and not updated any more.
+However, the described procedure still works.
 
 (1) Create a folder named "contrib" in the directory where this text file is located.
 

--- a/win32/Makefile_vcpkg.msc
+++ b/win32/Makefile_vcpkg.msc
@@ -1,0 +1,142 @@
+# Makefile for rrdtool using Microsoft (Visual) C
+#
+# Usage:
+#   nmake -f win32/Makefile_vcpkg.msc                 (for 32 bit Windows target)
+#   nmake -f win32/Makefile_vcpkg.msc USE_64BIT=1     (for 64 bit Windows target)
+#   nmake -f win32/Makefile_vcpkg.msc clean           (to remove all generated files)
+
+# The toplevel directory of the source tree
+#
+TOP = .
+RRD_LIB_NAME=librrd-4
+ARCH_PATH_X86=vcpkg\installed\x86-windows
+ARCH_PATH_X64=vcpkg\installed\x64-windows
+
+
+!ifndef USE_64BIT
+LD_FLAGS=/RELEASE /MACHINE:X86
+ARCH_PATH=$(ARCH_PATH_X86)
+CPPFLAGS = /arch:SSE2
+!else
+LD_FLAGS=/RELEASE /MACHINE:X64
+ARCH_PATH=$(ARCH_PATH_X64)
+!endif
+
+CPPFLAGS = $(CPPFLAGS) /TC /EHsc /O2 /Zi /Fd$(TOP)/win32/vc.pdb \
+        /I $(TOP)/win32 /I $(TOP)/src \
+        /I $(ARCH_PATH)\include \
+        /I $(ARCH_PATH)\include\cairo \
+        /I $(ARCH_PATH)\include\pango-1.0 \
+        /I $(ARCH_PATH)\include\glib-2.0 \
+        /I $(ARCH_PATH)\lib\glib-2.0\include \
+        /I $(ARCH_PATH)\include\libxml2
+
+THIRD_PARTY_LIB = /LIBPATH:$(ARCH_PATH)\lib \
+        libpng16.lib libxml2.lib \
+        glib-2.0.lib gobject-2.0.lib \
+        pango-1.0.lib pangocairo-1.0.lib cairo.lib \
+        Ws2_32.lib zlib.lib
+
+RRD_LIB_OBJ_LIST = \
+        $(TOP)/src/hash_32.obj \
+        $(TOP)/src/mkstemp.obj \
+        $(TOP)/src/mutex.obj \
+        $(TOP)/src/optparse.obj \
+        $(TOP)/src/plbasename.obj \
+        $(TOP)/src/pngsize.obj \
+        $(TOP)/src/quicksort.obj \
+        $(TOP)/src/rrd_client.obj \
+        $(TOP)/src/rrd_create.obj \
+        $(TOP)/src/rrd_diff.obj \
+        $(TOP)/src/rrd_dump.obj \
+        $(TOP)/src/rrd_error.obj \
+        $(TOP)/src/rrd_fetch.obj \
+        $(TOP)/src/rrd_fetch_cb.obj \
+        $(TOP)/src/rrd_first.obj \
+        $(TOP)/src/rrd_flushcached.obj \
+        $(TOP)/src/rrd_format.obj \
+        $(TOP)/src/rrd_gfx.obj \
+        $(TOP)/src/rrd_graph.obj \
+        $(TOP)/src/rrd_graph_helper.obj \
+        $(TOP)/src/rrd_hw.obj \
+        $(TOP)/src/rrd_hw_math.obj \
+        $(TOP)/src/rrd_hw_update.obj \
+        $(TOP)/src/rrd_info.obj \
+        $(TOP)/src/rrd_last.obj \
+        $(TOP)/src/rrd_lastupdate.obj \
+        $(TOP)/src/rrd_list.obj \
+        $(TOP)/src/rrd_modify.obj \
+        $(TOP)/src/rrd_nan_inf.obj \
+        $(TOP)/src/rrd_open.obj \
+        $(TOP)/src/rrd_parsetime.obj \
+        $(TOP)/src/rrd_resize.obj \
+        $(TOP)/src/rrd_restore.obj \
+        $(TOP)/src/rrd_rpncalc.obj \
+        $(TOP)/src/rrd_snprintf.obj \
+        $(TOP)/src/rrd_strtod.obj \
+        $(TOP)/src/rrd_thread_safe_nt.obj \
+        $(TOP)/src/rrd_tune.obj \
+        $(TOP)/src/rrd_update.obj \
+        $(TOP)/src/rrd_utils.obj \
+        $(TOP)/src/rrd_version.obj \
+        $(TOP)/src/rrd_xport.obj \
+        $(TOP)/win32/asprintf.obj \
+        $(TOP)/win32/vasprintf-msvc.obj \
+        $(TOP)/win32/win32-glob.obj
+# win32comp.obj is not added to RRD_LIB_OBJ_LIST, because definitions are already in rrd_thread_safe_nt.obj
+
+all: $(TOP)/win32/$(RRD_LIB_NAME).dll $(TOP)/win32/rrdtool.exe \
+        $(TOP)/win32/rrdupdate.exe $(TOP)/win32/rrdcgi.exe
+
+clean:
+    -@del /F /Q $(TOP)\src\*.obj 2>NUL
+    -@del /F /Q $(TOP)\win32\*.obj 2>NUL
+    -@del /F /Q $(TOP)\win32\*.res 2>NUL
+    -@del /F /Q $(TOP)\win32\*.exe 2>NUL
+    -@del /F /Q $(TOP)\win32\*.pdb 2>NUL
+    -@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).dll 2>NUL
+    -@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).exp 2>NUL
+    -@del /F /Q $(TOP)\win32\$(RRD_LIB_NAME).lib 2>NUL
+
+$(TOP)/win32/$(RRD_LIB_NAME).dll $(TOP)/win32/$(RRD_LIB_NAME).lib: \
+        $(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
+        $(RRD_LIB_OBJ_LIST)
+    cl /nologo /MD /LD /Zi /Fe$(TOP)/win32/$(RRD_LIB_NAME).dll \
+        /Fd$(TOP)/win32/$(RRD_LIB_NAME).pdb \
+        $(TOP)/win32/$(RRD_LIB_NAME).def $(TOP)/win32/$(RRD_LIB_NAME).res \
+        $(RRD_LIB_OBJ_LIST) /link $(THIRD_PARTY_LIB) $(LD_FLAGS)
+
+$(TOP)/win32/rrdtool.exe: $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
+        $(TOP)/win32/$(RRD_LIB_NAME).lib
+    cl /nologo /MD /Zi /Fe$@ $(TOP)/win32/rrdtool.res $(TOP)/src/rrd_tool.obj \
+        $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
+#Just waiting for antivirus program to finished check tasks
+    -@ping 1.1.1.1 -n 1 -w 1000 > NUL
+    -mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdtool.exe;#1
+
+$(TOP)/win32/rrdupdate.exe: $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
+        $(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib
+    cl /nologo /MD /Zi /Fe$@ $(TOP)/win32/rrdupdate.res $(TOP)/src/rrdupdate.obj \
+        $(TOP)/src/plbasename.obj $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
+#Just waiting for antivirus program to finished check tasks
+    -@ping 1.1.1.1 -n 1 -w 1000 > NUL
+    -mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdupdate.exe;#1
+
+$(TOP)/win32/rrdcgi.exe: $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
+        $(TOP)/src/optparse.obj \
+        $(TOP)/win32/$(RRD_LIB_NAME).lib
+    cl /nologo /MD /Zi /Fe$@ $(TOP)/win32/rrdcgi.res $(TOP)/src/rrd_cgi.obj \
+        $(TOP)/src/optparse.obj \
+        $(TOP)/win32/$(RRD_LIB_NAME).lib /link $(LD_FLAGS)
+#Just waiting for antivirus program to finished check tasks
+    -@ping 1.1.1.1 -n 1 -w 1000 > NUL
+    -mt -manifest $(TOP)/win32/uac.manifest -outputresource:$(TOP)/win32/rrdcgi.exe;#1
+
+{$(TOP)/src}.c{$(TOP)/src}.obj:
+    cl /nologo /MD /DWIN32 /c $(CPPFLAGS) /Fo$@ $<
+
+{$(TOP)/win32}.rc{$(TOP)/win32}.res:
+    rc /nologo /I./src /fo$@ $<
+
+{$(TOP)/win32}.c{$(TOP)/win32}.obj:
+    cl /nologo /MD /DWIN32 /c $(CPPFLAGS) /Fo$@ $<

--- a/win32/README
+++ b/win32/README
@@ -1,10 +1,15 @@
-Win32 Build Instructions:
+Win32 Build Instructions (using nmake Makefile):
 
 1) See build-rrdtool.dot (build-rrdtool.svg or build-rrdtool.pdf) for build
    dependency.
 
-2) If you do not want to build the build-dependencies, you can download prebuilt
-   versions from the following address:
+2) An efficient way, to obtain up-to-date build-dependencies, is using vcpkg.
+   Install the headers and libraries the following way into the vcpkg directory:
+   .\vcpkg install cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib --triplet x86-windows
+   .\vcpkg install cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib --triplet x64-windows
+
+   If you do not want to build the build-dependencies, you can download prebuilt
+   (but in the meantime outdated) versions from the following address:
 
    32bit dependencies should then be extracted into the contrib directory:
    http://ftp.gnome.org/pub/gnome/binaries/win32/
@@ -19,12 +24,15 @@ Win32 Build Instructions:
    from the following address:
    http://msinttypes.googlecode.com/svn/trunk/stdint.h
 
-4) Adjust the include path, library path, and library names which in the
-   Makefile.msc, to correspond with your local path or names.
+4) Adjust the include path, library path, and library names found in
+   Makefile_vcpkg.msc or Makefile.msc, to correspond to your local path or names.
 
-5) Run 'nmake -f win32\Makefile.msc' for 32 bit Windows target,
-   Run 'nmake -f win32\Makefile.msc USE_64BIT=1' for 64 bit Windows target.
-   Run 'nmake -f win32\Makefile.msc clean' to remove all generated files.
+5) Run 'nmake -f win32\Makefile_vcpkg.msc' for 32 bit Windows target,
+   Run 'nmake -f win32\Makefile_vcpkg.msc USE_64BIT=1' for 64 bit Windows target.
+   Run 'nmake -f win32\Makefile_vcpkg.msc clean' to remove all generated files.
+
+   If you use headers and libraries in the contrib or the contrib-x64 folder,
+   use Makefile.msc instead of Makefile_vcpkg.msc in the three commands above.
 
 6) librrd-4.dll, librrd-4.lib, rrdtool.exe, rrdupdate.exe, rrdcgi.exe, and
    these corresponding pdb files will be located in the win32 directory.


### PR DESCRIPTION
- This allows building against newer and up-to-date versions of
  required libraries. Vcpkg is a library manager and can be found here:
  https://github.com/microsoft/vcpkg
- Libraries are provided for 32-bit and 64-bit.
  Current versions of libraries are e.g.:
  cairo 1.16.0, expat 2.2.6, fontconfig 2.12.4, freetype 2.9.1,
  gettext 0.19, glib 2.52.3, libpng 1.6.37, pango 1.40.11, pcre 8.41,
  libxml2 2.9.9 and zlib 1.2.11
  Furthermore these libraries from vcpkg are regularly updated.
- Added information to WIN32-BUILD-TIPS.txt and win32/README concerning
  vcpkg
- Added win32/Makefile_vcpkg.msc for building using nmake