### PR TITLE
Update Windows GitHub Actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -80,6 +80,7 @@ jobs:
           vcpkgArguments: '${{ matrix.vcpkgPackages }}'
           # Ensure the vcpkg artifacts are cached, they are generated in the 'CMAKE_BINARY_DIR/vcpkg_installed' directory.
           additionalCachedPaths: ${{ env.buildDir }}/vcpkg_installed
+
       - name: Build ${{ matrix.configuration }}
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.configuration }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,40 +1,19 @@
 ---
-name: Windows CI
+name: Release Windows
 
 # yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: cmd
 
 jobs:
-  msys2:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
-        os: [windows-2019]
-        carch: [x86_64]
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - name: Disable git autocrlf
-        run: git config --global core.autocrlf false
-        shell: cmd
-      - uses: actions/checkout@v2
-      - uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: base-devel bc mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
-      - name: CI-Build
-        run: |
-          echo 'Running in MSYS2!'
-          ./ci-build_MSYS2.sh
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: test-suite.log
-      #     path: tests/test-suite.log
   MSVC:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -57,9 +36,6 @@ jobs:
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''
-    defaults:
-      run:
-        shell: cmd
     env:
       buildDir: '${{ github.workspace }}/build/'
     steps:
@@ -84,3 +60,10 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.configuration }}
           nmake -f win32\Makefile_vcpkg.msc ${{ matrix.nmake_configuration }}
+      - name: Collect files
+        run: |
+          win32\collect_rrdtool_vcpkg_files.bat ${{ matrix.configuration }}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: deploy-rrdtool-MSVC-${{ matrix.configuration }}
+          path: win32/nmake_release_${{ matrix.configuration }}_vcpkg/rrdtool-*-${{ matrix.configuration }}_vcpkg/

--- a/win32/Makefile_vcpkg.msc
+++ b/win32/Makefile_vcpkg.msc
@@ -27,6 +27,7 @@ CPPFLAGS = $(CPPFLAGS) /TC /EHsc /O2 /Zi /Fd$(TOP)/win32/vc.pdb \
         /I $(ARCH_PATH)\include \
         /I $(ARCH_PATH)\include\cairo \
         /I $(ARCH_PATH)\include\pango-1.0 \
+        /I $(ARCH_PATH)\include\harfbuzz \
         /I $(ARCH_PATH)\include\glib-2.0 \
         /I $(ARCH_PATH)\lib\glib-2.0\include \
         /I $(ARCH_PATH)\include\libxml2

--- a/win32/collect_rrdtool_vcpkg_files.bat
+++ b/win32/collect_rrdtool_vcpkg_files.bat
@@ -1,0 +1,67 @@
+@ echo off
+REM This script collects the built .exe and .dll files required for running RRDtool.
+REM It is supposed to be run after an MSVC build using nmake and libraries from vcpkg.
+REM Wolfgang Stöggl <c72578@yahoo.de>, 2017-2021.
+
+REM Run the batch file with command line parameter x64 or x86
+if "%1"=="" (
+  echo Command line parameter required: x64 or x86
+  echo e.g.: %~nx0 x64
+  exit /b
+)
+echo configuration: %1
+
+REM The script is located in the subdirectory win32
+echo %~dp0
+pushd %~dp0
+SET base_dir=..
+
+REM Read current version of RRDtool
+SET /p version=<%base_dir%\VERSION
+echo RRDtool version: %version%
+
+SET release_dir=%base_dir%\win32\nmake_release_%1_vcpkg\rrdtool-%version%-%1_vcpkg\
+echo release_dir: %release_dir%
+
+if exist %base_dir%\win32\nmake_release_%1_vcpkg rmdir %base_dir%\win32\nmake_release_%1_vcpkg /s /q
+mkdir %release_dir%
+
+REM use xcopy instead of copy. xcopy creates directories if necessary and outputs the copied file
+REM /Y Suppresses prompting to confirm that you want to overwrite an existing destination file.
+REM /D xcopy copies all Source files that are newer than existing Destination files
+
+xcopy /Y /D %base_dir%\win32\librrd-8.dll %release_dir%
+xcopy /Y /D %base_dir%\win32\rrdcgi.exe %release_dir%
+xcopy /Y /D %base_dir%\win32\rrdtool.exe %release_dir%
+xcopy /Y /D %base_dir%\win32\rrdupdate.exe %release_dir%
+
+REM The following part needs to be checked and maintained after an update to a new vcpkg version
+REM Names of dlls can change over time, which has happened in the past
+REM e.g. glib-2.dll -> glib-2.0-0.dll, expat.dll -> libexpat.dll
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\brotlicommon.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\brotlidec.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\bz2.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\cairo-2.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libexpat.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libffi.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\fontconfig-1.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\freetype.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\fribidi-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\gio-2.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\glib-2.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\gmodule-2.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\gobject-2.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\harfbuzz.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\iconv-2.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\intl-8.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libpng16.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libxml2.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\lzma.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pango-1.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangocairo-1.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangoft2-1.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangowin32-1.0-0.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pcre.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\zlib1.dll %release_dir%
+
+popd


### PR DESCRIPTION
- Update `ci-workflow.yml` and add GitHub Actions for Windows builds
  using MSVC and vcpkg. Both, x64 and x86 builds are part of the CI.
  The required vcpkg ports are installed and cached using
  [lukka/run-vcpkg@v7](https://github.com/lukka/run-vcpkg)
- Add `release-windows.yml`, which enables building Windows binaries of
  RRDtool. This GitHub action is run automatically upon new tags and
  can be triggered manually. The required .exe and .dll files are
  copied using `collect_rrdtool_vcpkg_files.bat` and deployed by
  [actions/upload-artifact@v2](https://github.com/actions/upload-artifact)
- `Makefile_vcpkg.msc`:
  Add `include\harfbuzz`, which is required for building pango.
  Fixes: `pango-coverage.h(28): fatal error C1083:`
  `Cannot open include file: 'hb.h': No such file or directory`
