### PR TITLE
Bump version to librrd-8.dll for MSVC builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ EXTRA_DIST = COPYRIGHT CHANGES TODO CONTRIBUTORS THREADS VERSION LICENSE \
              libtool .indent.pro \
              m4/snprintf.m4 \
              win32/build-rrdtool.dot win32/build-rrdtool.pdf win32/build-rrdtool.svg \
-             win32/librrd-4.def win32/librrd-4.rc win32/librrd-4.vcxproj \
+             win32/librrd-8.def win32/librrd-8.rc win32/librrd-8.vcxproj \
              win32/Makefile.msc win32/README win32/README-MinGW-w64 win32/rrdcgi.rc win32/rrd_config.h \
              win32/rrd.sln win32/rrdtool.rc win32/rrdtool.sln win32/rrdtool.vcxproj win32/rrdupdate.rc \
              win32/rrdupdate.sln win32/rrdupdate.vcxproj win32/uac.manifest \

--- a/Makefile.in
+++ b/Makefile.in
@@ -433,7 +433,7 @@ EXTRA_DIST = COPYRIGHT CHANGES TODO CONTRIBUTORS THREADS VERSION LICENSE \
              libtool .indent.pro \
              m4/snprintf.m4 \
              win32/build-rrdtool.dot win32/build-rrdtool.pdf win32/build-rrdtool.svg \
-             win32/librrd-4.def win32/librrd-4.rc win32/librrd-4.vcxproj \
+             win32/librrd-8.def win32/librrd-8.rc win32/librrd-8.vcxproj \
              win32/Makefile.msc win32/README win32/README-MinGW-w64 win32/rrdcgi.rc win32/rrd_config.h \
              win32/rrd.sln win32/rrdtool.rc win32/rrdtool.sln win32/rrdtool.vcxproj win32/rrdupdate.rc \
              win32/rrdupdate.sln win32/rrdupdate.vcxproj win32/uac.manifest \

--- a/WIN32-BUILD-TIPS.txt
+++ b/WIN32-BUILD-TIPS.txt
@@ -4,7 +4,7 @@ Compiling RRDtool on Win32 with Microsoft Visual C++:
 2010-06-04 Chris Larsen clarsen@euphoriaaudio.com
 2008-03-12 Stefan Ludewig stefan.ludewig@exitgames.com
 
-Here are step by step instructions for building librrd-4.dll and rrdtool.exe
+Here are step by step instructions for building librrd-8.dll and rrdtool.exe
 version 1.4.5 and newer with Microsoft Visual Studio 2013 (12.0.x) and newer.
 I you would like to build RRDtool using MinGW-w64, please have a look at
 win32/README-MinGW-w64
@@ -64,7 +64,7 @@ However, the described procedure still works.
     etc folders.
 
 (4) Open the Visual Studio 2013 Solution "rrd.sln" in the win32 folder of
