### PR TITLE
Update .travis.yml according to yamllint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ before_script:
 
 script:
   - ./configure --prefix=/opt/rrdtool-master --disable-ruby
-# - make CFLAGS+="-g -O0 -fprofile-arcs -ftest-coverage" LDFLAGS+="-fprofile-arcs --coverage"
+  # - make CFLAGS+="-g -O0 -fprofile-arcs -ftest-coverage" LDFLAGS+="-fprofile-arcs --coverage"
   - make
   - make check
   - make check TESTS_STYLE="rrdcached"
-# - make check TESTS_STYLE="valgrind-logfile"
-# Disable the following, failing tests: rpn1 rpn2 xport1
-# These tests are failing on Travis CI (currently Ubuntu xenial, 16.04LTS), when using valgrind-logfile
+  # - make check TESTS_STYLE="valgrind-logfile"
+  # Disable the following, failing tests: rpn1 rpn2 xport1
+  # These tests are failing on Travis CI (currently Ubuntu xenial, 16.04LTS), when using valgrind-logfile
   - make check TESTS_STYLE="valgrind-logfile" TESTS="modify1 modify2 modify3 modify4 modify5 tune1 tune2 graph1 rrdcreate dump-restore create-with-source-1 create-with-source-2 create-with-source-3 create-with-source-4 create-with-source-and-mapping-1 create-from-template-1 dcounter1 vformatter1 list1 pdp-calc1"
   - sudo make install
   - cd bindings/perl-shared && make test
@@ -41,9 +41,8 @@ script:
   - ./configure
   - sudo make install
   - cd /opt/rrdtool-`cat VERSION`
-  - ./bin/rrdtool  
+  - ./bin/rrdtool
 
 # after_success:
 #  - ( cd src ; find -name '*.c' | xargs -n 1 gcov -a .libs ; find -name '*.c' | xargs -n 1 )
 #  - coveralls --no-gcov --encoding latin1 --exclude tests --exclude bindings
-


### PR DESCRIPTION
- Fix the following warnings and errors reported by yamllint 1.17.0:
```console
24:1  warning  comment not indented like content (comments-indentation)
28:1  warning  comment not indented like content (comments-indentation)
44:18 error    trailing spaces (trailing-spaces)
49:1  error    too many blank lines (1 > 0) (empty-lines)
```

- Used the following yamllint command:
```console
  yamllint -d "{extends: default, rules: {document-start: disable, \
  line-length: {max: 512}}}" .travis.yml
```
