### PR TITLE
Add missing client symbols

### DIFF
--- a/src/librrd.sym
+++ b/src/librrd.sym
@@ -81,11 +81,15 @@ rrdc_fetch
 rrdc_first
 rrdc_flush
 rrdc_flush_if_daemon
+rrdc_flushall
+rrdc_flushall_if_daemon
 rrdc_forget
 rrdc_info
 rrdc_is_any_connected
 rrdc_is_connected
 rrdc_last
+rrdc_list
+rrdc_ping
 rrdc_stats_free
 rrdc_stats_get
 rrdc_update


### PR DESCRIPTION
A bunch of client symbols were missing from the shared library.

Aside, it is not at all clear to me how to copy rrd_client into an external project and build it, since it depends on a bunch of other files, especially since they do not share the same license.