### PR TITLE
fix: add pkg-config fallback for Perl and Ruby bindings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Bugfixes
 * Fix compilation on illumos @hadfl
 * Python2.3 is deprecated and therefore, the Python bindings should use Python3 as default @pticon
 * Fix issue where RRDtool detects a LINE or AREA with a constant numeric value as being exportable
+* Add pkg-config fallback for Perl and Ruby bindings when building standalone @somethingwithproof
+* Export ABS_TOP_BUILDDIR to environment for Ruby extconf.rb during in-tree builds @somethingwithproof
 
 Features
 --------

--- a/bindings/Makefile.am
+++ b/bindings/Makefile.am
@@ -52,7 +52,10 @@ install-data-local:
 ruby:
 	-mkdir -p ${builddir}/ruby
 	( cd ${builddir}/ruby \
-          && $(RUBY) ${abs_srcdir}/ruby/extconf.rb \
+          && env \
+             ABS_TOP_SRCDIR=${abs_top_srcdir} \
+             ABS_TOP_BUILDDIR=${abs_top_builddir} \
+             $(RUBY) ${abs_srcdir}/ruby/extconf.rb \
           && $(MAKE) \
              EPREFIX=$(exec_prefix) \
              ABS_TOP_SRCDIR=${abs_top_srcdir} \

--- a/bindings/perl-shared/Makefile.PL
+++ b/bindings/perl-shared/Makefile.PL
@@ -26,13 +26,13 @@ if (($Config{'osname'} eq 'MSWin32' && $ENV{'OSTYPE'} eq '')) {
 			'ABSTRACT' => 'Round Robin Database Tool',
 		) : ()
 	);
-}else{
+} elsif ($ENV{'ABS_TOP_BUILDDIR'}) {
 	my $TOP_SRCDIR = $ENV{'ABS_TOP_SRCDIR'} || '../..';
 	my $TOP_BUILDDIR = $ENV{'ABS_TOP_BUILDDIR'} || '../..';
 	my $SRCDIR = $ENV{'ABS_SRCDIR'} || '.';
 	# if the last argument when calling Makefile.PL is RPATH=/... and ... is the
 	# path to librrd.so then the Makefile will be written such that RRDs.so knows
-	# where to find librrd.so later on ... 
+	# where to find librrd.so later on ...
 	my $R="";
 	if ($ARGV[-1] =~ /RPATH=(\S+)/){
 		pop @ARGV;
@@ -65,9 +65,31 @@ if (($Config{'osname'} eq 'MSWin32' && $ENV{'OSTYPE'} eq '')) {
 		# Perl will figure out which one is valid
 		#'dynamic_lib'  => {'OTHERLDFLAGS' => "$librrd -lm"},
 		'depend'       => {'RRDs.c' => "${TOP_BUILDDIR}/src/librrd.la"},
-		'LDFROM'       => '$(OBJECT) '.$librrd, 
+		'LDFROM'       => '$(OBJECT) '.$librrd,
 		'realclean'    => {FILES => 't/demo?.rrd t/demo?.png' },
 		($^O eq 'darwin') ? ( 'LDDLFLAGS'    => "-L${TOP_BUILDDIR}/src/.libs/ $Config{lddlflags}" ) : ()
 	);
-}
+} else {
+	# standalone build: use pkg-config to find system-installed librrd
+	my $cflags = `pkg-config --cflags librrd 2>/dev/null`;
+	my $libs   = `pkg-config --libs librrd 2>/dev/null`;
+	chomp($cflags, $libs);
 
+	unless ($cflags || $libs) {
+		die "pkg-config could not find librrd. Is rrdtool installed?\n"
+		  . "Try: brew install rrdtool (macOS) or apt install librrd-dev (Debian/Ubuntu)\n";
+	}
+
+	WriteMakefile(
+		'NAME'         => 'RRDs',
+		'VERSION_FROM' => 'RRDs.pm',
+		'DEFINE'       => "-DPERLPATCHLEVEL=$Config{PATCHLEVEL}",
+		'INC'          => $cflags,
+		'LIBS'         => [$libs],
+		'realclean'    => {FILES => 't/demo?.rrd t/demo?.png'},
+		($] ge '5.005') ? (
+			'AUTHOR'   => 'Tobias Oetiker (tobi@oetiker.ch)',
+			'ABSTRACT' => 'Round Robin Database Tool',
+		) : ()
+	);
+}