-    your rrdtool-folder and build either the project librrd-4 (for the
+    your rrdtool-folder and build either the project librrd-8 (for the
     rrdtool-library), rrdtool (for the rrdtool-executable depending on the
     library) or the complete solution. A post-build event automatically copies
     all the dlls, needed by rrdtool, next to the .exe, when you build the

--- a/bindings/dotnet/rrdlib.cs
+++ b/bindings/dotnet/rrdlib.cs
@@ -93,7 +93,7 @@ namespace dnrrdlib
     public class rrd
     {
         // Set this path to the location of your "rrdlib.dll" file
-        const string dll = @"librrd-4.dll";
+        const string dll = @"librrd-8.dll";
 
         // IMPORTS - Main methods
         [DllImport(dll)] static extern Int32 rrd_create(Int32 argc, string[] argv);

--- a/bindings/perl-shared/Makefile.PL
+++ b/bindings/perl-shared/Makefile.PL
@@ -19,7 +19,7 @@ if (($Config{'osname'} eq 'MSWin32' && $ENV{'OSTYPE'} eq '')) {
 		'LDDLFLAGS'    => '-dll -nologo -opt:ref,icf -ltcg -libpath:"$perl_core_dir" -machine:X86',
 		'LDFLAGS'      => '-nologo -opt:ref,icf -ltcg -libpath:"$perl_core_dir" -machine:X86',
 		'OPTIMIZE'     => '-O2 -MD',
-		'LIBS'         => qq{"../../win32/librrd-4.lib" "perl$perlver.lib" -L../../contrib/lib -L../../win32 -L"$sdk_dir/lib" -L"$vc_dir/lib" -L"$perl_core_dir"},
+		'LIBS'         => qq{"../../win32/librrd-8.lib" "perl$perlver.lib" -L../../contrib/lib -L../../win32 -L"$sdk_dir/lib" -L"$vc_dir/lib" -L"$perl_core_dir"},
 		'realclean'    => {FILES => 't/demo?.rrd t/demo?.png' },
 		($] ge '5.005') ? (
 			'AUTHOR'   => 'Tobias Oetiker (tobi@oetiker.ch)',

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -8,7 +8,7 @@
 # The toplevel directory of the source tree
 #
 TOP = .
-RRD_LIB_NAME=librrd-4
+RRD_LIB_NAME=librrd-8
 ARCH_PATH_X86=contrib
 ARCH_PATH_X64=contrib-x64
 

--- a/win32/Makefile_vcpkg.msc
+++ b/win32/Makefile_vcpkg.msc
@@ -8,7 +8,7 @@
 # The toplevel directory of the source tree
 #
 TOP = .
-RRD_LIB_NAME=librrd-4
+RRD_LIB_NAME=librrd-8
 ARCH_PATH_X86=vcpkg\installed\x86-windows
 ARCH_PATH_X64=vcpkg\installed\x64-windows
 

--- a/win32/README
+++ b/win32/README
@@ -34,7 +34,7 @@ Win32 Build Instructions (using nmake Makefile):
    If you use headers and libraries in the contrib or the contrib-x64 folder,
    use Makefile.msc instead of Makefile_vcpkg.msc in the three commands above.
 
-6) librrd-4.dll, librrd-4.lib, rrdtool.exe, rrdupdate.exe, rrdcgi.exe, and
+6) librrd-8.dll, librrd-8.lib, rrdtool.exe, rrdupdate.exe, rrdcgi.exe, and
    these corresponding pdb files will be located in the win32 directory.
 
 7) To install, copy these files which you required to their permanent location.

--- a/win32/librrd-8.def
+++ b/win32/librrd-8.def
@@ -1,4 +1,4 @@
-LIBRARY "librrd-4.dll"
+LIBRARY "librrd-8.dll"
 EXPORTS
 rrd_add_ptr
 rrd_add_ptr_chunk

--- a/win32/librrd-8.rc
+++ b/win32/librrd-8.rc
@@ -24,8 +24,8 @@ BEGIN
       VALUE "ProductName", "RRDtool"
       VALUE "FileVersion", PACKAGE_VERSION
       VALUE "ProductVersion", PACKAGE_VERSION
-      VALUE "OriginalFilename", "librrd-4.dll"
-      VALUE "InternalName", "librrd-4.dll"
+      VALUE "OriginalFilename", "librrd-8.dll"
+      VALUE "InternalName", "librrd-8.dll"
     END
   END
   BLOCK "VarFileInfo"

--- a/win32/librrd-8.vcxproj
+++ b/win32/librrd-8.vcxproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CC158E1D-1364-43CA-9B2D-4AF54225C7CA}</ProjectGuid>
-    <RootNamespace>librrd-4</RootNamespace>
+    <RootNamespace>librrd-8</RootNamespace>
     <Keyword>Win32Proj</Keyword>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -107,7 +107,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
-      <ProgramDataBaseFileName>$(IntDir)librrd-4.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)librrd-8.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
@@ -129,7 +129,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader />
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
-      <ProgramDataBaseFileName>$(IntDir)librrd-4.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)librrd-8.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>None</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
@@ -150,7 +150,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
-      <ProgramDataBaseFileName>$(IntDir)librrd-4.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)librrd-8.pdb</ProgramDataBaseFileName>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
@@ -159,7 +159,7 @@
     <Link>
       <AdditionalDependencies>cairo.lib;glib-2.0.lib;gobject-2.0.lib;libpng.lib;libxml2.lib;pango-1.0.lib;pangocairo-1.0.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <ModuleDefinitionFile>librrd-4.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile>librrd-8.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
@@ -177,7 +177,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-      <ProgramDataBaseFileName>$(IntDir)librrd-4.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)librrd-8.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Lib>
       <AdditionalDependencies>cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -195,7 +195,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader />
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
-      <ProgramDataBaseFileName>$(IntDir)librrd-4.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)librrd-8.pdb</ProgramDataBaseFileName>
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>CompileAsC</CompileAs>
@@ -205,7 +205,7 @@
     <Link>
       <AdditionalDependencies>cairo.lib;glib-2.0.lib;gobject-2.0.lib;libpng.lib;libxml2.lib;pango-1.0.lib;ws2_32.lib;pangocairo-1.0.lib;gthread-2.0.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <ModuleDefinitionFile>librrd-4.def</ModuleDefinitionFile>
