### PR TITLE
Update vcpkg in Windows GitHub Actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -46,14 +46,14 @@ jobs:
         include:
           - os: windows-2019
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/50fd3d9957195575849a49fa591e645f1d8e7156
-            vcpkgCommitId: '50fd3d9957195575849a49fa591e645f1d8e7156'
+            # https://github.com/microsoft/vcpkg/commit/af2287382b1991dbdcb7e5112d236f3323b9dd7a
+            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2019
             triplet: x86-windows
-            vcpkgCommitId: '50fd3d9957195575849a49fa591e645f1d8e7156'
+            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -25,14 +25,14 @@ jobs:
         include:
           - os: windows-2019
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/50fd3d9957195575849a49fa591e645f1d8e7156
-            vcpkgCommitId: '50fd3d9957195575849a49fa591e645f1d8e7156'
+            # https://github.com/microsoft/vcpkg/commit/af2287382b1991dbdcb7e5112d236f3323b9dd7a
+            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2019
             triplet: x86-windows
-            vcpkgCommitId: '50fd3d9957195575849a49fa591e645f1d8e7156'
+            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''

--- a/win32/collect_rrdtool_vcpkg_files.bat
+++ b/win32/collect_rrdtool_vcpkg_files.bat
@@ -1,7 +1,7 @@
 @ echo off
 REM This script collects the built .exe and .dll files required for running RRDtool.
 REM It is supposed to be run after an MSVC build using nmake and libraries from vcpkg.
-REM Wolfgang Stöggl <c72578@yahoo.de>, 2017-2021.
+REM Wolfgang Stöggl <c72578@yahoo.de>, 2017-2022.
 
 REM Run the batch file with command line parameter x64 or x86
 if "%1"=="" (
@@ -56,7 +56,7 @@ xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\iconv-2.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\intl-8.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libpng16.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libxml2.dll %release_dir%
-xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\lzma.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\liblzma.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pango-1.0-0.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangocairo-1.0-0.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangoft2-1.0-0.dll %release_dir%


### PR DESCRIPTION
- Update vcpkg to current release 2022.03.10, commit [af22873](https://github.com/microsoft/vcpkg/commit/af2287382b1991dbdcb7e5112d236f3323b9dd7a)
- `win32/collect_rrdtool_vcpkg_files.bat`:
  `lzma.dll` is called `liblzma.dll` now
