### PR TITLE
Preserve user-supplied --step in rrdtool xport (#1023)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,11 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* `rrdtool xport --step` is no longer silently overridden by the
+  xsize-derived minimum step. When the user explicitly supplies
+  `--step`, the supplied value is used as-is and the max() clamping
+  against `(end-start)/xsize` is skipped. Issue #1023 reported by
+  @mprahlad95, fix by @oetiker.
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -116,6 +116,7 @@ int rrd_xport(
     int       enumds = 0;
     int       json = 0;
     int       showtime = 0;
+    int       step_requested = 0;
 
     int       opt;
 
@@ -124,6 +125,7 @@ int rrd_xport(
         switch (opt) {
         case 'S':
             im.step = atoi(options.optarg);
+            step_requested = 1;
             break;
         case 262:
             enumds = 1;
@@ -193,7 +195,8 @@ int rrd_xport(
 
     im.start = start_tmp;
     im.end = end_tmp;
-    im.step = max((long) im.step, (im.end - im.start) / im.xsize);
+    if (!step_requested)
+        im.step = max((long) im.step, (im.end - im.start) / im.xsize);
 
     rrd_graph_script(options.argc, options.argv, &im, options.optind);
     if (rrd_test_error()) {


### PR DESCRIPTION
Closes #1023.

## Problem

`rrdtool xport --step N` was silently overridden because `src/rrd_xport.c:196` unconditionally applied:

```c
im.step = max((long) im.step, (im.end - im.start) / im.xsize);
```

This clamps the user-supplied step up to the xsize-derived minimum, so e.g. `--step 60` would be replaced by a larger value when the time range divided by xsize exceeded 60.

## Fix

Introduce a `step_requested` flag. When `--step` is explicitly provided, skip the `max()` clamping so the user's value is passed intact to `data_fetch` and the output honours the requested resolution.

The XML path is unaffected (the same code path is used for both XML and JSON output; the bug affected all output formats when `--step` was smaller than the xsize-computed minimum).

## Changes

- `src/rrd_xport.c`: Add `step_requested` flag; guard the `max()` with `if (!step_requested)`
- `CHANGES`: Bugfix entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)