### PR TITLE
Fix rrd_cgi.c Cppcheck_warnings

### DIFF
--- a/src/rrd_cgi.c
+++ b/src/rrd_cgi.c
@@ -146,7 +146,7 @@ static s_cgi *rrdcgiInit(
  *  or doesn't exist.
  */
 static char *rrdcgiGetValue(
-    s_cgi * parms,
+    s_cgi *parms,
     const char *name);
 
 /*  rrdcgiReadVariables()
@@ -397,11 +397,11 @@ static int readfile(
         totalcnt = (ftell(input) + 1) / sizeof(char) - offset;
         if (totalcnt < MEMBLK)
             totalcnt = MEMBLK;  /* sanitize */
-        if (fseek(input, offset * sizeof(char), SEEK_SET) == -1)
-        {
-           rrd_set_error("fseek() failed on %s: %s", file_name, rrd_strerror(errno));
-           fclose(input);
-           return (-1);
+        if (fseek(input, offset * sizeof(char), SEEK_SET) == -1) {
+            rrd_set_error("fseek() failed on %s: %s", file_name,
+                          rrd_strerror(errno));
+            fclose(input);
+            return (-1);
         }
     }
     if (((*buffer) = (char *) malloc((totalcnt + 4) * sizeof(char))) == NULL) {
@@ -436,12 +436,13 @@ int main(
     char     *buffer;
     long      i;
     long      filter = 0;
+
     struct optparse_long longopts[] = {
         {"filter", 'f', OPTPARSE_NONE},
         {0},
     };
     struct optparse options;
-    int opt;
+    int       opt;
 
 #ifdef MUST_DISABLE_SIGFPE
     signal(SIGFPE, SIG_IGN);
@@ -454,7 +455,7 @@ int main(
        for (i=0;i<argc;i++)
        printf("%d-'%s'\n",i,argv[i]); */
     optparse_init(&options, argc, argv);
-    while ((opt = optparse_long(&options,longopts,NULL)) != -1) {
+    while ((opt = optparse_long(&options, longopts, NULL)) != -1) {
         switch (opt) {
         case 'f':
             filter = 1;
@@ -561,7 +562,7 @@ static char *rrdsetenv(
 {
     if (argc >= 2) {
         const size_t len = strlen(args[0]) + strlen(args[1]) + 2;
-        char *xyz = (char *) malloc(len);
+        char     *xyz = (char *) malloc(len);
 
         if (xyz == NULL) {
             return stralloc("[ERROR: allocating setenv buffer]");
@@ -754,7 +755,8 @@ static char *includefile(
 
         readfile(filename, &buffer, 0);
         if (rrd_test_error()) {
-            char err[4096];
+            char      err[4096];
+
             snprintf(err, sizeof(err), "[ERROR %s]", rrd_get_error());
             rrd_clear_error();
 
@@ -921,7 +923,8 @@ static char *drawgraph(
         return stralloc(calcpr[0]);
     } else {
         if (rrd_test_error()) {
-            char err[4096];
+            char      err[4096];
+
             snprintf(err, sizeof(err), "[ERROR %s]", rrd_get_error());
             rrd_clear_error();
 
@@ -964,7 +967,8 @@ static char *printtimelast(
 
         last = rrd_last(argc, (char **) args - 1);
         if (rrd_test_error()) {
-            char err[4096];
+            char      err[4096];
+
             snprintf(err, sizeof(err), "[ERROR %s]", rrd_get_error());
             rrd_clear_error();
 
@@ -975,7 +979,9 @@ static char *printtimelast(
         strftime(buf, 254, args[1], &tm_last);
         return buf;
     }
-    return stralloc("[ERROR: expected <RRD::TIME::LAST file.rrd strftime-format>]");
+    return
+        stralloc
+        ("[ERROR: expected <RRD::TIME::LAST file.rrd strftime-format>]");
 }
 
 static char *printtimenow(
@@ -1167,8 +1173,8 @@ static char *scanargs(
        over seemingly the old array ... but doing argv-1 will actually end
        up in a 'good' place now. */
 
-    *arguments = argv+1;
-    *argument_count = argc-1;
+    *arguments = argv + 1;
+    *argument_count = argc - 1;
 
     if (Quote) {
         return NULL;
@@ -1190,8 +1196,8 @@ static int parse(
     char **buf,         /* buffer */
     long i,             /* offset in buffer */
     char *tag,          /* tag to handle  */
-    char *    (*func) (long,
-                       const char **)   /* function to call for 'tag' */
+    char *    (*func)(long,
+                      const char **)    /* function to call for 'tag' */
     )
 {
     /* the name of the vairable ... */
@@ -1222,7 +1228,7 @@ static int parse(
     if (end) {
         /* got arguments, call function for 'tag' with arguments */
         val = func(argc, (const char **) args);
-        free(args-1);
+        free(args - 1);
     } else {
         /* next call, try parsing at current offset +1 */
         end = (*buf) + i + 1;
@@ -1333,11 +1339,13 @@ static char *rrdcgiDecodeString(
  * We can safely call free() on result[i]->{name,value} because they are
  * memset() to 0 after their allocation.
  */
-static void free_result(s_var **result, int number)
+static void free_result(
+    s_var **result,
+    int number)
 {
-    int i;
+    int       i;
 
-    for(i = 0; i < number; i++) {
+    for (i = 0; i < number; i++) {
         if (result && result[i]) {
             free(result[i]->name);
             free(result[i]->value);
@@ -1488,7 +1496,8 @@ static s_var **rrdcgiReadVariables(
                     return NULL;
                 }
                 if ((result[i]->name =
-                     (char *) malloc((esp - cp + 1) * sizeof(char))) == NULL) {
+                     (char *) malloc((esp - cp + 1) * sizeof(char))) ==
+                    NULL) {
                     free_result(result, i);
                     free(line);
                     return NULL;
@@ -1497,7 +1506,8 @@ static s_var **rrdcgiReadVariables(
                 strncpy(result[i]->name, cp, esp - cp);
                 cp = ++esp;
                 if ((result[i]->value =
-                     (char *) malloc((ip - esp + 1) * sizeof(char))) == NULL) {
+                     (char *) malloc((ip - esp + 1) * sizeof(char))) ==
+                    NULL) {
                     free_result(result, i);
                     free(line);
                     return NULL;
@@ -1552,7 +1562,7 @@ static s_cgi *rrdcgiInit(
     vars = rrdcgiReadVariables();
 
     if (!vars) {
-    	free(res);
+        free(res);
         return NULL;
     }
 
@@ -1562,7 +1572,7 @@ static s_cgi *rrdcgiInit(
 }
 
 static char *rrdcgiGetValue(
-    s_cgi * parms,
+    s_cgi *parms,
     const char *name)
 {
     int       i;
@@ -1589,4 +1599,3 @@ static char *rrdcgiGetValue(
     }
     return NULL;
 }
-

--- a/src/rrd_cgi.c
+++ b/src/rrd_cgi.c
@@ -346,9 +346,7 @@ static void calfree(
         long      i;
 
         for (i = 0; calcpr[i]; i++) {
-            if (calcpr[i]) {
-                free(calcpr[i]);
-            }
+            free(calcpr[i]);
         }
         if (calcpr) {
             free(calcpr);
@@ -525,7 +523,7 @@ int main(
 
     if (!filter) {
         printf("Content-Type: text/html\n"
-               "Content-Length: %zd\n", strlen(buffer));
+               "Content-Length: %zu\n", strlen(buffer));
 
         if (labs(goodfor) > 0) {
             time_t    now;


### PR DESCRIPTION
**Indent rrd_cgi.c**

- indent src/rrd_cgi.c using GNU indent 2.2.12
  before further changes to the code

**Fix rrd_cgi.c Cppcheck_warnings**

Remove the identical inner 'if' condition.
Use the `%zu` format specifier for `size_t` returned from `strlen()`,
according to: [https://en.cppreference.com/w/c/string/byte/strlen](https://en.cppreference.com/w/c/string/byte/strlen)
<pre>
- Fixes the following Cppcheck warnings:
  [src/rrd_cgi.c:349] (warning) Identical inner 'if' condition is
    always true (outer condition is 'calcpr[i]' and inner condition is
    'calcpr[i]'). [identicalInnerCondition]

  [src/rrd_cgi.c:527] (portability) %zd in format string (no. 1)
    requires 'ssize_t' but the argument type is 'size_t
    {aka unsigned long}'. [invalidPrintfArgType_sint]
  or
  [src/rrd_cgi.c:527] (portability) %zd in format string (no. 1)
    requires 'ssize_t' but the argument type is 'size_t
    {aka unsigned long long}'. [invalidPrintfArgType_sint]
</pre>