### PR TITLE
Fix compiler warning (-Wstringop-truncation)

### DIFF
--- a/src/rrd_cgi.c
+++ b/src/rrd_cgi.c
@@ -1404,7 +1404,7 @@ static s_var **rrdcgiReadVariables(
                 if ((unsigned) length > tmplen) {
                     if ((line = (char *) realloc(line, len)) == NULL)
                         return NULL;
-                    strncat(line, tmp, tmplen);
+                    strncat(line, tmp, len - strlen(line) - 1);
                 } else {
                     /* clean-up the storage allocated in previous iteration */
                     if (line) {


### PR DESCRIPTION
- Use `strncat()` the following way in rrd_cgi.c:
  `strncat(dest, src, dest_size - strlen(dest) - 1);`

- Fixes the following gcc compiler warning:
  `rrd_cgi.c:1407:21: warning: ‘strncat’ output truncated before`
  `terminating nul copying as many bytes from a string as its length`
  `[-Wstringop-truncation]`
  `strncat(line, tmp, tmplen);`
