### PR TITLE
Suppress more implicit fall through warnings.

### DIFF
--- a/src/rrd_create.c
+++ b/src/rrd_create.c
@@ -511,6 +511,7 @@ int parseRRA(
                     || atoi(*require_version) < atoi(RRD_VERSION4)) {
                     *require_version = RRD_VERSION4;    /* MHWPREDICT causes Version 4 */
                 }
+                /* intentional fall through */
             case CF_HWPREDICT:
                 token_min = 5;
                 /* initialize some parameters */
@@ -520,6 +521,7 @@ int parseRRA(
                 break;
             case CF_DEVSEASONAL:
                 token_min = 3;
+                /* intentional fall through */
             case CF_SEASONAL:
                 if (cf_id == CF_SEASONAL) {
                     token_min = 4;
@@ -527,7 +529,7 @@ int parseRRA(
                 /* initialize some parameters */
                 rra_def->par[RRA_seasonal_gamma].u_val = 0.1;
                 rra_def->par[RRA_seasonal_smoothing_window].u_val = 0.05;
-                /* fall through */
+                /* intentional fall through */
             case CF_DEVPREDICT:
                 if (cf_id == CF_DEVPREDICT) {
                     token_min = 3;

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -5677,6 +5677,7 @@ int rrd_graph_color(
             sscanf(color, "#%8lx%n", &col, &n);
             if (n == 9)
                 break;
+            /* intentional fall through */
         default:
             rrd_set_error("Color problem in %s", err);
         }


### PR DESCRIPTION
Especially in ``src/rrd_graph.c`` I'm not sure if I suppress an intentional fall through or that the compiler warning pointed to an actual potential bug.