### PR TITLE
Add test for rrd_first()

### DIFF
--- a/tests/create-from-template-1
+++ b/tests/create-from-template-1
@@ -33,6 +33,10 @@ rm -f ${PREFIX}*.rrd ${PREFIX}*.xml
 $RRDTOOL create ${PREFIX}ax1.rrd --start $(($ST-1)) --step 60 DS:a:GAUGE:120:0:U DS:b:COUNTER:120:0:U $RRA
 report createax1
 
+# Test rrd_first(), #1140
+RRD_FIRST=$($RRDTOOL first ${PREFIX}ax1.rrd)
+[ $RRD_FIRST = 1299994020 ] ; report rrdtool first == $RRD_FIRST
+
 cp ${BASE}ax1.rrd ${BASE}ax1-copy.rrd
 
 UPDATEAx1=


### PR DESCRIPTION
Make use of existing test "`create-from-template-1`", which already
creates, updates and dumps rrds and add a test for `rrdtool first`.

- This is a test for issue #1140
