### PR TITLE
configure: support Lua 5.5 library detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -879,12 +879,14 @@ LUA_EOF
       RRD_SEARCH_LIBS(lua_call, [#include <${lua_headerdir:+$lua_headerdir/}lua.h>], [0, 0, 0], lua$lua_vdot lua$lua_vndot lua,
         [AC_SEARCH_LIBS(luaL_openlibs, lua$lua_vdot lua$lua_vndot lua,
           [lua_havelib=LUA$lua_vndot],
-          [AC_SEARCH_LIBS(luaL_module, lualib$lua_vndot lualib$lua_vdot lualib,
-            [lua_havelib=$lua_vndot; $LUA -l compat-5.1 2>/dev/null;
-             test "$?" = "0" && LUA_HAVE_COMPAT51=HAVE_COMPAT51],
-            [AC_SEARCH_LIBS(luaL_openlib, lualib$lua_vdot lualib$lua_vndot lualib,
-              [lua_havelib=$lua_vndot],
-              [COMP_LUA=], [-lm])], [-lm])], [-lm])],
+          [AC_SEARCH_LIBS(luaL_openselectedlibs, lua$lua_vdot lua$lua_vndot lua,
+            [lua_havelib=LUA$lua_vndot],
+            [AC_SEARCH_LIBS(luaL_module, lualib$lua_vndot lualib$lua_vdot lualib,
+              [lua_havelib=$lua_vndot; $LUA -l compat-5.1 2>/dev/null;
+               test "$?" = "0" && LUA_HAVE_COMPAT51=HAVE_COMPAT51],
+              [AC_SEARCH_LIBS(luaL_openlib, lualib$lua_vdot lualib$lua_vndot lualib,
+                [lua_havelib=$lua_vndot],
+                [COMP_LUA=], [-lm])], [-lm])], [-lm])], [-lm])],
         [COMP_LUA=], [-lm])
       lua_libs=$LIBS
       LIBS=


### PR DESCRIPTION
This updates Lua library detection in `configure.ac` to handle Lua 5.5, where `luaL_openlibs` is a macro around `luaL_openselectedlibs`.

### What changed
- Kept the existing `luaL_openlibs` check as first choice.
- Added a fallback `AC_SEARCH_LIBS` check for `luaL_openselectedlibs`.
- Left existing legacy fallbacks (`luaL_module`, `luaL_openlib`) unchanged.

### Validation
- Regenerated `configure` from `configure.ac` in a temporary test copy.
- Ran `./configure` in that test copy to verify script generation/execution remained valid in this environment.

Fixes #1304