### PR TITLE
Fix for overlapping areas in transparent mode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ RRDtool - master ...
 
 Bugfixes
 --------
+* Fix ytop and ybase adjustments for overlaping area issue on transparent areas <turban>
 * Suppress warnings of implicit fall through <youpong>
 * Update tarball download link in doc <c72578>
 * Fix unsigned integer overflow in rrdtool first. Add test for rrd_first() <c72578>

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -4295,14 +4295,14 @@ int graph_paint_timestring(
                             ybase = extra;
                         }
                         if (im->slopemode == 0) {
-                            backY[++idxI] = ybase - 0.2;
+                            backY[++idxI] = ybase;
                             backX[idxI] = ii + im->xorigin - 1;
-                            foreY[idxI] = ytop + 0.2;
+                            foreY[idxI] = ytop;
                             foreX[idxI] = ii + im->xorigin - 1;
                         }
-                        backY[++idxI] = ybase - 0.2;
+                        backY[++idxI] = ybase;
                         backX[idxI] = ii + im->xorigin;
-                        foreY[idxI] = ytop + 0.2;
+                        foreY[idxI] = ytop;
                         foreX[idxI] = ii + im->xorigin;
                     }
                     /* close up any remaining area */


### PR DESCRIPTION
Fix for  Transparent Areas/Stacks are being overlayed, resulting in odd lines showing #1219 