### PR TITLE
compat-cloexec: fix HAVE_DECL checks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* Fix MacOS Build error (no SOCK_CLOEXEC on mac) @ensc fixes oetiker#1261
 
 Features
 --------

--- a/src/compat-cloexec.c
+++ b/src/compat-cloexec.c
@@ -17,7 +17,7 @@
 
 inline static bool have_decl_o_cloexec(void)
 {
-#ifdef HAVE_DECL_O_CLOEXEC
+#if defined(HAVE_DECL_O_CLOEXEC) && HAVE_DECL_O_CLOEXEC
 	return true;
 #else
 	return false;

--- a/src/compat-cloexec.h
+++ b/src/compat-cloexec.h
@@ -3,11 +3,11 @@
 
 #include <rrd_config.h>
 
-#ifndef HAVE_DECL_O_CLOEXEC
+#if !defined(HAVE_DECL_O_CLOEXEC) || !HAVE_DECL_O_CLOEXEC
 #  define O_CLOEXEC 0
 #endif
 
-#ifndef HAVE_DECL_SOCK_CLOEXEC
+#if !defined(HAVE_DECL_SOCK_CLOEXEC) || !HAVE_DECL_SOCK_CLOEXEC
 #  define SOCK_CLOEXEC 0
 #endif
 


### PR DESCRIPTION
AC_CHECK_DECLS() always defines the related HAVE_DECL_xxx symbol (either as '1' or as '0').

Fix the related #if blocks to check for value instead of existence of this symbol.

https://github.com/oetiker/rrdtool-1.x/issues/1261