### PR TITLE
Fix release matrix on new distros + modernize obsolete autoconf macros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
               freetype-devel libpng-devel zlib-devel \
               libxml2-devel glib2-devel libdbi-devel \
               perl-devel perl-ExtUtils-MakeMaker \
-              python3-devel \
+              python3-devel python3-setuptools \
               tcl-devel \
               lua-devel \
               ruby ruby-devel
@@ -512,7 +512,7 @@ jobs:
               --description "Round Robin Database Tool (upstream /opt build). Source /opt/rrdtool/bin/rrdtool-env.sh to use." \
               --depends "libcairo2" \
               --depends "libpango-1.0-0" \
-              --depends "libxml2" \
+              --depends "libxml2-16 | libxml2" \
               --depends "libpng16-16" \
               --depends "libfreetype6" \
               --depends "libdbi1" \

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* Modernize obsolete autoconf macros so configure regenerates cleanly with current autotools @oetiker
 
 Features
 --------

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ dnl Inspiration from http://autoconf-archive.cryp.to
 dnl tell automake the this script is for rrdtool
 
 dnl Minimum Autoconf version required.
-AC_PREREQ(2.59)
+AC_PREREQ([2.69])
 
 dnl the official version number is
 dnl a.b.c
@@ -170,7 +170,7 @@ dnl Check for the compiler and static/shared library creation.
 AC_PROG_CPP
 AC_PROG_CC
 AM_PROG_CC_C_O
-AC_PROG_LIBTOOL
+LT_INIT
 
 dnl Try to detect/use GNU features
 CFLAGS="$CFLAGS -D_GNU_SOURCE"
@@ -211,13 +211,11 @@ AC_SUBST(RRD_DEFAULT_FONT)
 CONFIGURE_PART(Checking for Header Files)
 
 dnl Checks for header files.
-AC_HEADER_STDC
 AC_HEADER_DIRENT
-AC_CHECK_HEADERS(langinfo.h stdint.h inttypes.h libgen.h features.h sys/stat.h sys/types.h fcntl.h fp_class.h malloc.h unistd.h ieeefp.h math.h sys/times.h sys/param.h sys/resource.h signal.h float.h stdio.h stdlib.h errno.h string.h ctype.h grp.h pwd.h glob.h)
+AC_CHECK_HEADERS(langinfo.h stdint.h inttypes.h libgen.h features.h sys/stat.h sys/types.h fcntl.h fp_class.h malloc.h unistd.h ieeefp.h math.h sys/time.h sys/times.h sys/param.h sys/resource.h signal.h float.h stdio.h stdlib.h errno.h string.h ctype.h grp.h pwd.h glob.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
-AC_HEADER_TIME
 AC_STRUCT_TM
 
 dnl figure out 'stuff' about
@@ -340,7 +338,7 @@ volatile int x;volatile float f;  ]], [[x = isinf(f)]])],[AC_MSG_RESULT(yes)
 
 dnl finite is BSD, isfinite is C99, so prefer the latter
 AC_CACHE_CHECK([whether isfinite is broken],[ac_cv_have_broken_isfinite],[
-AC_TRY_RUN([
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #ifdef HAVE_MATH_H
 #include <math.h>
 #endif
@@ -358,7 +356,7 @@ int main ()
 #endif
 #endif
 return 0;
-}],[ac_cv_have_broken_isfinite=no],[ac_cv_have_broken_isfinite=yes],[
+}]])],[ac_cv_have_broken_isfinite=no],[ac_cv_have_broken_isfinite=yes],[
 case "${target}" in
   hppa*-*-hpux*) ac_cv_have_broken_isfinite=yes ;;
   *-solaris2.8) ac_cv_have_broken_isfinite=yes ;;
@@ -394,15 +392,14 @@ GC_TIMEZONE()
 
 AC_CACHE_CHECK(whether sigwait has 2 arguments,
     ac_cv_libc_sigwait,
-    AC_TRY_COMPILE([
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
         #define _POSIX_PTHREAD_SEMANTICS
         #include <stdio.h>
-        #include <signal.h>],
-        [sigset_t sigs; int signo; sigwait(&sigs, &signo);],
-        AC_DEFINE(HAVE_SIGWAIT,1,[have two argument posix sigwait])
-        AC_MSG_RESULT(yes)
-        ,
-        AC_MSG_RESULT(no)
+        #include <signal.h>]],
+        [[sigset_t sigs; int signo; sigwait(&sigs, &signo);]])],
+        [AC_DEFINE(HAVE_SIGWAIT,1,[have two argument posix sigwait])
+        AC_MSG_RESULT(yes)],
+        [AC_MSG_RESULT(no)]
     )
 )
 
