### PR TITLE
Mark ruby bindings as ractor safe

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
-
+* Mark the Ruby bindings as Ractor safe @LevitatingBusinessMan
 * Fix Compatiblity with TCL-9 @yselkowitz
 * Correctly link Ruby Bindings @LevitatingBusinessMan
 * Fix MacOS Build error (no SOCK_CLOEXEC on mac) @ensc fixes oetiker#1261

--- a/bindings/ruby/extconf.rb
+++ b/bindings/ruby/extconf.rb
@@ -19,4 +19,5 @@ ABS_TOP_SRCDIR = ENV['ABS_TOP_SRCDIR'] || '../..'
 
 dir_config("rrd", ["#{ABS_TOP_BUILDDIR}/src", "#{ABS_TOP_SRCDIR}/src"], "#{ABS_TOP_BUILDDIR}/src/.libs")
 have_library("rrd", "rrd_create")
+have_func("rb_ext_ractor_safe", "ruby.h")
 create_makefile("RRD")

--- a/bindings/ruby/main.c
+++ b/bindings/ruby/main.c
@@ -371,6 +371,10 @@ VALUE rb_rrd_xport(
 void Init_RRD(
     )
 {
+    #if HAVE_RB_EXT_RACTOR_SAFE
+        rb_ext_ractor_safe(true);
+    #endif
+
     mRRD = rb_define_module("RRD");
     rb_eRRDError = rb_define_class("RRDError", rb_eStandardError);
 


### PR DESCRIPTION
My other PR isn't merged yet but I would also like for you to look at this one.

Ruby has a new method for concurrency called [Ractor](https://docs.ruby-lang.org/en/master/Ractor.htm)s.

For C bindings to be used inside a Ractor they need to be marked Ractor-safe:

> If an extension desires to be marked as Ractor-safe the extension should call rb_ext_ractor_safe(true) at the Init_ function for the extension, and all defined methods will be marked as Ractor-safe.

https://docs.ruby-lang.org/en/master/extension_rdoc.html#label-Appendix+F.+Ractor+support

I think all of the methods present in the bindings are inherently thread safe.
By marking them Ractor-safe ruby programs can generate graphs concurrently.

See also https://github.com/ruby/ruby/pull/3824 for more information concerning this method.
