### PR TITLE
Fix test xport3 under Windows msys2

### DIFF
--- a/tests/xport3
+++ b/tests/xport3
@@ -23,10 +23,11 @@ is_cached && exit 0
 
 xport_json() {
     local legend="$1"
-    $RRDTOOL xport --json \
+    local -n out="$2"
+    out=$($RRDTOOL xport --json \
         -s 1300000000 -e 1300000600 --step 300 \
         "DEF:v=${BUILD}.rrd:val:AVERAGE" \
-        "XPORT:v:${legend}"
+        "XPORT:v:${legend}")
 }
 
 # raw_legend_in_json <raw-json-output> <expected-escape-sequence>
@@ -48,35 +49,35 @@ if '$want' not in raw:
 }
 
 # --- Tab (0x09) → \t ---
-OUT=$(xport_json $'tab\there')
+xport_json $'tab\there' OUT
 RC=$?
 [ $RC -eq 0 ] || fail $RC "xport tab legend: non-zero exit"
 raw_legend_in_json "$OUT" '\\t'
 report "json legend tab escaped"
 
 # --- Backspace (0x08) → \b ---
-OUT=$(xport_json $'back\x08space')
+xport_json $'back\x08space' OUT
 RC=$?
 [ $RC -eq 0 ] || fail $RC "xport backspace legend: non-zero exit"
 raw_legend_in_json "$OUT" '\\b'
 report "json legend backspace escaped"
 
 # --- Form feed (0x0c) → \f ---
-OUT=$(xport_json $'form\x0cfeed')
+xport_json $'form\x0cfeed' OUT
 RC=$?
 [ $RC -eq 0 ] || fail $RC "xport formfeed legend: non-zero exit"
 raw_legend_in_json "$OUT" '\\f'
 report "json legend formfeed escaped"
 
 # --- Carriage return (0x0d) → \r ---
-OUT=$(xport_json $'cr\x0dend')
+xport_json $'cr\x0dend' OUT
 RC=$?
 [ $RC -eq 0 ] || fail $RC "xport CR legend: non-zero exit"
 raw_legend_in_json "$OUT" '\\r'
 report "json legend carriage-return escaped"
 
 # --- Raw control char SOH (0x01) → \u0001 ---
-OUT=$(xport_json $'soh\x01char')
+xport_json $'soh\x01char' OUT
 RC=$?
 [ $RC -eq 0 ] || fail $RC "xport SOH legend: non-zero exit"
 raw_legend_in_json "$OUT" '\\u0001'
@@ -86,7 +87,7 @@ report "json legend raw-ctrl-char escaped as uXXXX"
 # A legend of 200 SOH bytes expands to 200*6=1200 chars, exceeding dbuf (1024).
 # escapeJSON must truncate at the last complete escape boundary.
 LONG_LEGEND=$(python3 -c "import sys; sys.stdout.write('\x01' * 200)")
-OUT=$(xport_json "${LONG_LEGEND}")
+xport_json "${LONG_LEGEND}" OUT
 RC=$?
 [ $RC -eq 0 ] || fail $RC "xport truncation legend: non-zero exit"
 python3 -c "


### PR DESCRIPTION
Use bash nameref in function `xport_json()`.

- Fixes error: `FAILED: (rc=1) json legend carriage-return escaped`
- Using nameref instead of command substitution preserves `\r` in test
  `Carriage return (0x0d) → \r`
