### PR TITLE
Fix heap buffer overflow in checkUnusedValues() (alt. to #1329)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,15 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* Fix a 1-byte heap buffer overflow in `checkUnusedValues()` that
+  triggered `*** buffer overflow detected ***` SIGABRT under glibc
+  fortified `strcat()` when reporting unused graph arguments. The
+  function under-allocated by one byte and silently relied on that
+  overflow to make its trailing `:` strip land on the right index.
+  Refactored to size buffers correctly and prepend the separator
+  rather than build-then-strip, so the two no longer have to agree.
+  Reported and original fix attempt in PR #1329 by @ppisar,
+  refactored fix by @oetiker
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -120,39 +120,34 @@ char     *checkUnusedValues(
     parsedargs_t *pa)
 {
     char     *res = NULL;
-    size_t    len = 0;
+    size_t    used = 0;     /* current strlen(res) */
 
     for (int i = 0; i < pa->kv_cnt; i++) {
-        if (!pa->kv_args[i].flag) {
-            const size_t kvlen = strlen(pa->kv_args[i].keyvalue);
+        if (pa->kv_args[i].flag)
+            continue;
 
-            len += kvlen + 1;
+        const size_t kvlen = strlen(pa->kv_args[i].keyvalue);
+        const size_t sep   = res ? 1 : 0;             /* ':' before all but the first */
+        const size_t need  = used + sep + kvlen + 1;  /* + trailing NUL */
+        char        *t     = res ? (char *) realloc(res, need)
+                                 : (char *) malloc(need);
 
-            /* alloc/realloc if necessary and set to 0 */
-            if (res) {
-                char     *t = (char *) realloc(res, len);
-
-                if (!t) {
-                    return res;
-                }
-                res = t;
-            } else {
-                res = malloc(len);
-                if (!res) {
-                    return NULL;
-                }
-                *res = 0;
-            }
-            /* add key = value as originally given */
-            strncat(res, pa->kv_args[i].keyvalue, kvlen);
-            strcat(res, ":");
+        if (!t) {
+            return res;     /* keep what we have on OOM */
         }
+        if (!res) {
+            *t = 0;         /* initialize on first allocation */
+        }
+        res = t;
+
+        if (sep) {
+            res[used] = ':';
+        }
+        memcpy(res + used + sep, pa->kv_args[i].keyvalue, kvlen);
+        used += sep + kvlen;
+        res[used] = 0;
     }
-    /* if we got one, then strip the final : */
-    if (res) {
-        res[len - 1] = 0;
-    }
-    /* and return res */
+
     return res;
 }
 


### PR DESCRIPTION
## Summary

Counter-proposal to #1329 (kept that PR's commit message attribution).

@ppisar diagnosed a real 1-byte heap buffer overflow in `src/rrd_graph_helper.c:checkUnusedValues()` — glibc fortified `strcat()` SIGABRT in RRD-Simple-1.44 tests after upgrading to 1.10.0. PR #1329 fixes the overflow with a one-line `len = 1` change, but that change orphans the trailing-`:` strip at line 153, so the colon now survives in the error message (which @ppisar's own report shows: `"Unused Arguments \" ... CEST\r:\""`).

Root cause: the original function used the under-sized `len` *both* to allocate the buffer (`len - 1` byte short, hence the overflow) *and* to find the trailing `:` for the strip (`res[len - 1] = 0`). The bug and the strip were silently coupled — fixing one breaks the other.

## Approach

Rather than fix the indexing twice (`len = 1` *and* `res[len - 2] = 0`), refactor so the strip is gone:

- Track `used = strlen(res)` explicitly.
- Size each (re)allocation to exactly `used + sep + kvlen + 1`.
- Prepend `:` before all entries except the first.
- Use `memcpy` at the known offset rather than `strncat` (also avoids the per-iteration `strlen` walk).
- Preserve the realloc-OOM behaviour (return whatever was built).

Result string is identical to the *intended* behaviour of the original (e.g. `"alpha:beta"`, no trailing colon), and the buffer sizing and the content no longer have to agree by accident.

## Test plan

- [x] Function compiles with `-Wall -Werror` (the project's CI flags).
- [x] Standalone driver under `-fsanitize=address`, six cases:
  - empty list (no unused) → NULL
  - one unused → `"foo"`
  - two unused → `"foo=1:bar=2"`
  - mixed flagged/unflagged → `"alpha:beta"`
  - the timestamp-with-CR string from @ppisar's bug report → no overflow, NUL-terminated
  - all flagged → NULL
- [x] No ASan errors, no leaks.

The other failure @ppisar mentions — `Unused Arguments` for a `COMMENT` containing a literal `\r` — is a separate parsing bug, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)