### PR TITLE
Update MSVC .vcxproj files (SAFESH, IntDir)

### DIFF
--- a/win32/rrdcgi.vcxproj
+++ b/win32/rrdcgi.vcxproj
@@ -29,6 +29,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{87299711-CA4F-418B-A166-61D1EA021CAE}</ProjectGuid>
     <RootNamespace>rrdtool</RootNamespace>
+    <IntDirSharingDetected>None</IntDirSharingDetected>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static Debug|Win32'" Label="Configuration">
@@ -121,6 +122,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>
@@ -285,6 +287,7 @@ copy $(ProjectDir)\..\contrib-x64\bin\zlib1.dll $(TargetDir)\
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>

--- a/win32/rrdtool.vcxproj
+++ b/win32/rrdtool.vcxproj
@@ -29,6 +29,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{11CD05F8-E5E1-476E-A75F-A112655D4E94}</ProjectGuid>
     <RootNamespace>rrdtool</RootNamespace>
+    <IntDirSharingDetected>None</IntDirSharingDetected>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static Debug|Win32'" Label="Configuration">
@@ -121,6 +122,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>
@@ -285,6 +287,7 @@ copy $(ProjectDir)\..\contrib-x64\bin\zlib1.dll $(TargetDir)\
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>

--- a/win32/rrdupdate.vcxproj
+++ b/win32/rrdupdate.vcxproj
@@ -29,6 +29,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3AAE1E07-78D7-420D-968B-D2087D732D3B}</ProjectGuid>
     <RootNamespace>rrdtool</RootNamespace>
+    <IntDirSharingDetected>None</IntDirSharingDetected>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Static Debug|Win32'" Label="Configuration">
@@ -122,6 +123,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>
@@ -287,6 +289,7 @@ copy $(ProjectDir)\..\contrib-x64\bin\zlib1.dll $(TargetDir)\
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>NotSet</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
       <Message>get all the dlls, needed for running</Message>


### PR DESCRIPTION
Win32 Debug configurations have `EditAndContinue` set, whereas `/SAFESEH`
is incompatible with `EditAndContinue`. Add
`<ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>`
to these configurations.

- Fixes the following warning in Visual Studio build log files, e.g.:
  `warning LNK4075: ignoring '/EDITANDCONTINUE' due to`
  `'/SAFESEH' specification`

The projects librrd-8, rrdcgi, rrdtool and rrdupdate are built in
the same directory, which is OK, as there is no overlap. No need for a
separate `IntDir` for each project. To silence the warning, add:
`<IntDirSharingDetected>None</IntDirSharingDetected>`

- Fixes the following warning in Visual Studio build log files, e.g.:
  `warning MSB8028: The intermediate directory (Debug\) contains files`
  `shared from another project (librrd-8.vcxproj).`
  `This can lead to incorrect clean and rebuild behavior.`
