### PR TITLE
ci-workflow.yml: Add autotools to msys2

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,9 +5,10 @@ name: Windows CI
 # yamllint disable-line rule:truthy
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
+  workflow_dispatch:
 
 jobs:
   msys2:
@@ -30,7 +31,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: base-devel bc mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
+          install: base-devel bc mingw-w64-x86_64-autotools mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'


### PR DESCRIPTION
- Add `mingw-w64-x86_64-autotools` to "`install:`"
  Fixes:
  `./bootstrap: line 8: libtoolize: command not found`
  `./bootstrap: line 11: autoreconf: command not found`
- Minor modifications to `ci-workflow.yml`:
  * Fix yamllint errors in line 8 and 10:
    `too many spaces inside brackets`
  * Add "`workflow_dispatch:`" to allow manual run of the Windows CI
    workflow
