### PR TITLE
Fix possible memory leak by buffer.file

### DIFF
--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -432,6 +432,10 @@ int rrd_graph_xport(
 
     /* do the data processing */
     if (rrd_xport_fn(im, &start, &end, &step, &col_cnt, &legend_v, &data, 1)) {
+        /* close the file */
+        if (buffer.file) {
+            fclose(buffer.file);
+        }
         return -1;
     }
 


### PR DESCRIPTION
Close the opened buffer.file in rrd_xport.c before return -1,
if the data processing has failed

- Fixes the following Cppcheck error:
  `[rrdtool-1.x/src/rrd_xport.c:435] (error) Memory leak:`
  `buffer.file [memleak]`
