### PR TITLE
Name /opt package rrdtool-1-opt and verify it installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
           set -e
           mkdir -p out
           # Copy only the binary rpm (not the src.rpm — design says binaries only)
-          cp ~/rpmbuild/RPMS/x86_64/rrdtool-${VERSION}-*.rpm out/
+          cp ~/rpmbuild/RPMS/x86_64/rrdtool-1.x-opt-${VERSION}-*.rpm out/
           ls -l out/
 
       - uses: actions/upload-artifact@v6
@@ -330,6 +330,31 @@ jobs:
           name: rpm-${{ matrix.tag }}
           path: out/*.rpm
           if-no-files-found: error
+
+      - name: Verify the rpm installs, coexists, and runs
+        env:
+          VERSION: ${{ needs.compute-version.outputs.version }}
+        run: |
+          set -e
+          # Install the distro rrdtool first to prove DB-level coexistence.
+          dnf install -y rrdtool
+          # Install our /opt package alongside it.
+          dnf install -y ./out/rrdtool-1.x-opt-${VERSION}-*.rpm
+          # Both packages must be in the rpm database at the same time.
+          rpm -q rrdtool rrdtool-1.x-opt
+          # The distro binary and ours both run, independently.
+          rrdtool --version
+          /opt/rrdtool/bin/rrdtool --version
+          # Functional smoke test of the /opt build.
+          cd /tmp
+          /opt/rrdtool/bin/rrdtool create smoke.rrd --start 1000000000 --step 300 \
+              DS:x:GAUGE:600:U:U RRA:AVERAGE:0.5:1:12
+          /opt/rrdtool/bin/rrdtool update smoke.rrd 1000000300:42
+          /opt/rrdtool/bin/rrdtool fetch smoke.rrd AVERAGE \
+              --start 1000000000 --end 1000000300
+          # The env helper must put our build first on PATH.
+          . /opt/rrdtool/bin/rrdtool-env.sh
+          test "$(command -v rrdtool)" = /opt/rrdtool/bin/rrdtool
 
   # ---------------------------------------------------------------------------
   # build-deb: per-distro container, builds a .deb via fpm from a staged
@@ -418,7 +443,7 @@ jobs:
           set -e
           mkdir -p out
           fpm -s dir -t deb \
-              -n rrdtool \
+              -n rrdtool-1.x-opt \
               -v "$VERSION" \
               --iteration "1~${DISTRO_TAG}" \
               --license "GPL-2.0-or-later WITH FLOSS-exception-1.0" \
@@ -443,6 +468,29 @@ jobs:
           name: deb-${{ matrix.tag }}
           path: out/*.deb
           if-no-files-found: error
+
+      - name: Verify the deb installs, coexists, and runs
+        run: |
+          set -e
+          # Install the distro rrdtool first to prove DB-level coexistence.
+          apt-get install -y rrdtool
+          # Install our /opt package alongside it.
+          apt-get install -y ./out/rrdtool-1.x-opt_*.deb
+          # Both packages must be in the dpkg database at the same time.
+          dpkg -l rrdtool rrdtool-1.x-opt
+          # The distro binary and ours both run, independently.
+          rrdtool --version
+          /opt/rrdtool/bin/rrdtool --version
+          # Functional smoke test of the /opt build.
+          cd /tmp
+          /opt/rrdtool/bin/rrdtool create smoke.rrd --start 1000000000 --step 300 \
+              DS:x:GAUGE:600:U:U RRA:AVERAGE:0.5:1:12
+          /opt/rrdtool/bin/rrdtool update smoke.rrd 1000000300:42
+          /opt/rrdtool/bin/rrdtool fetch smoke.rrd AVERAGE \
+              --start 1000000000 --end 1000000300
+          # The env helper must put our build first on PATH.
+          . /opt/rrdtool/bin/rrdtool-env.sh
+          test "$(command -v rrdtool)" = /opt/rrdtool/bin/rrdtool
 
   # ---------------------------------------------------------------------------
   # publish: only job that mutates the repo. Runs only after every build job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
           set -e
           mkdir -p out
           # Copy only the binary rpm (not the src.rpm — design says binaries only)
-          cp ~/rpmbuild/RPMS/x86_64/rrdtool-1.x-opt-${VERSION}-*.rpm out/
+          cp ~/rpmbuild/RPMS/x86_64/rrdtool-1-opt-${VERSION}-*.rpm out/
           ls -l out/
 
       - uses: actions/upload-artifact@v6
@@ -339,9 +339,9 @@ jobs:
           # Install the distro rrdtool first to prove DB-level coexistence.
           dnf install -y rrdtool
           # Install our /opt package alongside it.
-          dnf install -y ./out/rrdtool-1.x-opt-${VERSION}-*.rpm
+          dnf install -y ./out/rrdtool-1-opt-${VERSION}-*.rpm
           # Both packages must be in the rpm database at the same time.
-          rpm -q rrdtool rrdtool-1.x-opt
+          rpm -q rrdtool rrdtool-1-opt
           # The distro binary and ours both run, independently.
           rrdtool --version
           /opt/rrdtool/bin/rrdtool --version
@@ -443,7 +443,7 @@ jobs:
           set -e
           mkdir -p out
           fpm -s dir -t deb \
-              -n rrdtool-1.x-opt \
+              -n rrdtool-1-opt \
               -v "$VERSION" \
               --iteration "1~${DISTRO_TAG}" \
               --license "GPL-2.0-or-later WITH FLOSS-exception-1.0" \
@@ -475,9 +475,9 @@ jobs:
           # Install the distro rrdtool first to prove DB-level coexistence.
           apt-get install -y rrdtool
           # Install our /opt package alongside it.
-          apt-get install -y ./out/rrdtool-1.x-opt_*.deb
+          apt-get install -y ./out/rrdtool-1-opt_*.deb
           # Both packages must be in the dpkg database at the same time.
-          dpkg -l rrdtool rrdtool-1.x-opt
+          dpkg -l rrdtool rrdtool-1-opt
           # The distro binary and ours both run, independently.
           rrdtool --version
           /opt/rrdtool/bin/rrdtool --version

--- a/conftools/rrdtool-opt.spec
+++ b/conftools/rrdtool-opt.spec
@@ -7,7 +7,7 @@
 #
 # @VERSION@ is substituted by the release workflow before invoking rpmbuild.
 
-Name:           rrdtool-1.x-opt
+Name:           rrdtool-1-opt
 Version:        @VERSION@
 Release:        1%{?dist}
 Summary:        Round Robin Database Tool (upstream /opt build)

--- a/conftools/rrdtool-opt.spec
+++ b/conftools/rrdtool-opt.spec
@@ -7,7 +7,7 @@
 #
 # @VERSION@ is substituted by the release workflow before invoking rpmbuild.
 
-Name:           rrdtool
+Name:           rrdtool-1.x-opt
 Version:        @VERSION@
 Release:        1%{?dist}
 Summary:        Round Robin Database Tool (upstream /opt build)


### PR DESCRIPTION
## Summary

Follow-up to the release workflow (#1316). Fixes a package-naming bug and adds the package-installability testing that was missing.

**Package name collision.** The `/opt` package was built as `Name: rrdtool` (RPM) / `-n rrdtool` (fpm) — the *same name* as the distribution's `rrdtool` package. RPM and dpkg both key the package database on name, so the two could never be installed simultaneously: installing the `/opt` package would replace the distro one. That contradicts the design's stated goal ("users can have both installed simultaneously") and the package's own `%description`.

Renamed to **`rrdtool-1-opt`**:
- Distinct from the distro `rrdtool`, so both coexist in the package DB (files were already conflict-free under `/opt/rrdtool`).
- The major version `1` pins the SemVer compatibility boundary, so `dnf update` / `apt upgrade` stay within the backward-compatible 1.x line and never silently cross into a `rrdtool-2-opt`. Uses the concrete major version, matching distro convention for version-pinned names (`gcc-12`, `postgresql-15`, `python3`).
- The binary inside is unchanged — still `/opt/rrdtool/bin/rrdtool`. Only the *package* name changes: `dnf install rrdtool-1-opt` / `apt install rrdtool-1-opt`.

**Installability testing.** `build-rpm` and `build-deb` previously built and uploaded the packages but never installed them. Each job now ends with a verification step that:
- installs the distro `rrdtool` **and** our package, then asserts both are present (`rpm -q` / `dpkg -l`) — proving real DB-level coexistence;
- runs both the distro binary and `/opt/rrdtool/bin/rrdtool`;
- runs a `create` / `update` / `fetch` smoke test against the `/opt` build (exercises the binary + `librrd` via the baked-in RPATH);
- sources `rrdtool-env.sh` and confirms it puts the `/opt` build first on `PATH`.

A failed verification fails the job, which fails the whole workflow before `publish` runs — so a broken package can never reach a release.

## Files changed

- `conftools/rrdtool-opt.spec` — `Name: rrdtool` → `Name: rrdtool-1-opt` (`%setup -n rrdtool-%{version}` and `Source0` unchanged — those track the upstream tarball, not the package name)
- `.github/workflows/release.yml` — fpm `-n rrdtool-1-opt`, rpm collection glob updated, verification step added to both `build-rpm` and `build-deb`

## Note on the other question raised

"The release workflow should only ever run on master" — already enforced, no change needed. `release.yml` has only a `workflow_dispatch` trigger (no push/PR/tag triggers), `check-ci`'s first step hard-fails if `github.ref != refs/heads/master`, and every other job transitively `needs:` `check-ci`. A dispatch from any non-master branch stops at the first step.

## Test plan

Same as #1316 — only verifiable by an actual dispatch on GitHub:

- [ ] Dispatch the Release workflow; confirm `build-rpm` / `build-deb` verification steps pass
- [ ] Confirm `dnf install -y rrdtool` succeeds in the AlmaLinux 9 container (rrdtool is in EPEL, which the job already enables) — if not, that one line is the fix
- [ ] On a real host: `dnf install rrdtool-1-opt` (or `apt install`) alongside the distro `rrdtool`, confirm `rpm -q`/`dpkg -l` show both and each binary runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
