### PR TITLE
rrdtool-python: Prefer Python3 over Python2.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Bugfixes
 * Fix MacOS Build error (no SOCK_CLOEXEC on mac) @ensc fixes oetiker#1261
 * Fix build on 32bits platforms (like armhf) when time_t is 64bits, fixes #1264
 * Fix compilation on illumos @hadfl
+* Python2.3 is deprecated and therefore, the Python bindings should use Python3 as default @pticon
 
 Features
 --------

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -41,6 +41,7 @@ def main():
                      'Programming Language :: Python :: 3.3',
                      'Programming Language :: Python :: 3.4',
                      'Programming Language :: Python :: 3.5',
+                     'Programming Language :: Python :: 3.10',
         ],
         ext_modules=[module],
         test_suite='tests'

--- a/configure.ac
+++ b/configure.ac
@@ -1018,7 +1018,7 @@ AC_ARG_ENABLE(python,AS_HELP_STRING([--disable-python],[do not build the python 
 
 if test  "$enable_python" = "yes"; then
 dnl Check for python
-AM_PATH_PYTHON(2.3,[],[enable_python=no])
+AM_PATH_PYTHON(3,[],[enable_python=no])
 AM_CHECK_PYTHON_HEADERS(,[enable_python=no;AC_MSG_WARN(could not find Python headers)])
 fi
 


### PR DESCRIPTION
Python2.3 is deprecated and therefore, the Python bindings should use Python3 as default.