### PR TITLE
Fix double meaning of time 0 as uninitialized value

### DIFF
--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -1026,6 +1026,10 @@ static graph_desc_t *newGraphDescription(
                     }
                     if (gf == GF_VRULE) {
                         gdp->xrule = val;
+                        if (gdp->xrule == 0) {
+                            /* distinguish from uninitialized */
+                            gdp->xrule++;
+                        }
                     } else {
                         gdp->yrule = val;
                     }


### PR DESCRIPTION
Treat "VRULE:0#..." as "VRULE:1#..." because elsewhere xrule==0 is
used to mean xrule has not been set, which can lead to an array
bounds violation.

Fixes #1078