### PR TITLE
Update vcpkg GitHub Action

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
-        os: [windows-2019]
+        # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
+        os: [windows-2022]
         carch: [x86_64]
     defaults:
       run:
@@ -45,20 +45,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
-        os: [windows-2019]
+        # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
+        os: [windows-2022]
         triplet: [x64-windows, x86-windows]
         include:
-          - os: windows-2019
+          - os: windows-2022
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/a7b6122f6b6504d16d96117336a0562693579933
-            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
+            # https://github.com/microsoft/vcpkg/commit/501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
+            vcpkgCommitId: '501db0f17ef6df184fcdbfbe0f87cde2313b6ab1'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
-          - os: windows-2019
+          - os: windows-2022
             triplet: x86-windows
-            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
+            vcpkgCommitId: '501db0f17ef6df184fcdbfbe0f87cde2313b6ab1'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''
@@ -88,5 +88,5 @@ jobs:
 
       - name: Build ${{ matrix.configuration }}
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.configuration }}
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.configuration }}
           nmake -f win32\Makefile_vcpkg.msc ${{ matrix.nmake_configuration }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -19,20 +19,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
-        os: [windows-2019]
+        # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
+        os: [windows-2022]
         triplet: [x64-windows, x86-windows]
         include:
-          - os: windows-2019
+          - os: windows-2022
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/a7b6122f6b6504d16d96117336a0562693579933
-            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
+            # https://github.com/microsoft/vcpkg/commit/501db0f17ef6df184fcdbfbe0f87cde2313b6ab1
+            vcpkgCommitId: '501db0f17ef6df184fcdbfbe0f87cde2313b6ab1'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
-          - os: windows-2019
+          - os: windows-2022
             triplet: x86-windows
-            vcpkgCommitId: 'a7b6122f6b6504d16d96117336a0562693579933'
+            vcpkgCommitId: '501db0f17ef6df184fcdbfbe0f87cde2313b6ab1'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''
@@ -58,7 +58,7 @@ jobs:
           additionalCachedPaths: ${{ env.buildDir }}/vcpkg_installed
       - name: Build ${{ matrix.configuration }}
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.configuration }}
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.configuration }}
           nmake -f win32\Makefile_vcpkg.msc ${{ matrix.nmake_configuration }}
       - name: Collect files
         run: |


### PR DESCRIPTION
- Update vcpkg to current release [2023.04.15](https://github.com/microsoft/vcpkg/releases/tag/2023.04.15), commit [501db0f](https://github.com/microsoft/vcpkg/commit/501db0f17ef6df184fcdbfbe0f87cde2313b6ab1)
- Current versions of libraries are e.g.:
  cairo 1.17.8, expat 2.5.0, fontconfig 2.14.2, freetype 2.12.1,
  gettext 0.21.1, glib 2.76.1, libpng 1.6.39, pango 1.50.12,
  pcre2 10.40, libxml2 2.10.3 and zlib 1.2.13
- Switch from `windows-2019` to `windows-2022`, which includes
  Visual Studio Enterprise 2022
