### PR TITLE
Add escapeJSON() to legend entries

### DIFF
--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -724,6 +724,9 @@ static int rrd_xport_format_xmljson(
     char      buf[256];
     char      dbuf[1024];
 
+    /* avoid calling escapeJSON() with garbage */
+    memset(dbuf, 0, sizeof(dbuf));
+
     rrd_value_t *ptr = data;
 
     if (json == 0) {
@@ -820,7 +823,10 @@ static int rrd_xport_format_xmljson(
         }
         /* now output it */
         if (json) {
-            snprintf(buf, sizeof(buf), "      \"%s\"", entry);
+            strncpy(dbuf, entry, sizeof(dbuf));
+            dbuf[sizeof(dbuf) - 1] = 0;
+            escapeJSON(dbuf, sizeof(dbuf));
+            snprintf(buf, sizeof(buf), "      \"%s\"", dbuf);
             addToBuffer(buffer, buf, 0);
             if (j < col_cnt - 1) {
                 addToBuffer(buffer, ",", 1);
@@ -1164,8 +1170,11 @@ static int rrd_xport_format_addprints(
                 entry++;
             }
             if (json) {
+                strncpy(dbuf, entry, sizeof(dbuf));
+                dbuf[sizeof(dbuf) - 1] = 0;
+                escapeJSON(dbuf, sizeof(dbuf));
                 snprintf(buf, sizeof(buf), ",\n        { \"line\": \"%s\" }",
-                         entry);
+                         dbuf);
             } else {
                 snprintf(buf, sizeof(buf), "        <line>%s</line>\n",
                          entry);


### PR DESCRIPTION
Double quotes in legends are currently not escaped, if JSON imgformat
is used for rrdtool graph. This produces invalid JSON files.
See https://github.com/oetiker/rrdtool-1.x/issues/409#issuecomment-871959824 for further details.