### PR TITLE
Clean up tests leftover files

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -28,7 +28,7 @@ AM_TESTS_ENVIRONMENT = \
 	TOP_BUILDDIR=${abs_top_builddir} ; export TOP_BUILDDIR ;
 
 CLEANFILES = *.rrd \
-	ct.out dur.out \
+	ct.out dur.out graph1.output.out \
 	modify5-testa1-mod.dump modify5-testa2-mod.dump \
-	modify5-testa1-mod.dump.tmp modify5-testa2-mod.dump.tmp
-
+	modify5-testa1-mod.dump.tmp modify5-testa2-mod.dump.tmp \
+	rpn1.output.out


### PR DESCRIPTION
Bold try. I haven't tested.
But Debian package system is complaining about these two extra files when building several time in a row...