### PR TITLE
parse_tick: shift the legend by 2 spaces for the "coloured-box"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Bugfixes
 * Escape control characters in JSON xport output per RFC 7159 @somethingwithproof fixes #1311
 * Add pkg-config fallback for Perl and Ruby bindings when building standalone @somethingwithproof
 * Export ABS_TOP_BUILDDIR to environment for Ruby extconf.rb during in-tree builds @somethingwithproof
+* Fix parse_tick: shift the legend by 2 spaces for the "coloured-box" @neo954 #1314
 
 Features
 --------

--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -1765,6 +1765,10 @@ static int parse_tick(
     dprintf("XAXIS : %i\n", gdp->xaxisidx);
     dprintf("YAXIS : %i\n", gdp->yaxisidx);
     dprintf("=================================\n");
+
+    /* shift the legend by 2 spaces for the "coloured-box"*/
+    legend_shift(gdp->legend);
+
     /* and return */
     return 0;
 }


### PR DESCRIPTION
The patch fixed the overlapping colored box and the legend.