@@ -618,10 +615,10 @@ EX_CHECK_ALL(glib-2.0,   glib_check_version,            glib.h,                 
 
 AC_CACHE_CHECK([whether we need to include gthreads for g_thread_init],
     [ac_cv_glibc_g_thread_init],
-    [AC_TRY_COMPILE([#include <glib.h>],
-                    [#if !GLIB_CHECK_VERSION(2, 32, 0)
+    [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <glib.h>]],
+                    [[#if !GLIB_CHECK_VERSION(2, 32, 0)
                      # error "glib needs g_thread_init"
-                     #endif],
+                     #endif]])],
                      [AC_MSG_RESULT(no)],
                      [EX_CHECK_ALL(gthread-2.0, g_thread_init, glib.h, gthread-2.0, x.x.x, "", "")
                      AC_MSG_RESULT(yes)])])

--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -367,7 +367,7 @@ int main(void){
     if (! rrdinf > 0) {printf ("not inf > 0 ... "); return 1;}
     if (! -rrdinf < 0) {printf ("not -inf < 0 ... "); return 1;}
     return 0;
- }]])],[rd_cv_ieee_$2=yes],[rd_cv_ieee_$2=no],[$as_echo_n "(skipped ... cross-compiling) " >&6
+ }]])],[rd_cv_ieee_$2=yes],[rd_cv_ieee_$2=no],[AS_ECHO_N(["(skipped ... cross-compiling) "]) >&6
   # Bypass further checks
   rd_cv_ieee_works=yes])])
 dnl these we run regardless is cached or not
@@ -441,7 +441,7 @@ AC_SUBST(PYTHON_INCLUDES)
 dnl check if the headers exist:
 save_CPPFLAGS="$CPPFLAGS"
 CPPFLAGS="$CPPFLAGS $PYTHON_INCLUDES"
-AC_TRY_CPP([#include <Python.h>],dnl
+AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <Python.h>]])],dnl
 [AC_MSG_RESULT(found)
 $1],dnl
 [AC_MSG_RESULT(not found)
@@ -582,29 +582,29 @@ AC_DEFUN([GC_TIMEZONE], [
         AC_REQUIRE([AC_STRUCT_TM])
         AC_CACHE_CHECK([tm_gmtoff in struct tm], gq_cv_have_tm_gmtoff,
                 gq_cv_have_tm_gmtoff=no
-                AC_TRY_COMPILE([#include <stdlib.h>
+                AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>
                                 #include <time.h>
                                 #include <$ac_cv_struct_tm>
-                                ],
-                               [struct tm t;
+                                ]],
+                               [[struct tm t;
                                 t.tm_gmtoff = 0;
                                 exit(0);
-                                ],
-                               gq_cv_have_tm_gmtoff=yes
+                                ]])],
+                               [gq_cv_have_tm_gmtoff=yes]
                         )
         )
 
         AC_CACHE_CHECK([__tm_gmtoff in struct tm], gq_cv_have___tm_gmtoff,
                 gq_cv_have___tm_gmtoff=no
-                AC_TRY_COMPILE([#include <stdlib.h>
+                AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>
                                 #include <time.h>
                                 #include <$ac_cv_struct_tm>
-                                ],
-                               [struct tm t;
+                                ]],
+                               [[struct tm t;
                                 t.__tm_gmtoff = 0;
                                 exit(0);
-                                ],
-                               gq_cv_have___tm_gmtoff=yes
+                                ]])],
+                               [gq_cv_have___tm_gmtoff=yes]
                         )
         )
 
