### PR TITLE
fetch - do not call rrd_freemem on uninitialized pointers

### DIFF
--- a/bindings/python/rrdtoolmodule.c
+++ b/bindings/python/rrdtoolmodule.c
@@ -476,10 +476,11 @@ _rrdtool_fetch(PyObject *Py_UNUSED(self), PyObject *args)
 
         for (i = 0; i < ds_cnt; i++)
             rrd_freemem(ds_namv[i]);
+
+        rrd_freemem(ds_namv);
+        rrd_freemem(data);
     }
 
-    rrd_freemem(ds_namv);
-    rrd_freemem(data);
     destroy_args(&rrdtool_argv);
     return ret;
 }


### PR DESCRIPTION
This change fixes a regression introduced with 411f10c.
The bug was reported in commx/python-rrdtool#34.