### PR TITLE
rewrite valstrfduration introduction

### DIFF
--- a/doc/rrdgraph_graph.pod
+++ b/doc/rrdgraph_graph.pod
@@ -197,7 +197,8 @@ A literal `%' character.
 
 =back
 
-Formatting values as duration is done using printf like conversion specifications:
+You can format values as duration using B<:valstrfduration> with the value being interpreted as milliseconds.
+Using printf like conversion specifications you can extract properties from the duration:
 
  - All non-conversion specification chars are copied unchanged
  - A conversion specification has format '%' [ ['0'] minwidth ] [ '.' precision ] conversion-specifier


### PR DESCRIPTION
This clarifies a section that took me more hours to understand that I'd like to admit.
While the interpretation as milliseconds is documented in rrdgraph.pod, it's only in a side note of `--left-axis-formatter`/`--right-axis-formatter`.

It also mentions `valstrfduration` to mirror the introduction paragraphs of `sftftime` and `valstrftime`, both of which quite clearly indicate that the next bit is about that. I think this should help the people looking at the doc with a search function.