### PR TITLE
Switch to pkgconf (MSYS2, MinGW-w64)

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: base-devel bc mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkg-config
+          install: base-devel bc mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'

--- a/win32/README-MinGW-w64
+++ b/win32/README-MinGW-w64
@@ -33,7 +33,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
  - i686 (32-bit)
    Install the required dependencies:
 
-   pacman -Sy --needed base-devel mingw-w64-i686-gcc mingw-w64-i686-cairo mingw-w64-i686-expat mingw-w64-i686-freetype mingw-w64-i686-gettext mingw-w64-i686-glib2 mingw-w64-i686-libpng mingw-w64-i686-libxml2 mingw-w64-i686-pango mingw-w64-i686-zlib mingw-w64-i686-pkg-config
+   pacman -Sy --needed base-devel mingw-w64-i686-gcc mingw-w64-i686-cairo mingw-w64-i686-expat mingw-w64-i686-freetype mingw-w64-i686-gettext mingw-w64-i686-glib2 mingw-w64-i686-libpng mingw-w64-i686-libxml2 mingw-w64-i686-pango mingw-w64-i686-zlib mingw-w64-i686-pkgconf
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
@@ -43,7 +43,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 - x86_64 (64-bit)
    Install the required dependencies:
 
-   pacman -Sy --needed base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkg-config
+   pacman -Sy --needed base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap


### PR DESCRIPTION
The MSYS2 project has switched from **`pkg-config`** to **`pkgconf`** as default.
For details, see: https://github.com/msys2/MSYS2-packages/pull/2197
Both packages work when building RRDtool for Windows using MSYS2.
- Switch to pkgconf instead of pkg-config
- Update the following files:
  `.github/workflows/ci-workflow.yml`
  `win32/README-MinGW-w64`
- This avoids the following warning in the Windows CI-build:
  `warning: removing 'mingw-w64-x86_64-pkg-config' from target list`
  `because it conflicts with 'mingw-w64-x86_64-pkgconf'`