### PR TITLE
Fix string truncation warnings related to PATH_MAX

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ Bugfixes
 * acinclude.m4: Include <stdlib.h> when using exit <ryandesign>
 * rrdtool-release: Create NUMVERS from VERSION file <c72578>
 * Avoids leaking of file descriptors in multi threaded programs by @ensc
+* Avoids potential unterminated string because of fixed PATH_MAX buffer
 
 Features
 --------


### PR DESCRIPTION
There are a number of places where rrdtool combines multiple PATH_MAX sized strings into one.

PATH_MAX is a constant that tends to work in practice a lot of the time but may not reflect the real capabilities of the system in real time.

In place of on-stack buffers of PATH_MAX size allocate memory dynamically. Initialize the pointers to NULL so they can be all freed unconditionally on exit.

Fixes: #1223

Note: this is not tested, and the changes are substantial. If this looks like a generally good way to do it it warrants running the code with valgrind or similar.

Also it is not clear that asprintf implementation is needed. configure tests for asprintf presence but a windows implementation is provided.