### PR TITLE
Fix #1268 - Segmentation Fault with Constant Lines

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Bugfixes
 * Fix MacOS Build error (no SOCK_CLOEXEC on mac) @ensc fixes oetiker#1261
 * Fix build on 32bits platforms (like armhf) when time_t is 64bits, fixes #1264
 * Fix compilation on illumos @hadfl
+* Fix division by zero segfault when exporting a LINEx with a constant value
 
 Features
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Bugfixes
 * Fix MacOS Build error (no SOCK_CLOEXEC on mac) @ensc fixes oetiker#1261
 * Fix build on 32bits platforms (like armhf) when time_t is 64bits, fixes #1264
 * Fix compilation on illumos @hadfl
-* Fix issue where RRDtool detects a LINE or AREA with a contant numeric value as being exportable
+* Fix issue where RRDtool detects a LINE or AREA with a constant numeric value as being exportable
 
 Features
 --------

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Bugfixes
 * Fix MacOS Build error (no SOCK_CLOEXEC on mac) @ensc fixes oetiker#1261
 * Fix build on 32bits platforms (like armhf) when time_t is 64bits, fixes #1264
 * Fix compilation on illumos @hadfl
-* Fix division by zero segfault when exporting a LINEx with a constant value
+* Fix issue where RRDtool detects a LINE or AREA with a contant numeric value as being exportable
 
 Features
 --------

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -386,14 +386,10 @@ static int rrd_xport_fn(
             long      vidx = im->gdes[ref_list[i]].vidx;
             time_t    now = *start + dst_row * *step;
 
-            (*dstptr++) = im->gdes[vidx].data[(unsigned long)
-                                              floor((double)
-                                                    (now -
-                                                     im->gdes[vidx].start)
-                                                    / im->gdes[vidx].step)
-                                              * im->gdes[vidx].ds_cnt +
-                                              im->gdes[vidx].ds];
-
+            if (im->gdes[vidx].step > 0) {
+                (*dstptr++) = im->gdes[vidx].data[(unsigned long)
+                    floor((double) (now - im->gdes[vidx].start) / im->gdes[vidx].step) * im->gdes[vidx].ds_cnt + im->gdes[vidx].ds];
+            }
         }
     }
 

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -416,7 +416,7 @@ static int rrd_xport_fn(
             time_t     now = *start + dst_row * *step;
 
             if (im->gdes[vidx].step > 0) {
-                chosen_idx = ceil((double) (now - im->gdes[vidx].start) / im->gdes[vidx].step) * im->gdes[vidx].ds_cnt + im->gdes[vidx].ds;
+                chosen_idx = floor((double) (now - im->gdes[vidx].start) / im->gdes[vidx].step) * im->gdes[vidx].ds_cnt + im->gdes[vidx].ds;
 
                 (*dstptr++) = im->gdes[vidx].data[chosen_idx];
             }

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -296,7 +296,7 @@ static int rrd_xport_fn(
         case GF_LINE:
         case GF_AREA:
         case GF_STACK:
-            /* only count the gf if it's numeric otherwise it's a contant line */
+            /* only count the gf if it's numeric otherwise it's a constant line */
             if (!is_numeric(im->gdes[i].vname)) {
                 (*col_cnt) += dolines;
             }


### PR DESCRIPTION
* This issue occurs with the --add-jsontime for lines that are a constant value.  In this case, the variable `im->gdes[vidx].step` is always 0, which results in a division by zero segmentation fault.