### PR TITLE
Fix AM_CHECK_PYTHON_HEADERS macro for Python3

### DIFF
--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -426,11 +426,16 @@ AC_DEFUN([AM_CHECK_PYTHON_HEADERS],
 [AC_REQUIRE([AM_PATH_PYTHON])
 AC_MSG_CHECKING(for headers required to compile python extensions)
 dnl deduce PYTHON_INCLUDES
-py_prefix=`$PYTHON -c "import sys; print(sys.prefix)"`
-py_exec_prefix=`$PYTHON -c "import sys; print(sys.exec_prefix)"`
-PYTHON_INCLUDES="-I${py_prefix}/include/python${PYTHON_VERSION}"
-if test "$py_prefix" != "$py_exec_prefix"; then
-  PYTHON_INCLUDES="$PYTHON_INCLUDES -I${py_exec_prefix}/include/python${PYTHON_VERSION}"
+py_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.prefix)"`
+py_exec_prefix=`$PYTHON -c "import sys; sys.stdout.write(sys.exec_prefix)"`
+PYTHON_CONFIG=`which $PYTHON`-config
+if test -x "$PYTHON_CONFIG"; then
+  PYTHON_INCLUDES=`$PYTHON_CONFIG --includes 2>/dev/null`
+else
+  PYTHON_INCLUDES="-I${py_prefix}/include/python${PYTHON_VERSION}"
+  if test "$py_prefix" != "$py_exec_prefix"; then
+    PYTHON_INCLUDES="$PYTHON_INCLUDES -I${py_exec_prefix}/include/python${PYTHON_VERSION}"
+  fi
 fi
 AC_SUBST(PYTHON_INCLUDES)
 dnl check if the headers exist:


### PR DESCRIPTION
This detects Python3 include paths like /usr/include/python3.7m.
Taken from pygobject.