### PR TITLE
fix: add -S short option for --step in rrdtool xport

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Bugfixes
 Features
 --------
 * Add Georgian translation @NorwayFun
+* Add -S short option for --step in rrdtool xport @somethingwithproof fixes #1310
 
 RRDtool 1.9.0 - 2024-07-29
 ==========================

--- a/doc/rrdxport.pod
+++ b/doc/rrdxport.pod
@@ -8,7 +8,7 @@ B<rrdtool> B<xport>
 S<[B<-s>|B<--start> I<seconds>]>
 S<[B<-e>|B<--end> I<seconds>]>
 S<[B<-m>|B<--maxrows> I<rows>]>
-S<[B<--step> I<value>]>
+S<[B<-S>|B<--step> I<value>]>
 S<[B<--json>]>
 S<[B<-t>|B<--showtime>]>
 S<[B<--enumds>]>
@@ -52,7 +52,7 @@ In fact it is exactly the same, but the parameter was renamed to
 describe its purpose in this module. See I<rrdgraph> documentation
 for details.
 
-=item B<--step> I<value> (default automatic)
+=item B<-S>|B<--step> I<value> (default automatic)
 
 See L<rrdgraph> documentation.
 

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -98,7 +98,7 @@ int rrd_xport(
         {"start", 's', OPTPARSE_REQUIRED},
         {"end", 'e', OPTPARSE_REQUIRED},
         {"maxrows", 'm', OPTPARSE_REQUIRED},
-        {"step", 261, OPTPARSE_REQUIRED},
+        {"step", 'S', OPTPARSE_REQUIRED},
         {"enumds", 262, OPTPARSE_NONE},
         {"json", 263, OPTPARSE_NONE},
         {"showtime", 't', OPTPARSE_NONE},
@@ -121,7 +121,7 @@ int rrd_xport(
     while ((opt = optparse_long(&options, longopts, NULL)) != -1) {
 
         switch (opt) {
-        case 261:
+        case 'S':
             im.step = atoi(options.optarg);
             break;
         case 262:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,7 +5,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	dump-restore \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
-	create-from-template-1 dcounter1 vformatter1 xport1 list1 \
+	create-from-template-1 dcounter1 vformatter1 xport1 xport2 list1 \
 	pdp-calc1
 
 EXTRA_DIST = Makefile.am \

--- a/tests/xport2
+++ b/tests/xport2
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+if [ -n "$MSYSTEM" ]; then
+    BUILD=xport2
+else
+    BUILD=$BUILDDIR/xport2
+fi
+
+# Shared RRD: step=300, a single GAUGE DS, two RRAs.
+$RRDTOOL create ${BUILD}.rrd \
+    --start 1300000000 --step 300 \
+    DS:val:GAUGE:600:U:U \
+    RRA:AVERAGE:0.5:1:600 \
+    RRA:AVERAGE:0.5:12:144
+report "create"
+
+$RRDTOOL update ${BUILD}.rrd \
+    1300000300:10 1300000600:20 1300000900:30 \
+    1300001200:40 1300001500:50 1300001800:60 \
+    1300002100:70 1300002400:80 1300002700:90 \
+    1300003000:100
+report "update"
+
+is_cached && exit 0
+
+# --- -S is equivalent to --step ---
+OUT_LONG=$($RRDTOOL xport --step 300 \
+    -s 1300000000 -e 1300003000 \
+    DEF:v=${BUILD}.rrd:val:AVERAGE \
+    XPORT:v:val)
+report "xport --step long form"
+
+OUT_SHORT=$($RRDTOOL xport -S 300 \
+    -s 1300000000 -e 1300003000 \
+    DEF:v=${BUILD}.rrd:val:AVERAGE \
+    XPORT:v:val)
+report "xport -S short form"
+
+if [ "$OUT_LONG" = "$OUT_SHORT" ] ; then
+    ok "xport -S and --step produce identical output"
+else
+    fail 1 "xport -S and --step output differs"
+fi


### PR DESCRIPTION
## Summary
- `rrdtool xport` accepts `--step` but has no `-S` short option, unlike `rrdtool graph`
- Adds `-S` as the short form for `--step` in the getopt_long table

## Test plan
- [ ] `rrdtool xport -S 300 DEF:...` produces 300s step output
- [ ] `rrdtool xport --step 300 DEF:...` still works (no regression)

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>