### PR TITLE
Fix wbuf segfault

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -4125,7 +4125,7 @@ static void *listen_thread_main(
                 continue;
             }
 
-            client_sock = (listen_socket_t *) malloc(sizeof(listen_socket_t));
+            client_sock = (listen_socket_t *) calloc(1, sizeof(listen_socket_t));
             if (client_sock == NULL) {
                 RRDD_LOG(LOG_ERR, "listen_thread_main: malloc failed.");
                 continue;

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -3775,6 +3775,9 @@ static int open_listen_socket_unix(
         return (-1);
     }
 
+    listen_fds[listen_fds_num].wbuf_data = NULL;
+    listen_fds[listen_fds_num].wbuf_size = 0;
+    listen_fds[listen_fds_num].wbuf_capacity = 0;
     listen_fds[listen_fds_num].fd = fd;
     listen_fds[listen_fds_num].family = PF_UNIX;
     listen_fds[listen_fds_num].addr = strdup(path);
@@ -3930,6 +3933,9 @@ static int open_listen_socket_network(
             return (-1);
         }
 
+        listen_fds[listen_fds_num].wbuf_data = NULL;
+        listen_fds[listen_fds_num].wbuf_size = 0;
+        listen_fds[listen_fds_num].wbuf_capacity = 0;
         listen_fds[listen_fds_num].fd = fd;
         listen_fds[listen_fds_num].family = ai_ptr->ai_family;
         listen_fds[listen_fds_num].addr = strdup(sock->addr);
@@ -4009,6 +4015,9 @@ static int open_listen_sockets_systemd(
             return i;
         }
 
+        listen_fds[listen_fds_num].wbuf_data = NULL;
+        listen_fds[listen_fds_num].wbuf_size = 0;
+        listen_fds[listen_fds_num].wbuf_capacity = 0;
         listen_fds[listen_fds_num].fd = sd_fd;
         listen_fds[listen_fds_num].family = sa.sun_family;
         /* Add permissions to the socket */


### PR DESCRIPTION
This ensures that wbuf_data, wbuf_size, and wbuf_capacity are all initialised to zero. Fixes #1043. 

In general, calloc should be preferred over malloc as it preserves alignment. However, as I'm not familiar enough with the code base, I'm going to simply change this one line to fix my problem. 