### PR TITLE
Ensure Perl manpages install to mandir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -704,8 +704,9 @@ fi
 langpref=$prefix
 test "$langpref" = '$(DESTDIR)NONE' && langpref='$(DESTDIR)'$ac_default_prefix
 test "$langpref" = "NONE" && langpref=$ac_default_prefix
+langmandir=$mandir
 
-PERL_MAKE_OPTIONS="PREFIX=$langpref INSTALL_BASE= LIB=$langpref/lib/perl/$PERL_VERSION"
+PERL_MAKE_OPTIONS="PREFIX=$langpref INSTALL_BASE= LIB=$langpref/lib/perl/$PERL_VERSION INSTALLSITEMAN3DIR=$langmandir/man3"
 
 dnl pass additional perl options when generating Makefile from Makefile.PL
 AC_ARG_ENABLE(perl-site-install,


### PR DESCRIPTION
This PR ensures that the `$mandir` destination is used in `PERL_MAKE_OPTIONS` to set `INSTALLSITEMAN3DIR`, so that the man3 install dir will be based on `$mandir` instead of on `$prefix`, in case the `$mandir` destination differs from the default `$prefix`-based path.

It isn't written quite as paranoid as the other variable lookups in the file, I confess -- mostly for lack of ideas for how to address situations where the variable _doesn't_ contain the expected data. I'm not aware of any situations where `$mandir` would be unset or set to an unusable value; it should either be based on `$datarootdir` (which is based on `$prefix`) if defaulted, or it should contain the path passed in via `--mandir=`. But if that's **not** the case, unlike with `$ac_default_prefix` I wouldn't really know how to go about hand-defining an unconfigured mandir.

A `DESTDIR=` argument passed to `make install` _will_ still be prepended to the `INSTALLSITEMAN3DIR` path as usual.

Fixes #1177