### PR TITLE
Update version to 1.8.0 for MSVC builds

### DIFF
--- a/win32/librrd-8.rc
+++ b/win32/librrd-8.rc
@@ -19,7 +19,7 @@ BEGIN
     BEGIN
       VALUE "Comments", "RRDtool is available under the terms of the GNU General Public License V2 or later"
       VALUE "CompanyName", "The RRDtool Project, https://oss.oetiker.ch/rrdtool/"
-      VALUE "LegalCopyright", "Copyright (c) 1998-2019 Tobias Oetiker"
+      VALUE "LegalCopyright", "Copyright (c) 1997-2022 Tobias Oetiker"
       VALUE "FileDescription", "time-series data storage and display system"
       VALUE "ProductName", "RRDtool"
       VALUE "FileVersion", PACKAGE_VERSION

--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -8,10 +8,10 @@
 
 /* Version numbers are updated by the rrdtool-release script. */
 #define PACKAGE_MAJOR       1
-#define PACKAGE_MINOR       7
-#define PACKAGE_REVISION    2
-#define PACKAGE_VERSION     "1.7.2"
-#define NUMVERS             1.7002
+#define PACKAGE_MINOR       8
+#define PACKAGE_REVISION    0
+#define PACKAGE_VERSION     "1.8.0"
+#define NUMVERS             1.8000
 
 #define RRD_DEFAULT_FONT "Courier"
 

--- a/win32/rrdcgi.rc
+++ b/win32/rrdcgi.rc
@@ -19,7 +19,7 @@ BEGIN
     BEGIN
       VALUE "Comments", "RRDtool is available under the terms of the GNU General Public License V2 or later"
       VALUE "CompanyName", "The RRDtool Project, https://oss.oetiker.ch/rrdtool/"
-      VALUE "LegalCopyright", "Copyright (c) 1998-2019 Tobias Oetiker"
+      VALUE "LegalCopyright", "Copyright (c) 1997-2022 Tobias Oetiker"
       VALUE "FileDescription", "time-series data storage and display system"
       VALUE "ProductName", "RRDtool"
       VALUE "FileVersion", PACKAGE_VERSION

--- a/win32/rrdtool.rc
+++ b/win32/rrdtool.rc
@@ -19,7 +19,7 @@ BEGIN
     BEGIN
       VALUE "Comments", "RRDtool is available under the terms of the GNU General Public License V2 or later"
       VALUE "CompanyName", "The RRDtool Project, https://oss.oetiker.ch/rrdtool/"
-      VALUE "LegalCopyright", "Copyright (c) 1998-2019 Tobias Oetiker"
+      VALUE "LegalCopyright", "Copyright (c) 1997-2022 Tobias Oetiker"
       VALUE "FileDescription", "time-series data storage and display system"
       VALUE "ProductName", "RRDtool"
       VALUE "FileVersion", PACKAGE_VERSION

--- a/win32/rrdupdate.rc
+++ b/win32/rrdupdate.rc
@@ -19,7 +19,7 @@ BEGIN
     BEGIN
       VALUE "Comments", "RRDtool is available under the terms of the GNU General Public License V2 or later"
       VALUE "CompanyName", "The RRDtool Project, https://oss.oetiker.ch/rrdtool/"
-      VALUE "LegalCopyright", "Copyright (c) 1998-2019 Tobias Oetiker"
+      VALUE "LegalCopyright", "Copyright (c) 1997-2022 Tobias Oetiker"
       VALUE "FileDescription", "time-series data storage and display system"
       VALUE "ProductName", "RRDtool"
       VALUE "FileVersion", PACKAGE_VERSION


### PR DESCRIPTION
Includes version and copyright year updates to files in the win32
subdirectory after running the `rrdtool-release` script.