### PR TITLE
Update vcpkg GitHub Action

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -51,14 +51,14 @@ jobs:
         include:
           - os: windows-2022
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/8eb57355a4ffb410a2e94c07b4dca2dffbee8e50
-            vcpkgCommitId: '8eb57355a4ffb410a2e94c07b4dca2dffbee8e50'
+            # https://github.com/microsoft/vcpkg/commit/b02e341c927f16d991edbd915d8ea43eac52096c
+            vcpkgCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2022
             triplet: x86-windows
-            vcpkgCommitId: '8eb57355a4ffb410a2e94c07b4dca2dffbee8e50'
+            vcpkgCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -25,14 +25,14 @@ jobs:
         include:
           - os: windows-2022
             triplet: x64-windows
-            # https://github.com/microsoft/vcpkg/commit/8eb57355a4ffb410a2e94c07b4dca2dffbee8e50
-            vcpkgCommitId: '8eb57355a4ffb410a2e94c07b4dca2dffbee8e50'
+            # https://github.com/microsoft/vcpkg/commit/b02e341c927f16d991edbd915d8ea43eac52096c
+            vcpkgCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x64'
             nmake_configuration: 'USE_64BIT=1'
           - os: windows-2022
             triplet: x86-windows
-            vcpkgCommitId: '8eb57355a4ffb410a2e94c07b4dca2dffbee8e50'
+            vcpkgCommitId: 'b02e341c927f16d991edbd915d8ea43eac52096c'
             vcpkgPackages: 'cairo expat fontconfig freetype gettext glib libpng libxml2 pango pcre zlib'
             configuration: 'x86'
             nmake_configuration: ''


### PR DESCRIPTION
- Update vcpkg to current [2025.03.19](https://github.com/microsoft/vcpkg/releases/tag/2025.03.19) Release, commit [b02e341](https://github.com/microsoft/vcpkg/commit/b02e341c927f16d991edbd915d8ea43eac52096c)
- Current versions of libraries are e.g.:
  cairo 1.18.2, expat 2.6.4, fontconfig 2.15.0, freetype 2.13.3,
  gettext 0.22.5, glib 2.80.0, libpng 1.6.4, pango 1.56.1,
  pcre2 10.45, libxml2 2.13.5 and zlib 1.3.1
