### PR TITLE
Avoid segfault: Don't read and write into the same buffer.

### DIFF
--- a/src/rrd_flushcached.c
+++ b/src/rrd_flushcached.c
@@ -92,13 +92,14 @@ int rrd_flushcached (int argc, char **argv)
             char *error;
             int   remaining;
 
-            error     = rrd_get_error();
+            error     = strdup(rrd_get_error());
             remaining = options.argc - options.optind - 1;
 
             rrd_set_error("Flushing of file \"%s\" failed: %s. Skipping "
                     "remaining %i file%s.", options.argv[i],
-                    (*error == '\0') ? "unknown error" : error,
+                    (error == NULL || *error == '\0') ? "unknown error" : error,
                     remaining, (remaining == 1) ? "" : "s");
+            free(error);
             break;
         }
     }


### PR DESCRIPTION
Using CTX->rrd_error as a source *and* destination buffer at the same time
provokes undefined behavior.  In real life you get funny error messages
and/or segfaults within vs(n)printf().

Simple solution: Use a temporary copy of the error message while writing
into it.