### PR TITLE
Fix rrdtool info truncation on empty last_ds via rrdcached (#1080)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,11 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* Fix rrdcached client truncating `rrdtool info` output when a DS's
+  `last_ds` is the empty string. The protocol parser treated a missing
+  third token as a fatal error; now an empty value is accepted for
+  string-typed fields. Issue #1080 reported by @DeHackEd, fix by
+  @oetiker.
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -1327,7 +1327,7 @@ rrd_info_t *rrd_client_info(
                 break;
             }
         }
-        if (!*s)
+        if (!*s && itype != RD_I_STR)
             break;
         /* finally, we're pointing to the value */
         switch (itype) {


### PR DESCRIPTION
Closes #1080.

When a DS has a `last_ds` value that is the empty string, the rrdcached daemon emits a protocol line with no third token (`key type \n`). The client parser in `rrd_client_info()` (rrd_client.c) checked `if (!*s) break` after extracting the type code, treating an empty value pointer as a fatal protocol error and aborting the entire info response loop — silently truncating all subsequent output.

The fix gates that break on the type: for `RD_I_STR` an empty third token is perfectly valid (the pointer already sits at the null terminator, and `strdup("")` produces the correct empty string), so only non-string numeric types still trigger the fatal-error path.

The change is one line in `rrd_client.c` and is fully backward-compatible — no daemon changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)