### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build-test-linux.yml
+++ b/.github/workflows/build-test-linux.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Disable git autocrlf
         run: git config --global core.autocrlf false
         shell: cmd
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo 'Running in MSYS2!'
           ./ci-build_MSYS2.sh
-      # - uses: actions/upload-artifact@v3
+      # - uses: actions/upload-artifact@v4
       #   with:
       #     name: test-suite.log
       #     path: tests/test-suite.log
@@ -68,7 +68,7 @@ jobs:
     env:
       buildDir: '${{ github.workspace }}/build/'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -52,4 +52,4 @@ jobs:
         (cd src && gcov *.gcno)
         (cd src && gcov .libs/*.gcno)
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3    
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,11 +37,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -52,7 +52,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
 #   - name: Autobuild
-#     uses: github/codeql-action/autobuild@v1
+#     uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -69,4 +69,4 @@ jobs:
        ./configure --disable-ruby
        make
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/release-source.yml
+++ b/.github/workflows/release-source.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Get Version
       id: get_version

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       buildDir: '${{ github.workspace }}/build/'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -63,7 +63,7 @@ jobs:
       - name: Collect files
         run: |
           win32\collect_rrdtool_vcpkg_files.bat ${{ matrix.configuration }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: deploy-rrdtool-MSVC-${{ matrix.configuration }}
           path: win32/nmake_release_${{ matrix.configuration }}_vcpkg/rrdtool-*-${{ matrix.configuration }}_vcpkg/


### PR DESCRIPTION
- The following GitHub Actions are deprecated:
  actions/checkout@v2, actions/checkout@v3,
  actions/upload-artifact@v3,
  codecov/codecov-action@v3,
  github/codeql-action/init@v1, github/codeql-action/analyze@v1
- Update GitHub Actions to current versions:
  actions/checkout@v4
  actions/upload-artifact@v4,
  codecov/codecov-action@v4,
  github/codeql-action/init@v3, github/codeql-action/analyze@v3
