### PR TITLE
Tolerate trailing : in graph element args (#655)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,12 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* A trailing colon in a graph element argument string (e.g.
+  `AREA:vname#color:Legend :`) caused `parseArguments()` to emit an
+  empty positional token that `checkUnusedValues()` then flagged as
+  `Unused Arguments "" in command: ...`. Fix: skip empty tokens
+  produced by a trailing (or consecutive) `:` separator.
+  Issue #655 reported by @Phhere, fix by @oetiker.
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -304,6 +304,11 @@ int parseArguments(
         case ':':{
             /* null and : separate the string */
             *pos = 0;
+            /* skip empty token (e.g. trailing colon in "Legend :")  */
+            if (*field == 0) {
+                field = NULL;
+                break;
+            }
             /* flag to say we are positional */
             //int ispos=0;
             /* handle the case where we have got an = */


### PR DESCRIPTION
Closes #655.

## Problem

A trailing colon in a graph element argument string such as

```
AREA:vname#color:Legend :
```

caused `parseArguments()` to emit an empty positional token. The
`do...while` loop resets `field` to `NULL` after each separator, then
at the top of the next iteration sets `field = pos` (pointing at the
end-of-string NUL). The `case 0:` handler then processes that empty
string as a positional argument. `checkUnusedValues()` subsequently
flags it as:

```
Unused Arguments "" in command: ...
```

## Fix

In the `case 0: / case ':':` block, after zeroing `*pos`, check whether
`*field == 0` (empty token). If so, reset `field = NULL` and break
without adding anything to the argument list. This also silently
discards consecutive `::` separators.

The change is 5 lines in `parseArguments()` and does not touch
`checkUnusedValues()`, so it composes cleanly with the recent #1329
heap-overflow fix in that function.

Reported by @Phhere, fix by @oetiker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)