### PR TITLE
Remove duplicate code of find_first_weekday()

### DIFF
--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -45,7 +45,6 @@
 #if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__CYGWIN32__)
 #include <io.h>
 #include <fcntl.h>
-#include <windows.h>    /* for GetLocaleInfoEx */
 #endif
 
 #include <time.h>
@@ -1536,56 +1535,6 @@ int data_proc(
     }
 
     return 0;
-}
-
-static int find_first_weekday(
-    void)
-{
-    static int first_weekday = -1;
-
-    if (first_weekday == -1) {
-#ifdef HAVE__NL_TIME_WEEK_1STDAY
-        /* according to http://sourceware.org/ml/libc-locales/2009-q1/msg00011.html */
-        /* See correct way here http://pasky.or.cz/dev/glibc/first_weekday.c */
-        first_weekday = nl_langinfo(_NL_TIME_FIRST_WEEKDAY)[0];
-        int       week_1stday;
-        long      week_1stday_l = (long) nl_langinfo(_NL_TIME_WEEK_1STDAY);
-
-        if (week_1stday_l == 19971130
-#if SIZEOF_LONG_INT > 4
-            || week_1stday_l >> 32 == 19971130
-#endif
-            )
-            week_1stday = 0;    /* Sun */
-        else if (week_1stday_l == 19971201
-#if SIZEOF_LONG_INT > 4
-                 || week_1stday_l >> 32 == 19971201
-#endif
-            )
-            week_1stday = 1;    /* Mon */
-        else {
-            first_weekday = 1;
-            return first_weekday;   /* we go for a Monday default */
-        }
-        first_weekday = (week_1stday + first_weekday - 1) % 7;
-#elif defined(_WIN32) && defined(LOCALE_NAME_USER_DEFAULT)
-        DWORD     week_1stday;
-
-        GetLocaleInfoEx(LOCALE_NAME_USER_DEFAULT,
-                        LOCALE_IFIRSTDAYOFWEEK | LOCALE_RETURN_NUMBER,
-                        (LPWSTR) & week_1stday,
-                        sizeof(week_1stday) / sizeof(WCHAR));
-        /* 0:Monday, ..., 6:Sunday. */
-        /* We need 1 for Monday, 0 for Sunday. */
-        first_weekday = (week_1stday + 1) % 7;
-#else
-        first_weekday = 0;
-#endif
-    }
-#ifdef DEBUG
-    printf("first_weekday = %d\n", first_weekday);
-#endif
-    return first_weekday;
 }
 
 /* identify the point where the first gridline, label ... gets placed */

--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -545,7 +545,7 @@ static int rpn_compare_double(
     return (diff < 0) ? -1 : (diff > 0) ? 1 : 0;
 }
 
-static int find_first_weekday(
+int find_first_weekday(
     void)
 {
     static int first_weekday = -1;

--- a/src/rrd_rpncalc.h
+++ b/src/rrd_rpncalc.h
@@ -101,4 +101,7 @@ short     rpn_calc(
     int output_idx,
     int step_width);
 
+int       find_first_weekday(
+    void);
+
 #endif

--- a/src/rrd_rpncalc.h
+++ b/src/rrd_rpncalc.h
@@ -18,14 +18,14 @@ enum op_en { OP_NUMBER = 0, OP_VARIABLE, OP_INF, OP_PREV, OP_NEGINF,
     OP_UN, OP_END, OP_LTIME, OP_NE, OP_ISINF, OP_PREV_OTHER, OP_COUNT,
     OP_ATAN, OP_SQRT, OP_SORT, OP_REV, OP_TREND, OP_TRENDNAN,
     OP_ATAN2, OP_RAD2DEG, OP_DEG2RAD,
-    OP_PREDICT,OP_PREDICTSIGMA,
+    OP_PREDICT, OP_PREDICTSIGMA,
     OP_AVG, OP_ABS, OP_ADDNAN,
     OP_MINNAN, OP_MAXNAN,
     OP_MEDIAN, OP_PREDICTPERC,
     OP_DEPTH, OP_COPY, OP_ROLL, OP_INDEX, OP_STEPWIDTH,
     OP_NEWDAY, OP_NEWWEEK, OP_NEWMONTH, OP_NEWYEAR,
     OP_SMIN, OP_SMAX, OP_STDEV, OP_PERCENT, OP_POW, OP_ROUND
- };
+};
 
 typedef struct rpnp_t {
     enum op_en op;
@@ -35,8 +35,10 @@ typedef struct rpnp_t {
     long      ds_cnt;   /* data source count for data pointer */
     long      step;     /* time step for OP_VAR das */
     void     *extra;    /* some extra data for longer setups */
-    void      (*free_extra)(void *); /* function pointer used to free extra
-				      * - NULL for "simple" free(extra); */
+    void      (
+    *free_extra) (
+    void *);            /* function pointer used to free extra
+                         * - NULL for "simple" free(extra); */
 } rpnp_t;
 
 void      rpnp_freeextra(
@@ -69,7 +71,8 @@ void      parseCDEF_DS(
     const char *def,
     ds_def_t *ds_def,
     void *key_hash,
-    long (*lookup) (void *, char *));
+    long      (*lookup)(void *,
+                        char *));
 
 long      lookup_DS(
     void *rrd_vptr,
@@ -88,15 +91,14 @@ void      rpn_compact2str(
 rpnp_t   *rpn_parse(
     void *key_hash,
     const char *const expr,
-    long      (*lookup) (void *,
-                         char *));
+    long      (*lookup)(void *,
+                        char *));
 short     rpn_calc(
     rpnp_t *rpnp,
     rpnstack_t *rpnstack,
     long data_idx,
     rrd_value_t *output,
     int output_idx,
-    int step_width
-);
+    int step_width);
 
 #endif


### PR DESCRIPTION
**Indent rrd_rpncalc.h**
Indent src/rrd_rpncalc.h using GNU indent 2.2.12
before further changes to the code

**Remove duplicate code of find_first_weekday()**
So far, the same code of `find_first_weekday()` was used in rrd_graph.c
and rrd_rpncalc.c
Remove duplicate code from rrd_graph.c and add `find_first_weekday()`
to rrd_rpncalc.h, which is included from rrd_graph.h