@@ -616,13 +616,13 @@ AC_DEFUN([GC_TIMEZONE], [
                 AC_DEFINE(TM_GMTOFF, __tm_gmtoff)
         else
                 AC_CACHE_CHECK(for timezone, ac_cv_var_timezone,
-                               [AC_TRY_LINK([
+                               [AC_LINK_IFELSE([AC_LANG_PROGRAM([[
                                              #include <time.h>
                                              extern long int timezone;
-                                ],
-                               [long int l = timezone;], 
-                                ac_cv_var_timezone=yes, 
-                                ac_cv_var_timezone=no)])
+                                ]],
+                               [[long int l = timezone;]])],
+                                [ac_cv_var_timezone=yes],
+                                [ac_cv_var_timezone=no])])
                 if test $ac_cv_var_timezone = yes; then
                         AC_DEFINE(HAVE_TIMEZONE,1,[is there an external timezone variable instead ?])
                 fi

--- a/src/rrd_config_bottom.h
+++ b/src/rrd_config_bottom.h
@@ -81,16 +81,10 @@
 #define _POSIX_THREAD_SAFE_FUNCTIONS 200112L
 #endif
 
-#ifdef TIME_WITH_SYS_TIME
+#ifdef HAVE_SYS_TIME_H
 # include <sys/time.h>
-# include <time.h>
-#else
-# ifdef HAVE_SYS_TIME_H
-#  include <sys/time.h>
-# else
-#  include <time.h>
-# endif
 #endif
+#include <time.h>
 
 #ifdef HAVE_SYS_TIMES_H
 # include <sys/times.h>
@@ -106,22 +100,7 @@ extern int getrusage(int, struct rusage *);
 #endif
 
 
-/* define strrchr, strchr and memcpy, memmove in terms of bsd funcs
-   make sure you are NOT using bcopy, index or rindex in the code */
-      
-#ifdef STDC_HEADERS
-# include <string.h>
-#else
-# ifndef HAVE_STRCHR
-#  define strchr index
-#  define strrchr rindex
-# endif
-char *strchr (), *strrchr ();
-# ifndef HAVE_MEMMOVE
-#  define memcpy(d, s, n) bcopy ((s), (d), (n))
-#  define memmove(d, s, n) bcopy ((s), (d), (n))
-# endif
-#endif
+#include <string.h>
 
 #ifdef NO_NULL_REALLOC
 # define rrd_realloc(a,b) ( (a) == NULL ? malloc( (b) ) : realloc( (a) , (b) ))


### PR DESCRIPTION
## Summary

Follow-up to the expanded DEB/RPM release matrix (AlmaLinux 8/10, Fedora, Ubuntu 26.04, Debian 13). The first release run with the new variants surfaced two hard build failures; this fixes them and also clears out the obsolete-autoconf-macro noise that newer autotools emit.

### Release blockers
- **RPM `almalinux:10` / Fedora** — Python 3.12+ no longer bundles `setuptools` with `python3-devel`, so the Python binding failed (`The setup requires setuptools`). Add `python3-setuptools` to the RPM build-deps (harmless on EL8/EL9).
- **DEB `ubuntu:26.04`** — Ubuntu 26.04 bumped libxml2 to 2.14 and renamed the runtime package `libxml2` → `libxml2-16`. The fpm dependency is now an alternative (`libxml2-16 | libxml2`) so apt resolves it on every distro in the matrix.

### Autoconf modernization
- `configure.ac`: `AC_PROG_LIBTOOL` → `LT_INIT`; `AC_TRY_RUN`/`AC_TRY_COMPILE` → `AC_RUN_IFELSE`/`AC_COMPILE_IFELSE`; drop obsolete `AC_HEADER_STDC` / `AC_HEADER_TIME`; quote `AC_PREREQ([2.69])` (2.69 = AlmaLinux 8's autoconf, the matrix floor).
- `rrd_config_bottom.h`: collapse the now-dead `STDC_HEADERS` / `TIME_WITH_SYS_TIME` branches. **`AC_HEADER_TIME` used to pull in `<sys/time.h>` implicitly**, so `sys/time.h` is added to `AC_CHECK_HEADERS` — otherwise `HAVE_SYS_TIME_H` is never defined and `gettimeofday` loses its declaration.
- `m4/acinclude.m4`: `AC_TRY_CPP`/`COMPILE`/`LINK` and `$as_echo_n` → modern equivalents. `AC_TRY_LINK_FUNC` in `ACX_PTHREAD` is left as-is (current autoconf does not flag it; not worth the risk).

The only obsolete-macro warnings left after this originate inside the bundled gettext m4 (`AM_GNU_GETTEXT`), which is regenerated by `autopoint` and not ours to edit.

## Test Plan
- [x] `./bootstrap` → exit 0, no build errors
- [x] Only gettext-origin obsolete-macro warnings remain
- [x] `gettimeofday` implicit-declaration regression caught and fixed (verified against pre-change CI build)
- [x] config detection intact — `HAVE_TM_GMTOFF`, `HAVE_ISFINITE`, `HAVE_SIGWAIT`, `HAVE_SYS_TIME_H` all still defined
- [x] `make check` — 28 passed, 0 failed, 0 errors
- [ ] `workflow_dispatch` release run: all 9 build jobs (4 RPM + 5 DEB) green — the real test of the two CI-blocker fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)