### PR TITLE
Use new vcpkg libffi dll name ffi-8.dll

### DIFF
--- a/win32/collect_rrdtool_vcpkg_files.bat
+++ b/win32/collect_rrdtool_vcpkg_files.bat
@@ -43,7 +43,7 @@ xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\brotlidec.dll %release_dir
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\bz2.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\cairo-2.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libexpat.dll %release_dir%
-xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\libffi.dll %release_dir%
+xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\ffi-8.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\fontconfig-1.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\freetype.dll %release_dir%
 xcopy /Y /D %base_dir%\vcpkg\installed\%1-windows\bin\fribidi-0.dll %release_dir%


### PR DESCRIPTION
vcpkg has been updated to [2023.10.19 Release](https://github.com/microsoft/vcpkg/releases/tag/2023.10.19), commit [8eb5735](https://github.com/microsoft/vcpkg/commit/8eb57355a4ffb410a2e94c07b4dca2dffbee8e50) in #1235.
The name of `libffi.dll` has changed to `ffi-8.dll`.

- Update `collect_rrdtool_vcpkg_files.bat`, which is used by the
  `release-windows.yml` GitHub Action:
  libffi.dll -> ffi-8.dll
