### PR TITLE
rrdtool-release: Create NUMVERS from VERSION file

### DIFF
--- a/rrdtool-release
+++ b/rrdtool-release
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2086,SC2046,SC2029
 set -e
 VERSION=$(cat VERSION)
-NUMVERS=$(perl -n -e 'm/NUMVERS=(\d+\.\d+)/ && print $1' configure)
+NUMVERS=$(perl -n -e 'my @x=split /\./;printf "%d.%d%03d", @x' VERSION)
 CURRENT_YEAR=$(date +"%Y")
 set -x
 perl -i -p -e 's/^\$VERSION.+/\$VERSION='$NUMVERS';/' bindings/perl-*/*.pm


### PR DESCRIPTION
In the script **`rrdtool-release`**, `NUMVERS` has been read from the
`configure` file so far, which may not be up-to-date.
Generate `NUMVERS` from the `VERSION` file instead. This ensures
that only one source is used for the version - the `VERSION` file.
Use the same perl command for creating `NUMVERS`, as in `configure.ac`