### PR TITLE
Reproducibility improvement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -693,6 +693,13 @@ fi
 AC_MSG_CHECKING(Perl Modules to build)
 AC_MSG_RESULT(${COMP_PERL:-No Perl Modules will be built})
 
+# Use reproducible build date and time
+if test "$SOURCE_DATE_EPOCH"; then
+	DATE_FMT="%d %b %Y %H:%M:%S"
+	BUILD_DATE=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT")
+	AC_DEFINE_UNQUOTED([BUILD_DATE], ["$BUILD_DATE"], [Use reproducible build date])
+fi
+
 # Options to pass when configuring perl module
 langpref=$prefix
 test "$langpref" = '$(DESTDIR)NONE' && langpref='$(DESTDIR)'$ac_default_prefix

--- a/src/rrd_cgi.c
+++ b/src/rrd_cgi.c
@@ -680,7 +680,11 @@ static char *rrdgetinternal(
         if (strcasecmp(args[0], "VERSION") == 0) {
             return stralloc(PACKAGE_VERSION);
         } else if (strcasecmp(args[0], "COMPILETIME") == 0) {
+#ifdef BUILD_DATE
+            return stralloc(BUILD_DATE);
+#else
             return stralloc(__DATE__ " " __TIME__);
+#endif
         } else {
             return stralloc("[ERROR: internal unknown argument]");
         }

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -309,7 +309,11 @@ static void PrintUsage(
         else if (!strcmp(cmd, "pwd"))
             help_cmd = C_PWD;
     }
+#ifdef BUILD_DATE
+    fprintf(stdout, _(help_main), PACKAGE_VERSION, BUILD_DATE);
+#else
     fprintf(stdout, _(help_main), PACKAGE_VERSION, __DATE__, __TIME__);
+#endif
     fflush(stdout);
     switch (help_cmd) {
     case C_NONE:


### PR DESCRIPTION
RRDtool binaries include build date and time, no matter if SOURCE_DATE_EPOCH environment variable was set or not. Following changes were made in the context of [Reproducible Builds](https://reproducible-builds.org/) initiative.