### PR TITLE
Fix compatibility with Tcl 9.0

### DIFF
--- a/bindings/tcl/tclrrd.c
+++ b/bindings/tcl/tclrrd.c
@@ -26,6 +26,9 @@
 
 /* support pre-8.4 tcl */
 
+#if TCL_MAJOR_VERSION > 8
+#   define CONST84 const
+#endif
 #ifndef CONST84
 #   define CONST84
 #endif


### PR DESCRIPTION
The deprecated CONST84 was removed in 9.0.
