### PR TITLE
rrd_rpncalc: Quiet gcc warning by copying one extra character.

### DIFF
--- a/src/rrd_rpncalc.c
+++ b/src/rrd_rpncalc.c
@@ -243,7 +243,7 @@ static short addop2str(
             rrd_set_error("failed to alloc memory in addop2str");
             return -1;
         }
-        strncpy(&((*result_str)[*offset]), op_str, op_len);
+        strncpy(*result_str + *offset, op_str, op_len + 1);
         *offset += op_len;
         return 1;
     }


### PR DESCRIPTION
gcc warns that strncpy truncates the copied string. Above the size allocated includes space for terminating zero. Include it in the copy.