### PR TITLE
Use LC_NUMERIC=C for tests

### DIFF
--- a/tests/functions
+++ b/tests/functions
@@ -2,6 +2,10 @@
 TZ=Europe/Zurich
 export TZ
 
+# Use dot as decimal separator, which is required for some tests to pass
+LC_NUMERIC=C
+export LC_NUMERIC
+
 BASEDIR="${BASEDIR:-$(dirname -- $0)}"
 BASEDIR="$(readlink -f -- $BASEDIR)"
 


### PR DESCRIPTION
The following tests require dot as decimal separator:
graph1, rpn1, create-with-source-4, dcounter1, vformatter1, pdp-calc1

Set `LC_NUMERIC=C`, which allows these tests to pass also under locales,
where the decimal separator is not a dot by default:
de_DE, es_ES, fr_FR, nl_NL etc.
