### PR TITLE
Fix rrd_pdpcalc whatis entry in manual

### DIFF
--- a/doc/rrd_pdpcalc.pod
+++ b/doc/rrd_pdpcalc.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-PDP calculation explanation - PDP inner calculation logics with an example by Tianpeng Xia
+rrd_pdpcalc - PDP inner calculation logics with an example by Tianpeng Xia
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
From Debian lintian checker:
 Each manual page should start with a "NAME" section, which lists the
 name and a brief description of the page separated by "\-". The "NAME"
 section is parsed by lexgrog and used to generate a database that's
 queried by commands like apropos and whatis. This tag indicates that
 lexgrog was unable to parse the NAME section of this manual page.

 For manual pages that document multiple programs, functions, files, or
 other things, the part before "\-" should list each separated by a comma
 and a space. Each thing listed must not contain spaces; a man page for a
 two-part command like "fs listacl" must use something like "fs_listacl"
 in the "NAME" section so that it can be parsed by lexgrog.

 Refer to the lexgrog(1) manual page, the groff_man(7) manual page, and
 the groff_mdoc(7) manual page for details.