### PR TITLE
Add Windows MSYS2 GitHub Action

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,28 @@
+---
+name: Windows MSYS2 x86_64
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Disable git autocrlf
+        run: git config --global core.autocrlf false
+        shell: cmd
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: base-devel bc mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkg-config
+      - name: CI-Build
+        run: |
+          echo 'Running in MSYS2!'
+          ./ci-build_MSYS2.sh
+      # - uses: actions/upload-artifact@v2
+      #   with:
+      #     name: test-suite.log
+      #     path: tests/test-suite.log

--- a/ci-build_MSYS2.sh
+++ b/ci-build_MSYS2.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+echo "MSYSTEM:     $MSYSTEM"
+echo "MINGW_CHOST: $MINGW_CHOST"
+./bootstrap
+./configure --host="$MINGW_CHOST" --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix
+make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+
+# The export of TZ=Europe/Zurich in tests/functions does not work under Windows. The timezone needs to be set
+# for Windows, e.g. using tzutil.exe
+# The timezone TZ=Europe/Zurich is required for several tests to pass:
+# modify1,modify2,modify3,modify4,modify5,tune1,tune2
+TZ_BAK=$(tzutil.exe //g)
+echo Current timezone="$TZ_BAK"
+tzutil.exe //s "W. Europe Standard Time"
+echo New timezone="$(tzutil.exe //g)"
+
+# Set first day of week to Sunday. This is required for test "rpn2"
+# 0 ... Monday, 6 ... Sunday
+iFirstDayOfWeek_key=$(reg query "HKEY_CURRENT_USER\Control Panel\International" //v iFirstDayOfWeek)
+iFirstDayOfWeek_BAK="${iFirstDayOfWeek_key//[!0-9]/}"
+echo Current iFirstDayOfWeek="$iFirstDayOfWeek_BAK"
+reg add "HKEY_CURRENT_USER\Control Panel\International" //t REG_SZ //v iFirstDayOfWeek //d 6 //f
+
+make check || :
+
+# Restore first day of week
+reg add "HKEY_CURRENT_USER\Control Panel\International" //t REG_SZ //v iFirstDayOfWeek //d "$iFirstDayOfWeek_BAK" //f
+
+# Restore the timezone
+tzutil.exe //s "$TZ_BAK"
+echo Restored timezone="$(tzutil.exe //g)"


### PR DESCRIPTION
This enables CI for Windows builds using MSYS2 mingw-w64-x86_64.
The GitHub Action is based on: https://www.msys2.org/docs/ci/