### PR TITLE
Fix RPM check-rpaths failure + Python env path; diagnose Ruby binding placement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,22 @@ jobs:
           make
           make install DESTDIR="$PWD/stage"
 
+      # Diagnostic: Ruby's mkmf ignores --prefix and installs the binding
+      # into Ruby's own tree. This step records where it actually landed
+      # and the mkmf variables that decided it, so the relocation fix can
+      # be made precisely. Read-only; never fails the job.
+      - name: Diagnose ruby binding placement
+        run: |
+          echo "=== bindings/ruby/Makefile key install vars ==="
+          grep -E '^(prefix|exec_prefix|libdir|rubylibprefix|RUBY_BASE_NAME|sitedir|sitelibdir|sitearchdir|ruby_version|sitearch|arch|RUBYARCHDIR|RUBYLIBDIR|target_prefix)[[:space:]]*=' \
+              bindings/ruby/Makefile || echo "(bindings/ruby/Makefile not found)"
+          echo "=== RRD.so location(s) in stage/ ==="
+          rrdso=$(find stage -name 'RRD.so')
+          echo "${rrdso:-(RRD.so not found in stage/)}"
+          echo "=== staged content outside /opt (expected: none) ==="
+          outside=$(find stage -mindepth 1 -maxdepth 1 -not -name opt)
+          echo "${outside:-(clean: only opt/ present)}"
+
       - name: Post-install touches (rpath + env helper)
         run: |
           set -e

--- a/conftools/rrdtool-env.sh.in
+++ b/conftools/rrdtool-env.sh.in
@@ -15,7 +15,7 @@ export PKG_CONFIG_PATH="$ROOT/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
 
 export PERL5LIB="$ROOT/lib/perl${PERL5LIB:+:$PERL5LIB}"
 
-PY_SP=$(ls -d "$ROOT"/lib/python*/site-packages 2>/dev/null | head -1)
+PY_SP=$(ls -d "$ROOT"/lib*/python*/site-packages 2>/dev/null | head -1)
 [ -n "$PY_SP" ] && export PYTHONPATH="$PY_SP${PYTHONPATH:+:$PYTHONPATH}"
 
 RB_ARCH=$(ls -d "$ROOT"/lib/ruby/*-* 2>/dev/null | head -1)

--- a/conftools/rrdtool-opt.spec
+++ b/conftools/rrdtool-opt.spec
@@ -7,6 +7,12 @@
 #
 # @VERSION@ is substituted by the release workflow before invoking rpmbuild.
 
+# Our binaries carry a deliberate RPATH of /opt/rrdtool/lib — that is how
+# they locate librrd without any system linker config. RHEL's check-rpaths
+# QA script rejects every non-standard RPATH and fails the build, so it
+# must be disabled for this package.
+%global __brp_check_rpaths %{nil}
+
 Name:           rrdtool-1-opt
 Version:        @VERSION@
 Release:        1%{?dist}


### PR DESCRIPTION
## Summary

The release workflow's RPM build failed in run [26024534669](https://github.com/oetiker/rrdtool-1.x/actions/runs/26024534669). Investigation found three issues; this PR fixes the two unambiguous ones and adds a diagnostic to pin down the third.

### 1. `check-rpaths` QA rejected our deliberate RPATH (the RPM failure)

`%install` failed because RHEL's `check-rpaths` QA script flags every non-standard RPATH as invalid — including the `/opt/rrdtool/lib` RPATH our binaries deliberately carry to locate `librrd` without any system linker config. That RPATH is the whole point of the design. Fixed with `%global __brp_check_rpaths %{nil}` in the spec.

### 2. Python env-script path bug

The build installs the Python binding under **`lib64`** on RHEL-family 64-bit (`/opt/rrdtool/lib64/python3.9/site-packages/...`), but `rrdtool-env.sh.in` only globbed `$ROOT/lib/python*`. A user sourcing the env script would get `ImportError`. Glob changed to `lib*`.

### 3. Ruby binding installs outside `/opt` — diagnostic added, fix deferred

Ruby's `mkmf` ignores `--prefix` and installed `RRD.so` into Ruby's own tree (`/usr/local/lib64/ruby/site_ruby/RRD.so`), outside `/opt/rrdtool`. RPM caught this as an unpackaged file. **`fpm` silently drops it** — so the three DEBs produced by run 26024534669 ship with *no Ruby binding at all*; do not publish those artifacts.

The exact relocation fix depends on the `mkmf`-generated Makefile variables, which differ by Ruby version. Rather than guess, this PR adds a read-only diagnostic step to `build-deb` (runs across Ubuntu 22.04 / 24.04 / Debian 12 — three Ruby versions) that dumps the `bindings/ruby/Makefile` install variables and where `RRD.so` actually landed. The Ruby relocation will be a focused follow-up once the next dispatch produces that data.

## Files changed

- `conftools/rrdtool-opt.spec` — `%global __brp_check_rpaths %{nil}`
- `conftools/rrdtool-env.sh.in` — Python glob `lib` → `lib*`
- `.github/workflows/release.yml` — diagnostic step in `build-deb`

## Expected state after this PR

- `check-rpaths` no longer fails the RPM build.
- The RPM build will **still fail** at `%files` with an unpackaged-file error for the stray Ruby `RRD.so`, until the follow-up relocates it. That next dispatch's `build-deb` logs will carry the diagnostic output needed to do so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