--- a/bindings/ruby/extconf.rb
+++ b/bindings/ruby/extconf.rb
@@ -3,21 +3,29 @@
 
 require 'mkmf'
 
-if /linux/ =~ RUBY_PLATFORM
-   $LDFLAGS += ' -Wl,--rpath -Wl,$(EPREFIX)/lib'
-elsif /solaris/ =~ RUBY_PLATFORM
-   $LDFLAGS += ' -R$(EPREFIX)/lib'
-elsif /hpux/ =~ RUBY_PLATFORM
-   $LDFLAGS += ' +b$(EPREFIX)/lib'
-elsif /aix/ =~ RUBY_PLATFORM
-   $LDFLAGS += ' -blibpath:$(EPREFIX)/lib'
+if ENV['ABS_TOP_BUILDDIR']
+   ABS_TOP_BUILDDIR = ENV['ABS_TOP_BUILDDIR'] || '../..'
+   ABS_TOP_SRCDIR = ENV['ABS_TOP_SRCDIR'] || '../..'
+
+   if /linux/ =~ RUBY_PLATFORM
+      $LDFLAGS += ' -Wl,--rpath -Wl,$(EPREFIX)/lib'
+   elsif /solaris/ =~ RUBY_PLATFORM
+      $LDFLAGS += ' -R$(EPREFIX)/lib'
+   elsif /hpux/ =~ RUBY_PLATFORM
+      $LDFLAGS += ' +b$(EPREFIX)/lib'
+   elsif /aix/ =~ RUBY_PLATFORM
+      $LDFLAGS += ' -blibpath:$(EPREFIX)/lib'
+   end
+
+   dir_config("rrd", ["#{ABS_TOP_BUILDDIR}/src", "#{ABS_TOP_SRCDIR}/src"], "#{ABS_TOP_BUILDDIR}/src/.libs")
+else
+   # standalone build: use pkg-config to find system-installed librrd
+   unless pkg_config('librrd')
+      abort "pkg-config could not find librrd. Is rrdtool installed?\n" \
+            "Try: brew install rrdtool (macOS) or apt install librrd-dev (Debian/Ubuntu)"
+   end
 end
 
-ABS_TOP_BUILDDIR = ENV['ABS_TOP_BUILDDIR'] || '../..'
-ABS_TOP_SRCDIR = ENV['ABS_TOP_SRCDIR'] || '../..'
-
-
-dir_config("rrd", ["#{ABS_TOP_BUILDDIR}/src", "#{ABS_TOP_SRCDIR}/src"], "#{ABS_TOP_BUILDDIR}/src/.libs")
 have_library("rrd", "rrd_create")
 have_func("rb_ext_ractor_safe", "ruby.h")
 create_makefile("RRD")


### PR DESCRIPTION
## Summary
- Perl and Ruby bindings fail to build standalone (outside autotools) because they hardcode in-tree paths
- Adds three-way detection: Windows (unchanged), in-tree (ABS_TOP_BUILDDIR), standalone (pkg-config)
- `die`/`abort` on missing librrd in standalone path instead of silent `exit 0`

## Test plan
- [ ] `perl Makefile.PL` with ABS_TOP_BUILDDIR set (in-tree build)
- [ ] `perl Makefile.PL` with librrd installed via pkg-config (standalone)
- [ ] `ruby extconf.rb` with both paths

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>