### PR TITLE
Fix Ubuntu deb dependency for pangocairo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,6 +546,7 @@ jobs:
               --description "Round Robin Database Tool (upstream /opt build). Source /opt/rrdtool/bin/rrdtool-env.sh to use." \
               --depends "libcairo2" \
               --depends "libpango-1.0-0" \
+              --depends "libpangocairo-1.0-0" \
               --depends "libxml2-16 | libxml2" \
               --depends "libpng16-16" \
               --depends "libfreetype6" \

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+- add missing cairo dependency for ubuntu package @peejaychilds
 
 Features
 --------


### PR DESCRIPTION
The Ubuntu 24.04 rrdtool-1-opt package installs successfully, but /opt/rrdtool/bin/rrdtool fails at runtime on a minimal host because libpangocairo-1.0.so.0 is missing:

  /opt/rrdtool/bin/rrdtool: error while loading shared libraries: libpangocairo-1.0.so.0: cannot open shared object file: No such file or directory

I hit this during an Ansible deployment: the package install task completed, but the subsequent version check failed when executing /opt/rrdtool/bin/rrdtool.

ldd shows that /opt/rrdtool/bin/rrdtool links against libpangocairo-1.0.so.0, but the generated deb metadata does not declare libpangocairo-1.0-0 as a dependency.

This adds libpangocairo-1.0-0 to the fpm --depends list.

Tested by rebuilding the Ubuntu 24.04 package from this workflow change. The generated package now includes libpangocairo-1.0-0 in Depends:

  Depends: libcairo2, libpango-1.0-0, libpangocairo-1.0-0, libxml2-16 | libxml2, libpng16-16, libfreetype6, libdbi1, zlib1g

I also tested installing the rebuilt package on Ubuntu 24.04 after removing rrdtool-1-opt and libpangocairo-1.0-0. apt pulled libpangocairo-1.0-0 in automatically, and both of these ran successfully:

  /opt/rrdtool/bin/rrdtool --version
  /opt/rrdtool/bin/rrdcached -V

ldd reported no missing shared libraries.