+      <ModuleDefinitionFile>librrd-8.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -287,7 +287,7 @@
     <ClInclude Include="win32-glob.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="librrd-4.def" />
+    <None Include="librrd-8.def" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win32/rrd.sln
+++ b/win32/rrd.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.30110.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "librrd-4", "librrd-4.vcxproj", "{CC158E1D-1364-43CA-9B2D-4AF54225C7CA}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "librrd-8", "librrd-8.vcxproj", "{CC158E1D-1364-43CA-9B2D-4AF54225C7CA}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rrdtool", "rrdtool.vcxproj", "{11CD05F8-E5E1-476E-A75F-A112655D4E94}"
 EndProject

--- a/win32/rrdtool.vcxproj
+++ b/win32/rrdtool.vcxproj
@@ -78,7 +78,7 @@
       <AdditionalIncludeDirectories>.;../../contrib/cairo/include/cairo;../../contrib/pango/include/pango-1.0;../../contrib/glib/include/glib-2.0;../../contrib/glib/lib/glib-2.0/include;../../contrib/libpng/include;../../contrib/zlib/include;../../contrib/libxml2/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>librrd-4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>librrd-8.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <AdditionalLibraryDirectories>$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -119,7 +119,7 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>librrd-4.lib;cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>librrd-8.lib;cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(Configuration); ../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
@@ -161,7 +161,7 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
       <AdditionalIncludeDirectories>.;../../contrib/cairo/include/cairo;../../contrib/pango/include/pango-1.0;../../contrib/glib/include/glib-2.0;../../contrib/glib/lib/glib-2.0/include;../../contrib/libpng/include;../../contrib/zlib/include;../../contrib/libxml2/include/libxml2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>librrd-4.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>librrd-8.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <AdditionalLibraryDirectories>$(Configuration);../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -197,7 +197,7 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll "$(TargetDir)"\
     <ClInclude Include="..\src\rrd_tool.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="librrd-4.vcxproj">
+    <ProjectReference Include="librrd-8.vcxproj">
       <Project>{cc158e1d-1364-43ca-9b2d-4af54225c7ca}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/win32/rrdupdate.vcxproj
+++ b/win32/rrdupdate.vcxproj
@@ -78,7 +78,7 @@
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>librrd-4.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>librrd-8.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <AdditionalLibraryDirectories>$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBCMTD.lib;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -120,7 +120,7 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>librrd-4.lib;cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>librrd-8.lib;cairo.lib;pango-1.0.lib;pangocairo-1.0.lib;libpng.lib;zdll.lib;glib-2.0.lib;gobject-2.0.lib;libxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(Configuration); ../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OptimizeReferences>true</OptimizeReferences>
@@ -162,7 +162,7 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll $(TargetDir)\
       <DisableSpecificWarnings>4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>librrd-4.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>librrd-8.lib;cairo.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>LinkVerboseLib</ShowProgress>
       <AdditionalLibraryDirectories>$(Configuration);../contrib/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -198,7 +198,7 @@ copy $(ProjectDir)\..\contrib\bin\zlib1.dll "$(TargetDir)"\
     <ClInclude Include="..\src\rrd_tool.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="librrd-4.vcxproj">
+    <ProjectReference Include="librrd-8.vcxproj">
       <Project>{cc158e1d-1364-43ca-9b2d-4af54225c7ca}</Project>
     </ProjectReference>
     <ProjectReference Include="rrdtool.vcxproj">


### PR DESCRIPTION
The current version in the filename of the library is 8, e.g.
librrd.so.8 or librrd-8.dll (MinGW-w64 builds), which is based on
LIBVERS from configure.ac. The version of the dll for MSVC builds is
not derived from LIBVERS and has not been updated yet.

- Substitute occurrences of librrd-4 with librrd-8 using:
  `git grep -l 'librrd-4' | xargs sed -b -i 's/librrd-4/librrd-8/g'`
- rename librrd-4* files to librrd-8* using:
  `find . -name 'librrd-4*' \`
  `-exec bash -c 'file={}; git mv $file ${file/librrd-4/librrd-8}' \;`