### PR TITLE
Accept zero delta in libdbi /derive (#550)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,11 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* libdbi /derive now returns 0 instead of NaN when the underlying
+  counter is constant (zero delta). Previously the strict `d_value > 0`
+  guard skipped zero deltas the same way it skips negative ones (counter
+  resets). Changed to `d_value >= 0`. Issue #550 reported by
+  @bitionaire, fix by @oetiker.
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_fetch_libdbi.c
+++ b/src/rrd_fetch_libdbi.c
@@ -706,8 +706,8 @@ rrd_fetch_fn_libdbi(
       r_value=DNAN;
       /* check for timestamp delta to be within an acceptable range */
       if ((d_timestamp>0)&&(d_timestamp<2*derive)) {
-	/* only handle positive delta - avoid wrap-arounds/counter resets showing up as spikes */
-	if (d_value>0) {
+	/* only handle non-negative delta - avoid wrap-arounds/counter resets showing up as spikes */
+	if (d_value>=0) {
 	  /* and normalize to per second */
 	  r_value=d_value/d_timestamp;
 	}


### PR DESCRIPTION
Closes #550.

## Problem

When using the `/derive` flag with a libdbi data source, a constant counter (zero delta between samples) returned NaN instead of 0. The guard `d_value > 0` treated a zero delta identically to a negative delta (counter reset / wrap-around).

## Fix

Change `d_value > 0` to `d_value >= 0` in `src/rrd_fetch_libdbi.c`. Negative deltas (counter resets) are still rejected as before; zero deltas now correctly produce 0.0.

## Change

One-character comparison operator change (`>` → `>=`) in `src/rrd_fetch_libdbi.c`, plus a CHANGES entry.

Reported by @bitionaire, fix by @oetiker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)