### PR TITLE
Update .travis.yml for Ubuntu xenial (16.04LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+# dist: trusty
+dist: xenial
+
 language: c
 
 perl:
+  - "5.22"
   - "5.20"
   - "5.18"
   - "5.16"
@@ -9,7 +13,7 @@ perl:
 
 install:
   - sudo apt-get update || true
-  - sudo apt-get install autopoint libdbi-dev tcl-dev lua5.1 liblua5.1-0-dev valgrind dc python-pip python-setuptools libpango1.0-dev ghostscript
+  - sudo apt-get install autopoint libdbi-dev libtool-bin tcl-dev lua5.1 liblua5.1-0-dev valgrind dc python-pip python-setuptools libpango1.0-dev ghostscript
   - sudo pip install cpp-coveralls
 
 before_script:
@@ -22,9 +26,9 @@ script:
   - make check
   - make check TESTS_STYLE="rrdcached"
 # - make check TESTS_STYLE="valgrind-logfile"
-# Disable the following, failing tests: rpn1 rpn2 create-with-source-4 vformatter1 xport1
-# These tests are failing on Travis CI (currently gcc 4.8.4, Ubuntu 14.04.3), when using valgrind-logfile
-  - make check TESTS_STYLE="valgrind-logfile" TESTS="modify1 modify2 modify3 modify4 modify5 tune1 tune2 rrdcreate dump-restore create-with-source-1 create-with-source-2 create-with-source-3 create-with-source-and-mapping-1 create-from-template-1 dcounter1 list1"
+# Disable the following, failing tests: rpn1 rpn2 xport1
+# These tests are failing on Travis CI (currently Ubuntu xenial, 16.04LTS), when using valgrind-logfile
+  - make check TESTS_STYLE="valgrind-logfile" TESTS="modify1 modify2 modify3 modify4 modify5 tune1 tune2 graph1 rrdcreate dump-restore create-with-source-1 create-with-source-2 create-with-source-3 create-with-source-4 create-with-source-and-mapping-1 create-from-template-1 dcounter1 vformatter1 list1 pdp-calc1"
   - sudo make install
   - cd bindings/perl-shared && make test
   - cd ../python && python setup.py test


### PR DESCRIPTION
- Install libtool-bin to fix failing "valgrind-logfile" tests
- Enable the following "valgrind-logfile" tests, which are passing now
  under xenial: create-with-source-4, vformatter1
  Add also graph1 and pdp-calc1, which have been added in the meantime.
  There are only three failing tests left: rpn1, rpn2, xport1
- Add Perl 5.22, which is the version in xenial
