### PR TITLE
Fix BUILD_DATE in rrdtool help output

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -695,7 +695,7 @@ AC_MSG_RESULT(${COMP_PERL:-No Perl Modules will be built})
 
 # Use reproducible build date and time
 if test "$SOURCE_DATE_EPOCH"; then
-	DATE_FMT="%d %b %Y %H:%M:%S"
+	DATE_FMT="%b %d %Y %H:%M:%S"
 	BUILD_DATE=$(LC_ALL=C date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT")
 	AC_DEFINE_UNQUOTED([BUILD_DATE], ["$BUILD_DATE"], [Use reproducible build date])
 fi

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -45,11 +45,19 @@ static void PrintUsage(
     char *cmd)
 {
 
+#ifdef BUILD_DATE
+    const char *help_main =
+        N_("RRDtool %s"
+           "  Copyright by Tobias Oetiker <tobi@oetiker.ch>\n"
+           "               Compiled %s\n\n"
+           "Usage: rrdtool [options] command command_options\n");
+#else
     const char *help_main =
         N_("RRDtool %s"
            "  Copyright by Tobias Oetiker <tobi@oetiker.ch>\n"
            "               Compiled %s %s\n\n"
            "Usage: rrdtool [options] command command_options\n");
+#endif
 
     const char *help_list =
         N_


### PR DESCRIPTION
- This is a followup to #1102
- Fixes segfault when running "rrdtool --help"
- Change `DATE_FMT` to the same date format as the `__DATE__` macro [1]:
  mmm dd yyyy

[1] https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
