### PR TITLE
Fix for a race condition in journal_write

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -3412,10 +3412,12 @@ static int journal_write(
 {                       /* {{{ */
     int       chars;
 
-    if (journal_fh == NULL)
-        return 0;
-
     pthread_mutex_lock(&journal_lock);
+    if (journal_fh == NULL) {
+        pthread_mutex_unlock(&journal_lock);
+        return 0;
+    }
+
     chars = fprintf(journal_fh, "%s %s\n", cmd, args);
     journal_size += chars;
 


### PR DESCRIPTION
There is a race condition in journal_write() where journal_lock is
being acquired after checking whether journal_fh is NULL or not.
journal_fh is a static file handle that can be set to NULL by any
other thread, while current thread is blocked by
pthread_mutex_lock(). This commit fixes this race condition.

Signed-off-by: Umer Saleem <usaleem@ixsystems.com>