### PR TITLE
Fix Perl $RRDs::VERSION monotonicity (fixes #1330)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,17 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
+  two-digit minor releases compare monotonically. The numeric version
+  now uses three-digit zero-padded minor and patch fields, e.g.
+  1.10.3 -> 1.010003 (previously 1.10003, which was numerically less
+  than 1.9.0 -> 1.9000). The same encoding is now used by `NUMVERS`
+  in `configure.ac` and `win32/rrd_config.h`. Note: consumers that
+  previously tested `$RRDs::VERSION >= 1.2` need to update their
+  checks (use `>= 1.002` or compare against the X.Y.Z string via the
+  `version` pragma) -- this is unavoidable given the existing format
+  could not represent two-digit minors monotonically. Issue #1330
+  reported by @ppisar, fixed by @oetiker
 * Y-axis labels keep enough fractional precision when the gridstep is
   fractional after SI scaling (e.g. values around 10G+), avoiding
   duplicate labels on tall graphs. Issue #1326 reported by @muusik,

--- a/bindings/perl-piped/RRDp.pm
+++ b/bindings/perl-piped/RRDp.pm
@@ -124,7 +124,7 @@ sub cmd (@);
 sub end ();
 sub read ();
 
-$VERSION=1.10003;
+$VERSION=1.010003;
 
 sub start ($){
   croak "rrdtool is already running"

--- a/bindings/perl-shared/RRDs.pm
+++ b/bindings/perl-shared/RRDs.pm
@@ -7,7 +7,7 @@ use vars qw(@ISA $VERSION);
 
 require DynaLoader;
 
-$VERSION=1.10003;
+$VERSION=1.010003;
 
 bootstrap RRDs $VERSION;
 

--- a/configure.ac
+++ b/configure.ac
@@ -683,11 +683,10 @@ AC_PATH_PROG(POD2MAN, pod2man, no)
 AC_PATH_PROG(POD2HTML, pod2html, no)
 
 dnl for testing a numerical version number comes handy
-dnl the released version are
-dnl a.bccc
-dnl the devel versions will be something like
-dnl a.b999yymmddhh
-NUMVERS=m4_esyscmd([perl -ne 'my @x=split /\./;printf "%d.%d%03d", @x' VERSION])
+dnl the released versions encode as a.bbbccc with three-digit zero-padded
+dnl minor and patch fields so the value stays monotonic for two-digit
+dnl minor releases (1.009000 < 1.010000 < 1.010003).
+NUMVERS=m4_esyscmd([perl -ne 'my @x=split /\./;printf "%d.%03d%03d", @x' VERSION])
 AC_SUBST(NUMVERS)
 
 AC_ARG_ENABLE(perl,AS_HELP_STRING([--disable-perl],[do not build the perl modules]),

--- a/conftools/bump-version.sh
+++ b/conftools/bump-version.sh
@@ -24,7 +24,10 @@ case "$VERSION" in
         ;;
 esac
 
-NUMVERS=$(printf '%s\n' "$VERSION" | perl -n -e 'my @x=split /\./;printf "%d.%d%03d", @x')
+# Format the numeric version with three-digit zero-padded minor and patch
+# so that comparison as a Perl decimal stays monotonic for two-digit minor
+# releases (e.g. 1.009000 < 1.010000 < 1.010003).
+NUMVERS=$(printf '%s\n' "$VERSION" | perl -n -e 'my @x=split /\./;printf "%d.%03d%03d", @x')
 CURRENT_YEAR=$(date +"%Y")
 
 set -x

--- a/win32/rrd_config.h
+++ b/win32/rrd_config.h
@@ -11,7 +11,7 @@
 #define PACKAGE_MINOR       10
 #define PACKAGE_REVISION    3
 #define PACKAGE_VERSION     "1.10.3"
-#define NUMVERS             1.10003
+#define NUMVERS             1.010003
 
 #define RRD_DEFAULT_FONT "Courier"
 


### PR DESCRIPTION
## Summary

Closes #1330.

The numeric version encoding used `%d.%d%03d`, which produced
`1.9.0 -> 1.9000` and `1.10.0 -> 1.10000`. As a Perl decimal,
`1.10000 < 1.9000`, so any consumer comparing `$RRDs::VERSION` against a
literal like `1.2` silently flipped from true to false at 1.10.0,
breaking e.g. `RRD::Simple`'s colon-escaping logic.

Switch the format string to `%d.%03d%03d` in both the autoconf macro
(`configure.ac`) and the release helper (`conftools/bump-version.sh`),
and propagate the new encoding into the Perl bindings and
`win32/rrd_config.h` via `bump-version.sh`. From 1.10.0 onward the value
is monotonic:

| Real version | Old NUMVERS | New NUMVERS |
|---|---|---|
| 1.7.2  | 1.7002  | 1.007002 |
| 1.9.0  | 1.9000  | 1.009000 |
| 1.10.0 | 1.10000 | 1.010000 |
| 1.10.3 | 1.10003 | 1.010003 |
| 1.11.0 | 1.11000 | 1.011000 |
| 2.0.0  | 2.0     | 2.000000 |

## Upgrade note (callout for the changelog)

This is a one-way format change. Code that previously tested
`$RRDs::VERSION >= 1.2` against any post-1.7 release will now see false
for every new-format release (since `1.010003 < 1.2` numerically).
Affected consumers should switch to either:

- a smaller numeric threshold (`>= 1.002`), or
- comparing against the X.Y.Z string via the `version` pragma.

The format could not be salvaged any other way -- two-digit minors are
not representable monotonically in the old encoding -- so the break is
unavoidable. `CHANGES` carries an upgrade note.

## Test plan
- [ ] `bash conftools/bump-version.sh 1.10.3` re-runs idempotently and produces `1.010003`
- [ ] `perl -e 'require "bindings/perl-shared/RRDs.pm"; print $RRDs::VERSION, "\n"'` prints `1.010003`
- [ ] `perl -e 'print ((1.009000 < 1.010000) ? "ok\n" : "fail\n")'` prints `ok` (sanity)
- [ ] `./bootstrap && ./configure` succeeds and the substituted `NUMVERS` in generated headers matches `1.010003`