### PR TITLE
Fix segfault on --x-grid without trailing format (#1291)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,14 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* Fix segfault when `--x-grid` is given without a trailing date-format
+  field. The `%n` conversion in `sscanf()` is not counted in its return
+  value, so `stroff` remained uninitialized when the input ended before
+  the final `:` separator; the subsequent `stroff != 0` guard read
+  garbage and could branch into `strdup()` with a bogus offset. Fixed by
+  initialising `stroff = 0` so a partial match safely falls through to
+  the existing "invalid x-grid format" error path. Issue #1291
+  reported by @anvilvapre, fixed by @oetiker
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -5019,7 +5019,7 @@ void rrd_graph_options(
     struct optparse *poptions,
     image_desc_t *im)
 {
-    int       stroff;
+    int       stroff = 0;
     char     *parsetime_error = NULL;
     char      scan_gtm[12], scan_mtm[12], scan_ltm[12], col_nam[12];
     char      double_str[41] = { 0 }, double_str2[41] = { 0 };


### PR DESCRIPTION
Closes #1291.

When `--x-grid` receives a value that is missing the trailing colon and date-format field (e.g. `MINUTE:1:MINUTE:5:MINUTE:30:0` instead of `MINUTE:1:MINUTE:5:MINUTE:30:0:%H:%M`), `sscanf()` returns 7 (the seven explicit conversion specifiers all match) but the `%n` assignment to `stroff` is never executed because `%n` is not counted in `sscanf`'s return value and the trailing `:` before it fails to match. This leaves `stroff` holding an uninitialized stack value; the guard `stroff != 0` then reads garbage and can direct execution into `strdup(optarg + stroff)` with a bogus offset, causing a segfault.

The fix is one character: initialize `int stroff = 0;` at its declaration in `rrd_graph_options()`. A partial match then leaves `stroff` as zero, the condition evaluates to false, and the code falls through to the existing `rrd_set_error("invalid x-grid format")` path — the correct behavior.

See triage analysis on #1291 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)