### PR TITLE
Suppress several warnings of implicit fall through

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
 
-RRDtool git - 2022-04-08
+RRDtool git - 2022-04-28
 ==========================
 
 Bugfixes
 --------
+* Suppress warnings of implicit fall through <youpong>
 * Update tarball download link in doc <c72578>
 * Fix unsigned integer overflow in rrdtool first. Add test for rrd_first() <c72578>
 * Fix tests under MSYS2 (Windows) <c72578>

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -4889,7 +4889,7 @@ static int read_options(
 
         case '?':
             fprintf(stderr, "%s\n", options.errmsg);
-            /* no break */
+            /* fall through */
 
         case 'h':
             printf("RRDCacheD %s\n"

--- a/src/rrd_strtod.c
+++ b/src/rrd_strtod.c
@@ -110,8 +110,11 @@ double rrd_strtod(const char *str, char **endptr) {
     // Handle optional sign
     negative = 0;
     switch (*p) {
-       case '-': negative = 1; // Fall through to increment position
-       case '+': p++;
+       case '-':
+           negative = 1;
+           /* fall through */
+       case '+':
+           p++;
     }
 
     number = 0.;
@@ -153,8 +156,11 @@ double rrd_strtod(const char *str, char **endptr) {
         // Handle optional sign
         negative = 0;
         switch (*++p) {
-            case '-': negative = 1; // Fall through to increment pos
-            case '+': p++;
+            case '-':
+                negative = 1;
+                /* fall through */
+            case '+':
+                p++;
         }
 
         // Process string of digits


### PR DESCRIPTION
Suppress the warning message of the intentional fall through like bellow.

```
rrd_strtod.c:113:27: warning: this statement may fall through [-Wimplicit-fallthrough=]
  113 |        case '-': negative = 1; // Fall through to increment position
      |                  ~~~~~~~~~^~~
rrd_strtod.c:114:8: note: here
  114 |        case '+': p++;
      |        ^~~~
```