### PR TITLE
Draft: Add support for TUNE command in rrdcached

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -46,14 +46,14 @@ jobs:
         include:
           - os: windows-2019
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/b361c2eefa3966cb7cec45275aff32e90430aaa6
-            vcpkgCommitId: 'b361c2eefa3966cb7cec45275aff32e90430aaa6'
+            # https://github.com/microsoft/vcpkg/commit/70033dbb31527fb3e69654731f540f59c87787f9
+            vcpkgCommitId: '70033dbb31527fb3e69654731f540f59c87787f9'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2019
             triplet: x86-windows
-            vcpkgCommitId: 'b361c2eefa3966cb7cec45275aff32e90430aaa6'
+            vcpkgCommitId: '70033dbb31527fb3e69654731f540f59c87787f9'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -25,14 +25,14 @@ jobs:
         include:
           - os: windows-2019
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/b361c2eefa3966cb7cec45275aff32e90430aaa6
-            vcpkgCommitId: 'b361c2eefa3966cb7cec45275aff32e90430aaa6'
+            # https://github.com/microsoft/vcpkg/commit/70033dbb31527fb3e69654731f540f59c87787f9
+            vcpkgCommitId: '70033dbb31527fb3e69654731f540f59c87787f9'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2019
             triplet: x86-windows
-            vcpkgCommitId: 'b361c2eefa3966cb7cec45275aff32e90430aaa6'
+            vcpkgCommitId: '70033dbb31527fb3e69654731f540f59c87787f9'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ script:
   # - make CFLAGS+="-g -O0 -fprofile-arcs -ftest-coverage" LDFLAGS+="-fprofile-arcs --coverage"
   - make
   - make check
-  - make check TESTS_STYLE="rrdcached"
+  - make check TESTS_STYLE="rrdcached-tcp"
+  - make check TESTS_STYLE="rrdcached-unix"
   # - make check TESTS_STYLE="valgrind-logfile"
   # Disable the following, failing tests: rpn1 rpn2 xport1
   # These tests are failing on Travis CI (currently Ubuntu xenial, 16.04LTS), when using valgrind-logfile

--- a/src/librrd.sym
+++ b/src/librrd.sym
@@ -16,6 +16,8 @@ rrd_dump_r
 rrd_fetch
 rrd_fetch_cb_register
 rrd_fetch_r
+rrd_tune
+rrd_tune_r
 rrd_first
 rrd_first_r
 rrd_flush

--- a/src/rrd.h
+++ b/src/rrd.h
@@ -303,6 +303,10 @@ extern    "C" {
     unsigned long *ds_cnt,
     char ***ds_namv,
     rrd_value_t **data);
