### PR TITLE
Sort and remove duplicate entries in ALL_LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -626,7 +626,8 @@ if test "$EX_CHECK_ALL_ERR" = "YES"; then
   AC_MSG_ERROR([Please fix the library issues listed above and try again.])
 fi
 
-ALL_LIBS="$LIBS"
+dnl Sort and remove duplicate entries in LIBS before assigning to ALL_LIBS
+ALL_LIBS=$(echo "$LIBS"|tr -s " " "\n"|sort -u|tr "\n" " ")
 LIBS=
 
 AC_SUBST(CORE_LIBS)


### PR DESCRIPTION
- So far, configure showed e.g. the following at the end:
`Libraries: -lgobject-2.0 -lpng -lm  -ldbi -lglib-2.0  -lpangocairo-1.0`
` -lpango-1.0 -lgobject-2.0 -lglib-2.0 -lharfbuzz -lcairo  -lxml2`

The variable `ALL_LIBS` included duplicates resulting from the configure
process and some double spaces.

- Now, `ALL_LIBS` is sorted and duplicate entries are removed, e.g.:
`Libraries: -lcairo -ldbi -lglib-2.0 -lgobject-2.0 -lharfbuzz -lm`
` -lpango-1.0 -lpangocairo-1.0 -lpng -lxml2`
