### PR TITLE
Fix python bindings installation in case of empty DESTDIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - podchecker doc/*.pod
   - sudo make install
   - cd bindings/perl-shared && make test
-  - cd ../python && python setup.py test
+  - cd ../python && sudo chown -R travis rrdtool.egg-info && python setup.py test
   - /opt/rrdtool-master/bin/rrdtool
   - /opt/rrdtool-master/share/rrdtool/examples/4charts.pl
   - cd ../..

--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -42,7 +42,7 @@ install-data-local:
            && ( cd ${builddir}/python \
                 && env BUILDLIBDIR=${abs_top_builddir}/src/.libs \
                   $(PYTHON) ${abs_srcdir}/python/setup.py install \
-                     --skip-build --root=$(DESTDIR) --prefix=$(prefix) \
+                     --skip-build --root=$(DESTDIR)/// --prefix=$(prefix) \
                      --exec-prefix=$(exec_prefix)) \
            || true
 

--- a/bindings/Makefile.in
+++ b/bindings/Makefile.in
@@ -738,7 +738,7 @@ install-data-local:
            && ( cd ${builddir}/python \
                 && env BUILDLIBDIR=${abs_top_builddir}/src/.libs \
                   $(PYTHON) ${abs_srcdir}/python/setup.py install \
-                     --skip-build --root=$(DESTDIR) --prefix=$(prefix) \
+                     --skip-build --root=$(DESTDIR)/// --prefix=$(prefix) \
                      --exec-prefix=$(exec_prefix)) \
            || true
 


### PR DESCRIPTION
The current behaviour is to install the extension to ./usr/local (if
prefix is /usr/local), so it ends up in the temporary build directory
instead of the intended absolute prefix.

The slash after $(DESTDIR) is needed to make empty DESTDIR mean
installation to / instead of making the prefix to mean a relative
path. We make it triple slash as POSIX reserves double slashes to
possibly have a special treatment by the OS.