### PR TITLE
Add -no-undefined automatically for MinGW-w64

### DIFF
--- a/ci-build_MSYS2.sh
+++ b/ci-build_MSYS2.sh
@@ -3,7 +3,7 @@ echo "MSYSTEM:     $MSYSTEM"
 echo "MINGW_CHOST: $MINGW_CHOST"
 ./bootstrap
 ./configure --host="$MINGW_CHOST" --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix
-make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+make CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 # The export of TZ=Europe/Zurich in tests/functions does not work under Windows. The timezone needs to be set
 # for Windows, e.g. using tzutil.exe

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -112,6 +112,9 @@ librrd_la_LIBADD          = librrdupd.la $(ALL_LIBS) $(LIBINTL)
 librrd_la_CFLAGS          = $(AM_CFLAGS) $(MULTITHREAD_CFLAGS)
 librrd_la_LDFLAGS         = $(MULTITHREAD_LDFLAGS) -version-info @LIBVERS@
 librrd_la_LDFLAGS         += -export-symbols $(srcdir)/librrd.sym
+if MINGW_W64
+librrd_la_LDFLAGS         += -no-undefined
+endif
 
 include_HEADERS	= rrd.h rrd_format.h rrd_client.h
 

--- a/win32/README-MinGW-w64
+++ b/win32/README-MinGW-w64
@@ -16,7 +16,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
    ./configure --host=i686-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=i686-w64-mingw32-pkg-config
-   make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+   make CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 - x86_64 (64-bit)
    Install the required dependencies:
@@ -26,7 +26,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
    ./configure --host=x86_64-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=x86_64-w64-mingw32-pkg-config
-   make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+   make CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 
 2) MSYS2 (https://sourceforge.net/projects/msys2/)
@@ -38,7 +38,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
    ./configure --host=i686-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix
-   make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+   make CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 - x86_64 (64-bit)
    Install the required dependencies:
@@ -48,7 +48,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
    ./configure --host=x86_64-w64-mingw32 --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached --without-libintl-prefix --without-libiconv-prefix
-   make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+   make CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 3) MXE (http://mxe.cc/ https://github.com/mxe/mxe)
  - i686 (32-bit)
@@ -59,7 +59,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
    ./configure --host=i686-w64-mingw32.shared --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=i686-w64-mingw32.shared-pkg-config
-   make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+   make CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
 
 - x86_64 (64-bit)
    Build the required dependencies:
@@ -69,4 +69,4 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
    ./configure --host=x86_64-w64-mingw32.shared --disable-static --disable-mmap --disable-tcl --disable-perl --disable-ruby --disable-python --disable-lua --disable-rrdcached PKGCONFIG=x86_64-w64-mingw32.shared-pkg-config
-   make LDFLAGS='-no-undefined' CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'
+   make CFLAGS='-D__USE_MINGW_ANSI_STDIO=1'


### PR DESCRIPTION
The linker flag `-no-undefined` is required, when building the dll for
Windows using MinGW-w64. Add `-no-undefined` to `librrd_la_LDFLAGS` in
**`Makefile.am`** in case of MinGW-w64 builds. This way it is not necessary
anymore to add `LDFLAGS=-no-undefined` to the make command.