### PR TITLE
Fix unsigned integer overflow in rrdtool first

### DIFF
--- a/src/rrd_first.c
+++ b/src/rrd_first.c
@@ -113,7 +113,8 @@ time_t rrd_first_r(
     then = (rrd.live_head->last_up -
             rrd.live_head->last_up %
             (rrd.rra_def[rraindex].pdp_cnt * rrd.stat_head->pdp_step)) +
-        (timer * rrd.rra_def[rraindex].pdp_cnt * rrd.stat_head->pdp_step);
+        (timer * (long) rrd.rra_def[rraindex].pdp_cnt *
+         (long) rrd.stat_head->pdp_step);
   err_close:
     rrd_close(rrd_file);
   err_free:


### PR DESCRIPTION
This fixes a signed/unsigned conversion bug in the calculation of
"`then`". Background info:
`pdp_cnt` and `pdp_step` are both `unsigned long`, whereas `timer` is `signed`.
When multiplying signed and unsigned integers (same size), a signed is
implicitly typecast to unsigned.

- A similar fix has already been applied to `rrd_dump.c`
  in commit e193975
- Resolves #1140
