### PR TITLE
Include asprintf.h in rrd_info.c for MSVC builds

### DIFF
--- a/src/rrd_info.c
+++ b/src/rrd_info.c
@@ -8,6 +8,9 @@
 #include "rrd_rpncalc.h"
 #include "rrd_client.h"
 #include <stdarg.h>
+#ifdef _MSC_VER
+#include "asprintf.h"   /* for vasprintf() here */
+#endif
 
 /* allocate memory for string */
 char     *sprintf_alloc(


### PR DESCRIPTION
- Fixes the following MSVC level 3 compiler warning:
  `rrd_info.c(21): warning C4013: 'vasprintf' undefined;`
  `assuming extern returning int`
- This is a follow-up to PR #828 and commit b1bcbca