### PR TITLE
Update tarball download link in doc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
 
-RRDtool git - 2022-04-06
+RRDtool git - 2022-04-08
 ==========================
 
 Bugfixes
 --------
+* Update tarball download link in doc <c72578>
 * Fix unsigned integer overflow in rrdtool first. Add test for rrd_first() <c72578>
 * Fix tests under MSYS2 (Windows) <c72578>
 * Fix BUILD_DATE in rrdtool help output <c72578>

--- a/doc/rrdbuild.pod
+++ b/doc/rrdbuild.pod
@@ -55,7 +55,7 @@ Now make sure the BUILD_DIR exists and go there:
 Lets first assume you already have all the necessary libraries
 pre-installed.
 
- wget https://oss.oetiker.ch/rrdtool/pub/rrdtool-1.8.0.tar.gz
+ wget https://github.com/oetiker/rrdtool-1.x/releases/download/v1.8.0/rrdtool-1.8.0.tar.gz
  gunzip -c rrdtool-1.8.0.tar.gz | tar xf -
  cd rrdtool-1.8.0
  ./configure --prefix=$INSTALL_DIR && make && make install

--- a/rrdtool-release
+++ b/rrdtool-release
@@ -8,7 +8,8 @@ set -x
 perl -i -p -e 's/^\$VERSION.+/\$VERSION='$NUMVERS';/' bindings/perl-*/*.pm
 perl -i -p -e 's/RRDtool \d\S+/RRDtool '$VERSION'/; s/Copyright.+?Oetiker.+\d{4}/Copyright by Tobi Oetiker, 1997-'$CURRENT_YEAR'/' src/*.h src/*.c
 perl -i -p -e 's/^Version:.+/Version: '$VERSION'/' rrdtool.spec
-perl -i -p -e 's/rrdtool-[\.\d]+\d(pre\d+)?(rc\d+)?/rrdtool-'$VERSION'/g' doc/rrdbuild.pod
+perl -i -p -e 's/rrdtool-[\.\d]+\d(pre\d+)?(rc\d+)?/rrdtool-'$VERSION'/g;
+               s/v\d+\.\d+\.\d+/v'$VERSION'/' doc/rrdbuild.pod
 # Update version and Copyright years for MSVC builds
 perl -i -p -e 's/Copyright \(c\).+?Oetiker/Copyright (c) 1997-'$CURRENT_YEAR' Tobias Oetiker/' win32/*.rc
 perl -i -p -e 's/PACKAGE_MAJOR.+\d{1}/PACKAGE_MAJOR       '$(echo $VERSION | cut -d. -f1)'/;


### PR DESCRIPTION
The download location of the release tarball has been moved to GitHub.

- Update the download link in `doc/rrdbuild.pod`
- `rrdtool-release`:
  Add substitution of version in download subdirectory, e.g. `v1.8.0` in:
  `rrdtool-1.x/releases/download/v1.8.0/rrdtool-1.8.0.tar.gz`