### PR TITLE
Normalize NaN sign in rrdtool fetch output (#297)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* `rrdtool fetch` now always emits `nan` (never `-nan`) for unknown
+  values. GCC >= 4.4.4 may produce NaN with the sign bit set, and
+  glibc honours that sign in printf, breaking consumers (e.g. OpenNMS)
+  that match on the string `nan`. Fix by @oetiker. Issue #297.
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_tool.c
+++ b/src/rrd_tool.c
@@ -766,8 +766,13 @@ static int HandleInputLine(
 #else
                 printf("%10lu:", ti);
 #endif
-                for (ii = 0; ii < ds_cnt; ii++)
-                    printf(" %0.10e", *(datai++));
+                for (ii = 0; ii < ds_cnt; ii++) {
+                    rrd_value_t val = *(datai++);
+                    if (isnan(val))
+                        printf(" %16s", "nan");
+                    else
+                        printf(" %0.10e", val);
+                }
                 printf("\n");
             }
             for (i = 0; i < ds_cnt; i++)


### PR DESCRIPTION
Closes #297.

GCC >= 4.4.4 may produce NaN values with the sign bit set, and modern glibc honours that sign in `printf`, causing `rrdtool fetch` to emit `-nan` for unknown values on RHEL 6 x86_64 and similar systems. Consumers such as OpenNMS match on the literal string `nan`, so the leading minus breaks them.

The fix checks `isnan()` before formatting each value in the fetch output loop, and emits the fixed string `nan` (right-aligned to preserve column width) instead of relying on `%e` conversion which leaks the sign bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)