+    int       rrd_tune_r(
+    const char *filename,
+    int argc,
+    const char **argv);
     int       rrd_dump_opt_r(
     const char *filename,
     char *outname,

--- a/src/rrd_client.h
+++ b/src/rrd_client.h
@@ -103,6 +103,10 @@ int rrd_client_fetch(rrd_client_t *client, const char *filename,
     char ***ret_ds_names,
     rrd_value_t **ret_data);
 
+int rrd_client_tune(rrd_client_t *client, const char *filename,
+    int argc,
+    const char **argv);
+
 int rrd_client_stats_get(rrd_client_t *client, rrdc_stats_t **ret_stats);
 
 /*
@@ -143,6 +147,10 @@ int rrdc_forget (const char *filename);
 int rrdc_flush_if_daemon (const char *opt_daemon, const char *filename);
 int rrdc_flushall (void);
 int rrdc_flushall_if_daemon (const char *opt_daemon);
+
+int rrdc_tune (const char *filename,
+    int argc,
+    const char **argv);
 
 int rrdc_fetch (const char *filename,
     const char *cf,

--- a/tests/cached/dcounter1.output
+++ b/tests/cached/dcounter1.output
@@ -1,0 +1,1 @@
+../dcounter1.output

--- a/tests/cached/graph1.output
+++ b/tests/cached/graph1.output
@@ -1,0 +1,1 @@
+../graph1.output

--- a/tests/cached/graph2.output
+++ b/tests/cached/graph2.output
@@ -1,0 +1,1 @@
+../graph2.output

--- a/tests/cached/modify-test1.create.dump
+++ b/tests/cached/modify-test1.create.dump
@@ -1,0 +1,1 @@
+../modify-test1.create.dump

--- a/tests/cached/modify-test1.mod1.dump
+++ b/tests/cached/modify-test1.mod1.dump
@@ -1,0 +1,1 @@
+../modify-test1.mod1.dump

--- a/tests/cached/modify-test3.create.dump
+++ b/tests/cached/modify-test3.create.dump
@@ -1,0 +1,1 @@
+../modify-test3.create.dump

--- a/tests/cached/modify-test3.mod1.dump
+++ b/tests/cached/modify-test3.mod1.dump
@@ -1,0 +1,1 @@
+../modify-test3.mod1.dump

--- a/tests/cached/modify2-testa-create.dump
+++ b/tests/cached/modify2-testa-create.dump
@@ -1,0 +1,1 @@
+../modify2-testa-create.dump

--- a/tests/cached/modify2-testb-mod1.dump
+++ b/tests/cached/modify2-testb-mod1.dump
@@ -1,0 +1,1 @@
+../modify2-testb-mod1.dump

--- a/tests/cached/modify2-testc-mod1.dump
+++ b/tests/cached/modify2-testc-mod1.dump
@@ -1,0 +1,1 @@
+../modify2-testc-mod1.dump

--- a/tests/cached/modify4-testa-create.dump
+++ b/tests/cached/modify4-testa-create.dump
@@ -1,0 +1,1 @@
+../modify4-testa-create.dump

--- a/tests/cached/modify4-testa1-create.dump
+++ b/tests/cached/modify4-testa1-create.dump
@@ -1,0 +1,1 @@
+../modify4-testa1-create.dump

--- a/tests/cached/modify4-testa2-create.dump
+++ b/tests/cached/modify4-testa2-create.dump
@@ -1,0 +1,1 @@
+../modify4-testa2-create.dump

--- a/tests/cached/modify5-testa1-create.dump
+++ b/tests/cached/modify5-testa1-create.dump
@@ -1,0 +1,1 @@
+../modify5-testa1-create.dump

--- a/tests/cached/modify5-testa2-create.dump
+++ b/tests/cached/modify5-testa2-create.dump
@@ -1,0 +1,1 @@
+../modify5-testa2-create.dump

--- a/tests/cached/pdp-calc1-1-avg-300.output
+++ b/tests/cached/pdp-calc1-1-avg-300.output
@@ -1,0 +1,1 @@
+../pdp-calc1-1-avg-300.output

--- a/tests/cached/pdp-calc1-1-avg-60.output
+++ b/tests/cached/pdp-calc1-1-avg-60.output
@@ -1,0 +1,1 @@
+../pdp-calc1-1-avg-60.output

--- a/tests/cached/pdp-calc1-1-max-300.output
+++ b/tests/cached/pdp-calc1-1-max-300.output
@@ -1,0 +1,1 @@
+../pdp-calc1-1-max-300.output

--- a/tests/cached/rpn1.output
+++ b/tests/cached/rpn1.output
@@ -1,0 +1,1 @@
+../rpn1.output

--- a/tests/cached/rpn2.output
+++ b/tests/cached/rpn2.output
@@ -1,0 +1,1 @@
+../rpn2.output

--- a/tests/cached/tune1-testa-mod1.dump
+++ b/tests/cached/tune1-testa-mod1.dump
@@ -1,0 +1,1 @@
+../tune1-testa-mod1.dump

--- a/tests/cached/tune1-testa-mod2.dump
+++ b/tests/cached/tune1-testa-mod2.dump
@@ -1,0 +1,1 @@
+../tune1-testa-mod2.dump

--- a/tests/cached/tune1-testorg.dump
+++ b/tests/cached/tune1-testorg.dump
@@ -1,0 +1,1 @@
+../tune1-testorg.dump

--- a/tests/cached/tune2-testa-mod1.dump
+++ b/tests/cached/tune2-testa-mod1.dump
@@ -1,0 +1,1 @@
+../tune2-testa-mod1.dump

--- a/tests/cached/tune2-testorg.dump
+++ b/tests/cached/tune2-testorg.dump
@@ -1,0 +1,1 @@
+../tune2-testorg.dump

--- a/tests/cached/valgrind-supressions
+++ b/tests/cached/valgrind-supressions
@@ -1,0 +1,1 @@
+../valgrind-supressions

--- a/tests/cached/xport1.json.output
+++ b/tests/cached/xport1.json.output
@@ -1,0 +1,1 @@
+../xport1.json.output

--- a/tests/cached/xport1.xml.output
+++ b/tests/cached/xport1.xml.output
@@ -1,0 +1,1 @@
+../xport1.xml.output

--- a/tests/create-from-template-1
+++ b/tests/create-from-template-1
@@ -33,7 +33,7 @@ rm -f ${PREFIX}*.rrd ${PREFIX}*.xml
 $RRDTOOL create ${PREFIX}ax1.rrd --start $(($ST-1)) --step 60 DS:a:GAUGE:120:0:U DS:b:COUNTER:120:0:U $RRA
 report createax1
 
-cp ${PREFIX}ax1.rrd ${PREFIX}ax1-copy.rrd
+cp ${BASE}ax1.rrd ${BASE}ax1-copy.rrd
 
 UPDATEAx1=
 V=10

--- a/tests/create-with-source-1
+++ b/tests/create-with-source-1
@@ -41,7 +41,7 @@ $RRDTOOL update ${PREFIX}a1.rrd  $UPDATE
 $RRDTOOL create ${PREFIX}a2.rrd --start $ST --step 60 --source ${PREFIX}a1.rrd DS:a:GAUGE:120:0:U  RRA:AVERAGE:0.5:1:100 RRA:AVERAGE:0.5:5:2 RRA:MIN:0.5:5:2 RRA:MAX:0.5:5:2 RRA:LAST:0.5:5:2 
 report create-with-source-1
 
-[ -f ${PREFIX}a2.rrd ] || fail "file is missing!!"
+[ -f ${BASE}a2.rrd ] || fail "file is missing!!"
 
 $RRDTOOL dump ${PREFIX}a1.rrd > ${PREFIX}a1.xml
 $RRDTOOL dump ${PREFIX}a2.rrd > ${PREFIX}a2.xml

--- a/tests/create-with-source-3
+++ b/tests/create-with-source-3
@@ -29,7 +29,7 @@ ST=$FIRST
 
 
 
-rm -f ${PREFIX}*.rrd ${PREFIX}*.xml
+rm -f ${BASE}*.rrd ${BASE}*.xml
 $RRDTOOL create ${PREFIX}a1_x.rrd --start $(($ST-1)) --step 60 DS:a:GAUGE:120:0:U  RRA:AVERAGE:0.5:1:100 RRA:AVERAGE:0.5:5:2 RRA:MIN:0.5:5:2 RRA:MAX:0.5:5:2 RRA:LAST:0.5:5:2 
 report createa1
 
@@ -45,8 +45,8 @@ report createba1
 $RRDTOOL create ${PREFIX}bca1_x.rrd --start $(($ST-1)) --step 60 DS:b:GAUGE:120:0:U DS:c:GAUGE:120:0:U DS:a:GAUGE:120:0:U  RRA:AVERAGE:0.5:1:100 RRA:AVERAGE:0.5:5:2 RRA:MIN:0.5:5:2 RRA:MAX:0.5:5:2 RRA:LAST:0.5:5:2 
 report createbca1
 
-for A in ${PREFIX}*_x.rrd ; do
-	cp $A $(basename $A _x.rrd)_y.rrd
+for A in ${BASE}*_x.rrd ; do
+	cp $A ${BASEDIR}/$(basename $A _x.rrd)_y.rrd
 done
 
 

--- a/tests/create-with-source-4
+++ b/tests/create-with-source-4
@@ -73,15 +73,15 @@ report create-ab-with-two-sources
 
 # now calculate average and standard deviation
 
-AB1=$($RRDTOOL graph ${PREFIX}ab1.png --imginfo '' --end "$ST" --start end-1h DEF:a=${PREFIX}ab1.rrd:a:AVERAGE  DEF:b=${PREFIX}ab1.rrd:b:AVERAGE CDEF:c=b,2,/,a,/ VDEF:s=c,STDEV VDEF:cavg=c,AVERAGE PRINT:s:%lg PRINT:cavg:%lg)
-AB2=$($RRDTOOL graph ${PREFIX}ab2.png --imginfo '' --end "$ST" --start end-1h DEF:a=${PREFIX}ab2.rrd:a:AVERAGE  DEF:b=${PREFIX}ab2.rrd:b:AVERAGE CDEF:c=b,2,/,a,/ VDEF:s=c,STDEV VDEF:cavg=c,AVERAGE PRINT:s:%lg PRINT:cavg:%lg)
-
+AB1=$($RRDTOOL graph ${PREFIX}ab1.png --imginfo '%s%lu%lu' --end "$ST" --start end-1h DEF:a=${PREFIX}ab1.rrd:a:AVERAGE  DEF:b=${PREFIX}ab1.rrd:b:AVERAGE CDEF:c=b,2,/,a,/ VDEF:s=c,STDEV VDEF:cavg=c,AVERAGE PRINT:s:%lg PRINT:cavg:%lg)
+AB2=$($RRDTOOL graph ${PREFIX}ab2.png --imginfo '%s%lu%lu' --end "$ST" --start end-1h DEF:a=${PREFIX}ab2.rrd:a:AVERAGE  DEF:b=${PREFIX}ab2.rrd:b:AVERAGE CDEF:c=b,2,/,a,/ VDEF:s=c,STDEV VDEF:cavg=c,AVERAGE PRINT:s:%lg PRINT:cavg:%lg)
+echo $AB1
 set -- $AB1
-STDEV1=$1
-AVG1=$2
+STDEV1=$2
+AVG1=$3
 set -- $AB2
-STDEV2=$1
-AVG2=$2
+STDEV2=$2
+AVG2=$3
 
 [ $AVG1 = 1 ] ; report average ab1 == 1
 [ $(dc <<< "$AVG2 1 - 10000 * 1 / p") -lt 10 ] ; report "average ab2 ($AVG2 - 1) < 1/1000"

--- a/tests/dump-restore
+++ b/tests/dump-restore
@@ -18,7 +18,7 @@ for A in $(seq $ST 60 $(($ST + 60*($CNT - 1))) ) ; do
 	ST=$A
 	$RRDTOOL update ${BUILD}a1.rrd  $A:$V
 
-	rm -f ${BUILD}a1.xml ${BUILD}r1.rrd ${BUILD}r1.xml
+	rm -f ${BASE}a1.xml ${BASE}r1.rrd ${BASE}r1.xml
 
 	$RRDTOOL dump ${BUILD}a1.rrd ${BUILD}a1.xml
 	$RRDTOOL restore ${BUILD}a1.xml ${BUILD}r1.rrd

--- a/tests/functions
+++ b/tests/functions
@@ -204,10 +204,11 @@ function run_cached {
             export RRDTOOL=RRDTOOLCOMPAT
 
             randport=$(python -S -c "import random; random.seed('$(basename $0)'); print(random.randrange(49152,65535))")
-            port=$(python -S << HERE
-import socketserver
-with socketserver.TCPServer(("localhost", 0), None) as s:
-  print(s.server_address[1])
+            port=$(python2 -S << HERE
+import SocketServer
+s = SocketServer.TCPServer(("localhost", 0), None)
+print(s.server_address[1])
+s.server_close()
 HERE
 )
             ADDR="localhost:$port"

--- a/tests/functions
+++ b/tests/functions
@@ -138,6 +138,8 @@ function run_cached {
         stop_cached
 
         local ADDR
+        [ -z "$RRDCACHED_SOCK" ] && RRDCACHED_SOCK="unix"
+
         if [ $RRDCACHED_SOCK == "unix" ]; then
             export BASEDIR="${BUILDDIR}/cached"
             export BUILDDIR="${BASEDIR}"
@@ -202,7 +204,13 @@ function run_cached {
             export RRDTOOL=RRDTOOLCOMPAT
 
             randport=$(python -S -c "import random; random.seed('$(basename $0)'); print(random.randrange(49152,65535))")
-            ADDR="localhost:$randport"
+            port=$(python -S << HERE
+import socketserver
+with socketserver.TCPServer(("localhost", 0), None) as s:
+  print(s.server_address[1])
+HERE
+)
+            ADDR="localhost:$port"
         fi
 
         CACHED_PID_FILE="$BASEDIR/$(basename $0)-rrdcached.pid"

--- a/tests/functions
+++ b/tests/functions
@@ -138,10 +138,76 @@ function run_cached {
         stop_cached
 
         local ADDR
-        ADDR="unix:$BASEDIR/$(basename $0)-rrdcached.sock"
+        if [ $RRDCACHED_SOCK == "unix" ]; then
+            export BASEDIR="${BUILDDIR}/cached"
+            export BUILDDIR="${BASEDIR}"
+            ADDR="unix:$BASEDIR/$(basename $0)-rrdcached.sock"
+        else
+            export BASEDIR="${BUILDDIR}/cached"
+            export RRDCACHED_STRIPPATH="${BUILDDIR}"
+
+            function RRDTOOLCOMPAT() {
+                RRDCACHED_STRIPPATH=${BUILDDIR}
+                RRDTOOL_ORIG=$TOP_BUILDDIR/src/rrdtool
+                ARGS=("$@")
+
+                # rrdcached does not support update with remote template
+                if [ $1 == "update" ] && [ $3 == '--template' ]; then
+                    RRDCACHED_STRIPPATH=${BASEDIR}
+                    ARGS=( $(sed "s#${BUILDDIR}#${BASEDIR}#" <<< "${ARGS[@]}") )
+                fi
+
+                # rrdcached does not support remote dump
+                if [ $1 == "dump" ]; then
+                    RRDCACHED_STRIPPATH=${BUILDDIR} $RRDTOOL_ORIG flushcached $2 || fail flushcached
+                    ARGS=( $(sed "s#${BUILDDIR}#${BASEDIR}#" <<< "${ARGS[@]}") )
+                    RRDCACHED_STRIPPATH=${BASEDIR}
+                fi
+
+                # rrdcached does not support remote restore
+                if [ $1 == "restore" ]; then
+                    ARGS=( "restore" "$2" $(sed "s#${BUILDDIR}#${BASEDIR}#" <<< $3) )
+                    RRDCACHED_STRIPPATH=${BASEDIR}
+                fi
+
+                # rrdcached does not support tune
+                # if [ $1 == "tune" ]; then
+                #     ARGS=( $(sed "s#${BUILDDIR}#${BASEDIR}#" <<< "${ARGS[@]}") )
+                # fi
+
+                # rrdcached does not support create with remote source or template
+                if [ $1 == "create" ]; then
+                    NEWARGS=()
+                    IS_NEXT_SOURCE_TEMPLATE=0
+                    for arg in $(echo "${ARGS[@]}"); do
+                        if [ $IS_NEXT_SOURCE_TEMPLATE == "1" ]; then
+                            arg=$(sed "s#${BUILDDIR}#${BASEDIR}#" <<< $arg)
+                            IS_NEXT_SOURCE_TEMPLATE=0
+                        fi
+                        ([ $arg == "--source" ] || [ $arg == "--template" ]) && IS_NEXT_SOURCE_TEMPLATE=1
+                        NEWARGS+="$arg "
+                    done
+                    ARGS=( ${NEWARGS[@]} )
+                fi
+
+                $RRDTOOL_ORIG "${ARGS[@]}"
+                ret=$?
+
+                if [ $1 == "update" ]; then
+                    RRDCACHED_STRIPPATH=${BUILDDIR} $RRDTOOL_ORIG flushcached $2 || fail flushcached
+                fi
+
+                return $ret
+            }
+            export RRDTOOL=RRDTOOLCOMPAT
+
+            randport=$(python -S -c "import random; random.seed('$(basename $0)'); print(random.randrange(49152,65535))")
+            ADDR="localhost:$randport"
+        fi
+
         CACHED_PID_FILE="$BASEDIR/$(basename $0)-rrdcached.pid"
 
-        $CACHED -p "$CACHED_PID_FILE" -l "$ADDR" -b "$(readlink -f -- $BASEDIR)" -F
+        $CACHED -p "$CACHED_PID_FILE" -l "$ADDR" -b "$(readlink -f -- $BASEDIR)" -F -B
 
         RRDCACHED_ADDRESS=$ADDR
         export RRDCACHED_ADDRESS
@@ -179,9 +245,15 @@ if [ -z "$RRDTOOL" ] ; then
         NEED_CACHED=
         for ST in $TESTS_STYLE ; do
                 case "$ST" in
-                rrdcached)
+                rrdcached-unix)
                         NEED_CACHED=1
                         STANDARD_RRDCACHED="$RRDCACHED"
+                        RRDCACHED_SOCK=unix
+                        ;;
+                rrdcached-tcp)
+                        NEED_CACHED=1
+                        STANDARD_RRDCACHED="$RRDCACHED"
+                        RRDCACHED_SOCK=tcp
                         ;;
                 valgrind)
                         RRDTOOL="valgrind $TOP_BUILDDIR/src/rrdtool"

--- a/tests/graph1
+++ b/tests/graph1
@@ -2,7 +2,10 @@
 
 . $(dirname $0)/functions
 
-RRD=graph1.rrd
+BASE=$BASEDIR/
+BUILD=$BUILDDIR/
+
+RRD=${BUILD}graph1.rrd
 
 $RRDTOOL create $RRD --start 920804400 DS:speed:COUNTER:600:U:U RRA:AVERAGE:0.5:1:24 RRA:AVERAGE:0.5:6:10
 report "create"

--- a/tests/list1
+++ b/tests/list1
@@ -86,9 +86,11 @@ else
 fi
 
 if is_cached; then
-        mkdir -p "$LIST_DIR"
+        PWD_TEMP="$PWD"
         # This relies on '-b' setting in functions::run_cached()
-        CACHED_DIR=`echo "$LIST_DIR" | sed "s|^$BASEDIR||"`
+        CACHED_DIR=`echo "$LIST_DIR" | sed "s|^$BUILDDIR||"`
+        cd "$BASEDIR" && mkdir -p ".$CACHED_DIR"
+        $RRDTOOL create ${BUILD}.rrd --start 1300000000 --step 60s DS:dv:DDERIVE:300:U:U DS:wh:DCOUNTER:300:0:U RRA:AVERAGE:0.5:1:600 RRA:AVERAGE:0.5:10:144
         do_list_tests "$CACHED_DIR"
 
         # rrdcached-specific tests
@@ -97,7 +99,8 @@ if is_cached; then
         test $list_count -eq 0
         report "escape from cached basedir via symlink denied"
 
-        rm -rf "$LIST_DIR"
+        rm -rf ".$CACHED_DIR"
+        cd "$PWD_TEMP"
         stop_cached || true
 else
         echo "rrdcached not started - skipping"

--- a/tests/list1
+++ b/tests/list1
@@ -83,6 +83,9 @@ if [ -n "$TEMP_RRDCACHED_ADDRESS" ]; then
         export RRDCACHED_ADDRESS=$TEMP_RRDCACHED_ADDRESS
 else
         run_cached
+        BUILDDIR=$BUILDDIR
+        BUILD=$BUILDDIR/`basename $0`
+        LIST_DIR=$BUILDDIR/`basename $0`_dir
 fi
 
 if is_cached; then

--- a/tests/modify1
+++ b/tests/modify1
@@ -14,11 +14,12 @@ for T in $(seq 1300000020 60 1300003020) ; do
 	let N=$N+10
 done
 
+
 $RRDTOOL dump ${BUILD}a.rrd | $DIFF9 - ${BASE}.create.dump 
 report "created content"
 
 # extend base RRA, refill from coarse RRA
-cp ${BUILD}a.rrd ${BUILD}b.rrd
+cp ${BASE}a.rrd ${BASE}b.rrd
 $RRDTOOL tune ${BUILD}b.rrd RRA#0:+10 || fail "tune"
 $RRDTOOL dump ${BUILD}b.rrd | $DIFF9 - ${BASE}.mod1.dump 
 report "extend base RRA"

--- a/tests/modify2
+++ b/tests/modify2
@@ -17,12 +17,12 @@ done
 $RRDTOOL dump ${BUILD}a.rrd | $DIFF9 ${BASE}a-create.dump -
 report create
 
-cp ${BUILD}a.rrd ${BUILD}b.rrd
+cp ${BASE}a.rrd ${BASE}b.rrd
 $RRDTOOL tune ${BUILD}b.rrd RRA#1:+10 RRA#2:+10 RRA#3:+10 RRA#4:+10 || fail modify
 $RRDTOOL dump ${BUILD}b.rrd | $DIFF9 ${BASE}b-mod1.dump -
 report "simultaneously extend aggregate RRAs"
 
-cp ${BUILD}a.rrd ${BUILD}c.rrd
+cp ${BASE}a.rrd ${BASE}c.rrd
 $RRDTOOL tune ${BUILD}c.rrd RRA:AVERAGE:0.5:2:10 || fail modify
 $RRDTOOL dump ${BUILD}c.rrd | $DIFF9 ${BASE}c-mod1.dump -
 report "add RRA with intermediate pdp_cnt"

--- a/tests/modify3
+++ b/tests/modify3
@@ -16,7 +16,7 @@ done
 $RRDTOOL dump ${BUILD}a.rrd | $DIFF9 - ${BASE}.create.dump && ok "create" || fail "create"
 
 # extend base RRA, refill from coarse RRA
-cp ${BUILD}a.rrd ${BUILD}b.rrd
+cp ${BASE}a.rrd ${BASE}b.rrd
 $RRDTOOL tune ${BUILD}b.rrd DEL:a RRA#0:+10 || fail modify
 
 $RRDTOOL dump ${BUILD}b.rrd | $DIFF9 - ${BASE}.mod1.dump && ok "extend base RRA" || fail "extend base RRA"

--- a/tests/modify4
+++ b/tests/modify4
@@ -30,13 +30,13 @@ report create 1
 $RRDTOOL dump ${BUILD}a2.rrd | $DIFF9 ${BASE}a2-create.dump -
 report create 2
 
-cp ${BUILD}a2.rrd ${BUILD}b2.rrd
+cp ${BASE}a2.rrd ${BASE}b2.rrd
 $RRDTOOL tune ${BUILD}b2.rrd DELRRA:5 || fail modify
 
 $RRDTOOL dump ${BUILD}b2.rrd | $DIFF9 ${BASE}a1-create.dump -
 report "remove additional RRA from second - must then be equal original first"
 
-cp ${BUILD}a1.rrd ${BUILD}b1.rrd
+cp ${BASE}a1.rrd ${BASE}b1.rrd
 $RRDTOOL tune ${BUILD}b1.rrd RRA:AVERAGE:0.5:4:10 || fail modify
 
 $RRDTOOL dump ${BUILD}b1.rrd | $DIFF9 ${BASE}a2-create.dump -

--- a/tests/modify5
+++ b/tests/modify5
@@ -41,14 +41,14 @@ do
 	$RRDTOOL dump ${BUILD}a2.rrd > ${BUILD}a2-mod.dump.tmp
 	
 	# remove RRA 5 from second RRD, should now match first RRD
-	cp ${BUILD}a2.rrd ${BUILD}b2.rrd 
+	cp ${BASE}a2.rrd ${BASE}b2.rrd 
 	$RRDTOOL tune ${BUILD}b2.rrd DELRRA:5
 
 	$RRDTOOL dump ${BUILD}b2.rrd | diff -u ${BUILD}a1-mod.dump.tmp -
 	report "remove additional RRA from second - must then be equal original first"
 
         # add RRA to first RRD, should now match second RRD
-	cp ${BUILD}a1.rrd ${BUILD}b1.rrd
+	cp ${BASE}a1.rrd ${BASE}b1.rrd
 	$RRDTOOL tune ${BUILD}b1.rrd RRA:AVERAGE:0.5:4:10
 
 	$RRDTOOL dump ${BUILD}b1.rrd | diff -u ${BUILD}a2-mod.dump.tmp -

--- a/tests/rpn1
+++ b/tests/rpn1
@@ -2,7 +2,10 @@
 
 . $(dirname $0)/functions
 
-RRD=rpn1.rrd
+BASE=$BASEDIR/
+BUILD=$BUILDDIR/
+
+RRD=${BUILD}rpn1.rrd
 
 $RRDTOOL create $RRD --start 920804400 DS:speed:COUNTER:600:U:U RRA:AVERAGE:0.5:1:24 RRA:AVERAGE:0.5:6:10
 report "create"

--- a/tests/rpn2
+++ b/tests/rpn2
@@ -2,7 +2,10 @@
 
 . $(dirname $0)/functions
 
-RRD=rpn2.rrd
+BASE=$BASEDIR/
+BUILD=$BUILDDIR/
+
+RRD=${BUILD}rpn2.rrd
 
 $RRDTOOL create $RRD --step 7200 --start 1167487000 DS:speed:DCOUNTER:14000:U:U RRA:AVERAGE:0.5:1:30
 report "create"

--- a/tests/tune1
+++ b/tests/tune1
@@ -22,7 +22,7 @@ report "update"
 is_cached && ( $RRDTOOL flushcached ${BUILD}org.rrd || fail flushcached)
 
 
-cp ${BUILD}org.rrd ${BUILD}a.rrd
+cp ${BASE}org.rrd ${BASE}a.rrd
 $RRDTOOL tune ${BUILD}a.rrd --heartbeat a:90 --minimum b:U
 $RRDTOOL tune ${BUILD}a.rrd --heartbeat a:90 --minimum b:-100
 $RRDTOOL dump ${BUILD}a.rrd | $DIFF9 - ${BASE}a-mod1.dump
@@ -31,7 +31,7 @@ report "tune heartbeat/minimum"
 # NOTE: for rrdcached based tests, we must flush before we can copy...
 is_cached && ( $RRDTOOL flushcached ${BUILD}org.rrd || fail flushcached )
 
-cp ${BUILD}org.rrd ${BUILD}a.rrd
+cp ${BASE}org.rrd ${BASE}a.rrd
 $RRDTOOL tune ${BUILD}a.rrd --data-source-type a:COUNTER --data-source-rename b:c
 $RRDTOOL dump ${BUILD}a.rrd | $DIFF9 - ${BASE}a-mod2.dump
 report "tune dst/ds-name" 

--- a/tests/tune2
+++ b/tests/tune2
@@ -12,7 +12,7 @@ $RRDTOOL dump ${BUILD}org.rrd | $xDIFF9 - ${BASE}org.dump
 report create
 
 is_cached && ( $RRDTOOL flushcached ${BUILD}org.rrd || fail flushcached )
-cp ${BUILD}org.rrd ${BUILD}a.rrd
+cp ${BASE}org.rrd ${BASE}a.rrd
 # this must fail
 ! $RRDTOOL tune ${BUILD}a.rrd --beta 1.4 2>/dev/null
 report "out of range beta error"

--- a/tests/vformatter1
+++ b/tests/vformatter1
@@ -2,6 +2,11 @@
 
 . $(dirname $0)/functions
 
+BASE=$BASEDIR/
+BUILD=$BUILDDIR/
+
+RRD=${BUILD}vfmt1.rrd
+
 export TZ=UTC
 
 function rtest() {
@@ -13,10 +18,10 @@ function rtest() {
     #&& echo "OK: $testname" || echo "FAIL: $testname"
 }
 
-$RRDTOOL create vfmt1.rrd --start 1420070400 --step 60s DS:v:GAUGE:60:U:U RRA:LAST:0:1:10 || exit 1
+$RRDTOOL create $RRD --start 1420070400 --step 60s DS:v:GAUGE:60:U:U RRA:LAST:0:1:10 || exit 1
 
 declare -a graphargs
-graphargs=(graph /dev/null --start 1420070400 --end 1420071000 'DEF:dv=vfmt1.rrd:v:LAST' 'VDEF:v=dv,LAST')
+graphargs=(graph /dev/null --start 1420070400 --end 1420071000 "DEF:dv=$RRD:v:LAST" 'VDEF:v=dv,LAST')
 
 rtest "No data, numeric" '0x0\nnan' "${graphargs[@]}" 'PRINT:v:%0.1lf'
 
@@ -27,7 +32,7 @@ rtest "No data, value timestamp" '0x0\nnan' "${graphargs[@]}" 'PRINT:v:%F %T:val
 rtest "No data, value duration" '0x0\nnan' "${graphargs[@]}" 'PRINT:v::valstrfduration'
 
 
-$RRDTOOL update vfmt1.rrd --template v -- 1420070460:0 || exit 1
+$RRDTOOL update $RRD --template v -- 1420070460:0 || exit 1
 
 rtest "Zero, numeric" '0x0\n0.0' "${graphargs[@]}" 'PRINT:v:%0.1lf'
 
@@ -37,7 +42,7 @@ rtest "Zero, value timestamp" '0x0\n1970-01-01 00:00:00' "${graphargs[@]}" 'PRIN
 
 rtest "Zero, value duration" '0x0\n0_00_00_000' "${graphargs[@]}" 'PRINT:v:%H_%02m_%02s_%03f:valstrfduration'
 
-$RRDTOOL update vfmt1.rrd --template v -- 1420070520:3000 || exit 1
+$RRDTOOL update $RRD --template v -- 1420070520:3000 || exit 1
 
 rtest "3000, numeric" '0x0\n3000.0' "${graphargs[@]}" 'PRINT:v:%0.1lf'
 


### PR DESCRIPTION
# Summary

## Context 

The `TUNE` command is not supported by rrdcached (see issue https://github.com/librenms/librenms/issues/4356). Running `rrdtool tune` with the `-D` argument is only used for FLUSH and still requires rrdcached and rrdtool to be using a shared filesystem.

## Solution

This PR aims to fix this by implementing the TUNE command in rrdcached and modifying rrdtool to properly run it on the remote server instead of locally when the `-D` argument is supplied.

# Testing

## Context

This PR originates from the fact that LibreNMS supports using a remote rrdcached for storage. Because rrdtool currently lacks the TUNE function over a remote rrdcached, issues arise when one tries to tune the ports [as described in the documentation](https://docs.librenms.org/Extensions/RRDTune/) (see also the issue mentioned above).

## Sample infrastructure

This patch was introduced within a production infrastructure that can be basically summarized like this:

```
+----------------------------------------------+
|                     librenms infrastructure  |
|                                              |
|                                              |
|                                              |
| +----------+      +-----------+              |
| | frontend |      | rrdcached |              |
| | 10.1.0.3 +------+ 10.1.0.42 |              |
| +----------+      +---+-+-+---+              |
|                       | | |                  |
|                       | | |                  |
|                       | | |                  |
|                    +--+-+-+--+               |
|                    | pollers |               |
|                    +---------+               |
|                                              |
+----------------------------------------------+
```

## Validating

We confirm that the patch is functional with the following steps, checked on `sample_hostname` with a port whose speed had recently been upgraded.

### Checking the RRD file

```shell
$ rrdtool info --daemon 10.1.0.42:42217 sample_hostname/port-id996775.rrd | head -30
[...]
ds[INOCTETS].max = 1.2500000000e+1
```

### Tuning using LibreNMS

```shell
$ cd /opt/librenms/ && cat config.d/rrdcached.php
<?php
$config['rrdcached'] = "10.1.0.42:42217";
$config['rrdtool_version'] = '1.7.2';
$ ./scripts/tune_port.php -h sample_hostname -p port-channel4094.3
Found hostname sample_hostname.......
Tuning port port-channel4094.3.......
$ exit
```

### Checking the RRD file again

```shell
$ rrdtool info --daemon 10.1.0.42:42217 sample_hostname/port-id996775.rrd | head -30
[...]
ds[INOCTETS].max = 2.5000000000e+10
```

# Notes

- **This patch is being tested within a production infrastructure and the PR description is updated as we get more insights**
- I am by no means a professional C developer, reviewers might want to take this into account!