### PR TITLE
Fix tests under MSYS2 (Windows)

### DIFF
--- a/tests/graph1
+++ b/tests/graph1
@@ -5,7 +5,12 @@
 BASE=$BASEDIR/
 BUILD=$BUILDDIR/
 
-RRD=${BUILD}graph1.rrd
+if [ -n "$MSYSTEM" ]; then
+    # Avoid Windows drive letter issues in the path of DEF:vname=rrdfile under MSYS or MSYS2
+    RRD=graph1.rrd
+else
+    RRD=${BUILD}graph1.rrd
+fi
 
 $RRDTOOL create $RRD --start 920804400 DS:speed:COUNTER:600:U:U RRA:AVERAGE:0.5:1:24 RRA:AVERAGE:0.5:6:10
 report "create"

--- a/tests/rpn1
+++ b/tests/rpn1
@@ -5,7 +5,12 @@
 BASE=$BASEDIR/
 BUILD=$BUILDDIR/
 
-RRD=${BUILD}rpn1.rrd
+if [ -n "$MSYSTEM" ]; then
+    # Avoid Windows drive letter issues in the path of DEF:vname=rrdfile under MSYS or MSYS2
+    RRD=rpn1.rrd
+else
+    RRD=${BUILD}rpn1.rrd
+fi
 
 $RRDTOOL create $RRD --start 920804400 DS:speed:COUNTER:600:U:U RRA:AVERAGE:0.5:1:24 RRA:AVERAGE:0.5:6:10
 report "create"

--- a/tests/rpn2
+++ b/tests/rpn2
@@ -5,7 +5,12 @@
 BASE=$BASEDIR/
 BUILD=$BUILDDIR/
 
-RRD=${BUILD}rpn2.rrd
+if [ -n "$MSYSTEM" ]; then
+    # Avoid Windows drive letter issues in the path of DEF:vname=rrdfile under MSYS or MSYS2
+    RRD=rpn2.rrd
+else
+    RRD=${BUILD}rpn2.rrd
+fi
 
 $RRDTOOL create $RRD --step 7200 --start 1167487000 DS:speed:DCOUNTER:14000:U:U RRA:AVERAGE:0.5:1:30
 report "create"

--- a/tests/vformatter1
+++ b/tests/vformatter1
@@ -5,7 +5,12 @@
 BASE=$BASEDIR/
 BUILD=$BUILDDIR/
 
-RRD=${BUILD}vfmt1.rrd
+if [ -n "$MSYSTEM" ]; then
+    # Avoid Windows drive letter issues in the path of DEF:vname=rrdfile under MSYS or MSYS2
+    RRD=vfmt1.rrd
+else
+    RRD=${BUILD}vfmt1.rrd
+fi
 
 export TZ=UTC
 


### PR DESCRIPTION
This is a follow-up to commit 7cd748e considering running the tests
in Windows under MSYS2. A similar approach has already been used in
`tests\graph2` and `tests\xport1` (see also: 847d679)

- Updates the following tests:
  `graph1, rpn1, rpn2, vformatter1`
- Avoid Windows drive letter in the path of `DEF:vname=rrdfile`
  under MSYS or MSYS2. Use only the filename of the rrd and not
  the full path if environmental variable `MSYSTEM` is set.
