### PR TITLE
doc/rrdbuild: Expand Debian build dependencies

### DIFF
--- a/doc/rrdbuild.pod
+++ b/doc/rrdbuild.pod
@@ -97,7 +97,9 @@ Make sure the RRDtool build system finds your new compiler
 Use apt-get to make sure you have all that is required. A number
 of packages will get added through dependencies.
 
- apt-get install libpango1.0-dev libxml2-dev
+ apt-get install autoconf autopoint build-essential
+ apt-get install groff-base libtool libpango1.0-dev libxml2-dev
+ apt-get install python3-dev python3-setuptools
 
 =head2 Gentoo
 


### PR DESCRIPTION
To build the project on a (lean) Debian Bookworm system, there are several more build dependencies which need to be installed in order for the `make` command to succeed.

Also add the build dependencies for python bindings.