### PR TITLE
Fix extra reference of parameters of rrd_fetch_dbi_{long,double}

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Bugfixes
 * rrdtool-release: Create NUMVERS from VERSION file <c72578>
 * Avoids leaking of file descriptors in multi threaded programs by @ensc
 * Avoids potential unterminated string because of fixed PATH_MAX buffer
+* Fix extra reference of parameters of rrd_fetch_dbi_{long,double} <jamborm> 
 
 Features
 --------

--- a/src/rrd_fetch_libdbi.c
+++ b/src/rrd_fetch_libdbi.c
@@ -26,13 +26,13 @@ static char* _find_next_separator(char* start,char separator);
 static char* _find_next_separator_twice(char*start,char separator);
 static char _hexcharhelper(char c);
 static int _inline_unescape (char* string);
-static double rrd_fetch_dbi_double(dbi_result *result,int idx);
-static long rrd_fetch_dbi_long(dbi_result *result,int idx);
+static double rrd_fetch_dbi_double(dbi_result result,int idx);
+static long rrd_fetch_dbi_long(dbi_result result,int idx);
 
 /* the real code */
 
 /* helpers to get correctly converted values from DB*/
-static long rrd_fetch_dbi_long(dbi_result *result,int idx) {
+static long rrd_fetch_dbi_long(dbi_result result,int idx) {
   char *ptmp="";
   long value=DNAN;
   /* get the attributes for this filed */
@@ -89,7 +89,7 @@ static long rrd_fetch_dbi_long(dbi_result *result,int idx) {
   return value;
 }
 
-static double rrd_fetch_dbi_double(dbi_result *result,int idx) {
+static double rrd_fetch_dbi_double(dbi_result result,int idx) {
   char *ptmp="";
   double value=DNAN;
   /* get the attributes for this filed */


### PR DESCRIPTION
Functions rrd_fetch_dbi_long and rrd_fetch_dbi_double currently take the first parameter of type "bi_result result *" even though that is already a pointer and the use of that parameter suggests the extra indirection is not wanted.  What is more, the caller passes just "bi_result result" to the corresponding actual arguments which results in compile errors with GCC 14 because it now does not accept incompatible pointer types by default.