### PR TITLE
Detect nroff -Wbreak support at configure time (fixes #1323)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ Bugfixes
   fractional after SI scaling (e.g. values around 10G+), avoiding
   duplicate labels on tall graphs. Issue #1326 reported by @muusik,
   fixed by @oetiker
+* Detect nroff support for -Wbreak at configure time, so building the
+  text documentation works on systems with BSD-derived nroff (e.g.
+  macOS /usr/bin/nroff). Issue #1323 reported by @gigaimage, fixed by
+  @oetiker
 
 Features
 --------

--- a/configure.ac
+++ b/configure.ac
@@ -1038,6 +1038,17 @@ AC_PATH_PROGS(NROFF, [gnroff nroff])
 if test x$NROFF = x; then
   AC_MSG_ERROR([I need a copy of *nroff to format the documentation])
 fi
+dnl -Wbreak is a GNU groff extension used to silence "can't break line"
+dnl warnings; BSD-derived nroff (e.g. macOS /usr/bin/nroff) rejects it.
+AC_MSG_CHECKING([whether $NROFF supports -Wbreak])
+if $NROFF -man -Wbreak /dev/null >/dev/null 2>&1; then
+  NROFF_WBREAK="-Wbreak"
+  AC_MSG_RESULT([yes])
+else
+  NROFF_WBREAK=""
+  AC_MSG_RESULT([no])
+fi
+AC_SUBST(NROFF_WBREAK)
 AC_ARG_VAR(TROFF, [path to the local troff version])
 AC_PATH_PROGS(TROFF, [groff troff])
 if test x$TROFF = x; then

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -71,7 +71,7 @@ all-local: link man txt html-local
 	$(AM_V_GEN)@POD2MAN@ --release=$(VERSION) --center=rrdtool --section=3 $< > $@
 
 .1.txt .3.txt:
-	$(AM_V_GEN)GROFF_NO_SGR=1 @NROFF@ -man -Tlp -Wbreak $< > $@
+	$(AM_V_GEN)GROFF_NO_SGR=1 @NROFF@ -man -Tlp @NROFF_WBREAK@ $< > $@
 
 .1.pdf .3.pdf:
 	$(AM_V_GEN)@TROFF@ -man $< | ps2pdf - $@


### PR DESCRIPTION
## Summary

- `doc/Makefile.am` unconditionally passes `-Wbreak` to `nroff` when generating `.txt` from `.1`/`.3`, but `-Wbreak` is a GNU groff extension. macOS 12's `/usr/bin/nroff` is BSD-derived and rejects it with `invalid option -Wbreak`, aborting `make install` (reported in #1323 by @gigaimage).
- Feature-test the flag at configure time in `configure.ac` and substitute the result via `@NROFF_WBREAK@` in `doc/Makefile.am`. groff users keep the warning suppression; BSD-nroff users get a working build.

## Test plan

- [x] `autoreconf -fi` regenerates cleanly (only pre-existing warnings)
- [x] Linux groff: `checking whether /bin/nroff supports -Wbreak... yes` → `-Wbreak` retained in generated Makefile, `make rrdtool.txt` builds correctly
- [x] Simulated BSD-nroff (shim that rejects `-Wbreak`): `... supports -Wbreak... no` → flag dropped from generated Makefile rule
- [ ] Verify on actual macOS 12 (cannot reproduce locally; behavior validated via shim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)