### PR TITLE
Update msys2 GitHub Action

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: base-devel bc mingw-w64-x86_64-autotools mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
+          install: base-devel bc groff mingw-w64-x86_64-autotools mingw-w64-x86_64-toolchain mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
       - name: CI-Build
         run: |
           echo 'Running in MSYS2!'

--- a/ci-build_MSYS2.sh
+++ b/ci-build_MSYS2.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 echo "MSYSTEM:     $MSYSTEM"
 echo "MINGW_CHOST: $MINGW_CHOST"
 ./bootstrap

--- a/win32/README-MinGW-w64
+++ b/win32/README-MinGW-w64
@@ -33,7 +33,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
  - i686 (32-bit)
    Install the required dependencies:
 
-   pacman -Sy --needed base-devel mingw-w64-i686-gcc mingw-w64-i686-cairo mingw-w64-i686-expat mingw-w64-i686-freetype mingw-w64-i686-gettext mingw-w64-i686-glib2 mingw-w64-i686-libpng mingw-w64-i686-libxml2 mingw-w64-i686-pango mingw-w64-i686-zlib mingw-w64-i686-pkgconf
+   pacman -Sy --needed base-devel groff mingw-w64-i686-gcc mingw-w64-i686-cairo mingw-w64-i686-expat mingw-w64-i686-freetype mingw-w64-i686-gettext mingw-w64-i686-glib2 mingw-w64-i686-libpng mingw-w64-i686-libxml2 mingw-w64-i686-pango mingw-w64-i686-zlib mingw-w64-i686-pkgconf
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap
@@ -43,7 +43,7 @@ Compiled binaries: rrdtool.exe rrdupdate.exe rrdcgi.exe librrd-8.dll
 - x86_64 (64-bit)
    Install the required dependencies:
 
-   pacman -Sy --needed base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
+   pacman -Sy --needed base-devel groff mingw-w64-x86_64-gcc mingw-w64-x86_64-cairo mingw-w64-x86_64-expat mingw-w64-x86_64-freetype mingw-w64-x86_64-gettext mingw-w64-x86_64-glib2 mingw-w64-x86_64-libpng mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pango mingw-w64-x86_64-zlib mingw-w64-x86_64-pkgconf
 
    Run the following commands from the rrdtool-1.x directory:
    ./bootstrap


### PR DESCRIPTION
- Add `groff` to required msys2 packages. It has been removed from group
  base-devel: msys2/MSYS2-packages@66a18d1
- Fixes configure error:
  `I need a copy of *nroff to format the documentation`
- `ci-build_MSYS2.sh`:
  Add `set -e` to the bash script.
  Otherwise CI seems OK despite a build error.
