### PR TITLE
Fix format specifiers

### DIFF
--- a/bindings/tcl/tclrrd.c
+++ b/bindings/tcl/tclrrd.c
@@ -510,7 +510,7 @@ static int Rrd_Lastupdate(
             sprintf(s, " %28s", ds_namv[i]);
             Tcl_ListObjAppendElement(interp, listPtr,
                                      Tcl_NewStringObj(s, -1));
-            sprintf(s, "\n\n%10lu:", last_update);
+            sprintf(s, "\n\n%10lu:", (unsigned long) last_update);
             Tcl_ListObjAppendElement(interp, listPtr,
                                      Tcl_NewStringObj(s, -1));
             for (i = 0; i < ds_cnt; i++) {

--- a/src/rrd_fetch_libdbi.c
+++ b/src/rrd_fetch_libdbi.c
@@ -53,14 +53,14 @@ static long rrd_fetch_dbi_long(dbi_result *result,int idx) {
       } else if (attr & DBI_INTEGER_SIZE4) { value=dbi_result_get_int_idx(result,idx);
       } else if (attr & DBI_INTEGER_SIZE8) { value=dbi_result_get_longlong_idx(result,idx);
       } else {                               value=DNAN;
-        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %i for type INTEGER\n",time(NULL),idx,attr ); }
+        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %u for type INTEGER\n",time(NULL),idx,attr ); }
       }
       break;
     case DBI_TYPE_DECIMAL:
       if        (attr & DBI_DECIMAL_SIZE4) { value=floor(dbi_result_get_float_idx(result,idx));
       } else if (attr & DBI_DECIMAL_SIZE8) { value=floor(dbi_result_get_double_idx(result,idx));
       } else {                               value=DNAN;
-        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %i for type DECIMAL\n",time(NULL),idx,attr ); }
+        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %u for type DECIMAL\n",time(NULL),idx,attr ); }
       }
       break;
     case DBI_TYPE_BINARY:
@@ -82,7 +82,7 @@ static long rrd_fetch_dbi_long(dbi_result *result,int idx) {
        value=dbi_result_get_datetime_idx(result,idx);
        break;
     default:
-      if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported type: %i with attribute %i\n",time(NULL),idx,type,attr ); }
+      if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported type: %u with attribute %u\n",time(NULL),idx,type,attr ); }
       value=DNAN;
       break;
   }
@@ -116,14 +116,14 @@ static double rrd_fetch_dbi_double(dbi_result *result,int idx) {
       } else if (attr & DBI_INTEGER_SIZE4) { value=dbi_result_get_int_idx(result,idx);
       } else if (attr & DBI_INTEGER_SIZE8) { value=dbi_result_get_longlong_idx(result,idx);
       } else {                               value=DNAN;
-        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %i for type INTEGER\n",time(NULL),idx,attr ); }
+        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %u for type INTEGER\n",time(NULL),idx,attr ); }
       }
       break;
     case DBI_TYPE_DECIMAL:
       if        (attr & DBI_DECIMAL_SIZE4) { value=dbi_result_get_float_idx(result,idx);
       } else if (attr & DBI_DECIMAL_SIZE8) { value=dbi_result_get_double_idx(result,idx);
       } else {                               value=DNAN;
-        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %i for type DECIMAL\n",time(NULL),idx,attr ); }
+        if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported attribute flags %u for type DECIMAL\n",time(NULL),idx,attr ); }
       }
       break;
     case DBI_TYPE_BINARY:
@@ -145,7 +145,7 @@ static double rrd_fetch_dbi_double(dbi_result *result,int idx) {
        value=dbi_result_get_datetime_idx(result,idx);
        break;
     default:
-      if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported type: %i with attribute %i\n",time(NULL),idx,type,attr ); }
+      if (getenv("RRDDEBUGSQL")) { fprintf(stderr,"RRDDEBUGSQL: %li: column %i unsupported type: %u with attribute %u\n",time(NULL),idx,type,attr ); }
       value=DNAN;
       break;
   }

--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -1502,14 +1502,14 @@ static int parse_stack(
 
     for (i = im->gdes_c - 1; (gdp->gf == gf) && (i >= 0); i--) {
         dprintfparsed("trying to process entry %li with type %u\n", i,
-                      im->gdes[i].gf);
+                      (unsigned int) im->gdes[i].gf);
         switch (im->gdes[i].gf) {
         case GF_LINE:
         case GF_AREA:
             gdp->gf = im->gdes[i].gf;
             gdp->linewidth = im->gdes[i].linewidth;
             dprintfparsed("found matching LINE/AREA at %li with type %u\n", i,
-                          im->gdes[i].gf);
+                          (unsigned int) im->gdes[i].gf);
             break;
         default:
             break;
@@ -1692,7 +1692,7 @@ static int parse_gprint(
     }
     dprintf("VNAME : %s (%li)\n", gdp->vname, gdp->vidx);
     if ((int) gdp->cf > -1) {
-        dprintf("CF : (%u)\n", gdp->cf);
+        dprintf("CF : (%u)\n", (unsigned int) gdp->cf);
     }
     dprintf("FORMAT: \"%s\"\n", gdp->legend);
     dprintf("=================================\n");
@@ -1809,7 +1809,7 @@ static int parse_textalign(
     /* debug output */
     dprintf("=================================\n");
     dprintf("TEXTALIGN : %s\n", pa->arg_orig);
-    dprintf("ALIGNMENT : %s (%u)\n", align, gdp->txtalign);
+    dprintf("ALIGNMENT : %s (%u)\n", align, (unsigned int) gdp->txtalign);
     dprintf("=================================\n");
     /* and return */
     return 0;

--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -389,7 +389,7 @@ int rrd_tune(
 
         for (i = 0; i < (int) rrd.stat_head->ds_cnt; i++)
             if (dst_conv(rrd.ds_def[i].dst) != DST_CDEF) {
-                printf("DS[%s] typ: %s\thbt: %ld\tmin: %1.4f\tmax: %1.4f\n",
+                printf("DS[%s] typ: %s\thbt: %lu\tmin: %1.4f\tmax: %1.4f\n",
                        rrd.ds_def[i].ds_nam,
                        rrd.ds_def[i].dst,
                        rrd.ds_def[i].par[DS_mrhb_cnt].u_cnt,


### PR DESCRIPTION
- Fixes the following Cppcheck warnings:
<pre>
  [bindings/tcl/tclrrd.c:513] (warning) %lu in format string (no. 1)
    requires 'unsigned long' but the argument type is 'signed long'.
    [invalidPrintfArgType_uint]

  [src/rrd_fetch_libdbi.c:56] (warning) %i in format string (no. 3)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]
  [src/rrd_fetch_libdbi.c:63] (warning) %i in format string (no. 3)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]
  [src/rrd_fetch_libdbi.c:85] (warning) %i in format string (no. 3)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]
  [src/rrd_fetch_libdbi.c:85] (warning) %i in format string (no. 4)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]
  [src/rrd_fetch_libdbi.c:119] (warning) %i in format string (no. 3)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]
  [src/rrd_fetch_libdbi.c:126] (warning) %i in format string (no. 3)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]
  [src/rrd_fetch_libdbi.c:148] (warning) %i in format string (no. 3)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]
  [src/rrd_fetch_libdbi.c:148] (warning) %i in format string (no. 4)
    requires 'int' but the argument type is 'unsigned int'.
    [invalidPrintfArgType_sint]

  [src/rrd_graph_helper.c:1504] (warning) %u in format string (no. 2)
    requires 'unsigned int' but the argument type is 'signed int'.
    [invalidPrintfArgType_uint]
  [src/rrd_graph_helper.c:1511] (warning) %u in format string (no. 2)
    requires 'unsigned int' but the argument type is 'signed int'.
    [invalidPrintfArgType_uint]
  [src/rrd_graph_helper.c:1695] (warning) %u in format string (no. 1)
    requires 'unsigned int' but the argument type is 'signed int'.
    [invalidPrintfArgType_uint]
  [src/rrd_graph_helper.c:1812] (warning) %u in format string (no. 2)
    requires 'unsigned int' but the argument type is 'signed int'.
    [invalidPrintfArgType_uint]

  [src/rrd_tune.c:392] (warning) %ld in format string (no. 3)
    requires 'long' but the argument type is 'unsigned long'.
    [invalidPrintfArgType_sint]
</pre>