### PR TITLE
Update vcpkg GitHub Action

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Disable git autocrlf
         run: git config --global core.autocrlf false
         shell: cmd
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo 'Running in MSYS2!'
           ./ci-build_MSYS2.sh
-      # - uses: actions/upload-artifact@v2
+      # - uses: actions/upload-artifact@v3
       #   with:
       #     name: test-suite.log
       #     path: tests/test-suite.log
@@ -51,14 +51,14 @@ jobs:
         include:
           - os: windows-2019
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/af2287382b1991dbdcb7e5112d236f3323b9dd7a
-            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
+            # https://github.com/microsoft/vcpkg/commit/a7b6122f6b6504d16d96117336a0562693579933
+            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2019
             triplet: x86-windows
-            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
+            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''
@@ -68,7 +68,7 @@ jobs:
     env:
       buildDir: '${{ github.workspace }}/build/'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -25,21 +25,21 @@ jobs:
         include:
           - os: windows-2019
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/af2287382b1991dbdcb7e5112d236f3323b9dd7a
-            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
+            # https://github.com/microsoft/vcpkg/commit/a7b6122f6b6504d16d96117336a0562693579933
+            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2019
             triplet: x86-windows
-            vcpkgCommitId: 'af2287382b1991dbdcb7e5112d236f3323b9dd7a'
+            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''
     env:
       buildDir: '${{ github.workspace }}/build/'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -63,7 +63,7 @@ jobs:
       - name: Collect files
         run: |
           win32\collect_rrdtool_vcpkg_files.bat ${{ matrix.configuration }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: deploy-rrdtool-MSVC-${{ matrix.configuration }}
           path: win32/nmake_release_${{ matrix.configuration }}_vcpkg/rrdtool-*-${{ matrix.configuration }}_vcpkg/

--- a/win32/collect_rrdtool_vcpkg_files.bat
+++ b/win32/collect_rrdtool_vcpkg_files.bat
@@ -61,7 +61,8 @@ xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pango-1.0-0.dll %release_d
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangocairo-1.0-0.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangoft2-1.0-0.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pangowin32-1.0-0.dll %release_dir%
-xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pcre.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pcre2-8.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\pixman-1-0.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\zlib1.dll %release_dir%
 
 popd


### PR DESCRIPTION
- Update vcpkg to current release 2023.02.24, commit [a7b6122](https://github.com/microsoft/vcpkg/commit/a7b6122f6b6504d16d96117336a0562693579933)
- Use actions/checkout@v3 and actions/upload-artifact@v3 in order to
  avoid the following warning:
  `Node.js 12 actions are deprecated.`
- `win32/collect_rrdtool_vcpkg_files.bat`:
  Add required `pcre2-8.dll` and `pixman-1-0.dll`
  Remove `pcre.dll`, which is not required anymore
