### PR TITLE
Add daemon dispatch for rrdtool lastupdate (#1293)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,12 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* `rrdtool lastupdate --daemon host:port file.rrd` now correctly
+  dispatches to the rrdcached daemon instead of erroring with
+  "No such file or directory". Added `rrdc_lastupdate()` and
+  `rrd_client_lastupdate()` client functions and a corresponding
+  `LASTUPDATE` command in the daemon. Issue #1293
+  reported by @FlyveHest, fix by @oetiker
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/librrd.sym
+++ b/src/librrd.sym
@@ -90,6 +90,7 @@ rrdc_info
 rrdc_is_any_connected
 rrdc_is_connected
 rrdc_last
+rrdc_lastupdate
 rrdc_list
 rrdc_ping
 rrdc_stats_free

--- a/src/rrd_client.c
+++ b/src/rrd_client.c
@@ -1586,6 +1586,149 @@ time_t rrdc_last(
     return t;
 }                       /* }}} int rrdc_last */
 
+int rrd_client_lastupdate(
+    rrd_client_t *client,
+    const char *filename,   /* {{{ */
+    time_t *ret_last_update,
+    unsigned long *ret_ds_count,
+    char ***ret_ds_names,
+    char ***ret_last_ds)
+{
+    char      buffer[RRD_CMD_MAX];
+    char     *buffer_ptr;
+    size_t    buffer_free;
+    size_t    buffer_size;
+    rrdc_response_t *res;
+    int       status;
+    char     *file_path;
+    unsigned long ds_count;
+    size_t    i;
+
+    if (client == NULL)
+        return -1;
+    if (filename == NULL) {
+        rrd_set_error("rrdc_lastupdate: no filename");
+        return (-1);
+    }
+
+    memset(buffer, 0, sizeof(buffer));
+    buffer_ptr = &buffer[0];
+    buffer_free = sizeof(buffer);
+
+    status = buffer_add_string("lastupdate", &buffer_ptr, &buffer_free);
+    if (status != 0) {
+        rrd_set_error("rrdc_lastupdate: out of memory");
+        return (-1);
+    }
+
+    file_path = get_path(client, filename);
+    if (file_path == NULL) {
+        return (-1);
+    }
+
+    status = buffer_add_string(file_path, &buffer_ptr, &buffer_free);
+    free(file_path);
+
+    if (status != 0) {
+        rrd_set_error("rrdc_lastupdate: out of memory");
+        return (-1);
+    }
+
+    assert(buffer_free < sizeof(buffer));
+    buffer_size = sizeof(buffer) - buffer_free;
+    assert(buffer[buffer_size - 1] == ' ');
+    buffer[buffer_size - 1] = '\n';
+
+    res = NULL;
+    status = request(client, buffer, buffer_size, &res);
+
+    if (status != 0)
+        return (-1);
+    if (res->status < 0) {
+        response_free(res);
+        return (-1);
+    }
+
+    /* The status line message contains the timestamp */
+    *ret_last_update = (time_t) atol(res->message);
+    ds_count = (unsigned long) res->lines_num;
+
+    *ret_ds_names = (char **) calloc(ds_count, sizeof(char *));
+    if (*ret_ds_names == NULL) {
+        rrd_set_error("rrdc_lastupdate: out of memory");
+        response_free(res);
+        return (-1);
+    }
+
+    *ret_last_ds = (char **) calloc(ds_count, sizeof(char *));
+    if (*ret_last_ds == NULL) {
+        rrd_set_error("rrdc_lastupdate: out of memory");
+        free(*ret_ds_names);
+        *ret_ds_names = NULL;
+        response_free(res);
+        return (-1);
+    }
+
+    /* Each response line has the format: "<dsname> <lastvalue>" */
+    for (i = 0; i < ds_count; i++) {
+        char     *line = res->lines[i];
+        char     *space = strchr(line, ' ');
+
+        if (space == NULL) {
+            rrd_set_error("rrdc_lastupdate: malformed response line: %s", line);
+            /* free what we've allocated so far */
+            for (size_t j = 0; j < i; j++) {
+                free((*ret_ds_names)[j]);
+                free((*ret_last_ds)[j]);
+            }
+            free(*ret_ds_names);
+            *ret_ds_names = NULL;
+            free(*ret_last_ds);
+            *ret_last_ds = NULL;
+            response_free(res);
+            return (-1);
+        }
+        *space = '\0';
+        (*ret_ds_names)[i] = strdup(line);
+        (*ret_last_ds)[i]  = strdup(space + 1);
+
+        if ((*ret_ds_names)[i] == NULL || (*ret_last_ds)[i] == NULL) {
+            rrd_set_error("rrdc_lastupdate: out of memory");
+            for (size_t j = 0; j <= i; j++) {
+                if ((*ret_ds_names)[j]) free((*ret_ds_names)[j]);
+                if ((*ret_last_ds)[j])  free((*ret_last_ds)[j]);
+            }
+            free(*ret_ds_names);
+            *ret_ds_names = NULL;
+            free(*ret_last_ds);
+            *ret_last_ds = NULL;
+            response_free(res);
+            return (-1);
+        }
+    }
+
+    *ret_ds_count = ds_count;
+    response_free(res);
+    return (0);
+}                       /* }}} int rrd_client_lastupdate */
+
+int rrdc_lastupdate(
+    const char *filename,   /* {{{ */
+    time_t *ret_last_update,
+    unsigned long *ret_ds_count,
+    char ***ret_ds_names,
+    char ***ret_last_ds)
+{
+    int       status;
+
+    mutex_lock(&lock);
+    status = rrd_client_lastupdate(&default_client, filename,
+                                   ret_last_update, ret_ds_count,
+                                   ret_ds_names, ret_last_ds);
+    mutex_unlock(&lock);
+    return status;
+}                       /* }}} int rrdc_lastupdate */
+
 time_t rrd_client_first(
     rrd_client_t *client,
     const char *filename,

--- a/src/rrd_client.h
+++ b/src/rrd_client.h
@@ -74,6 +74,11 @@ int rrd_client_update(rrd_client_t *client, const char *filename, int values_num
 rrd_info_t * rrd_client_info(rrd_client_t *client, const char *filename);
 char *rrd_client_list(rrd_client_t *client, int recursive, const char *dirname);
 time_t rrd_client_last(rrd_client_t *client, const char *filename);
+int rrd_client_lastupdate(rrd_client_t *client, const char *filename,
+    time_t *ret_last_update,
+    unsigned long *ret_ds_count,
+    char ***ret_ds_names,
+    char ***ret_last_ds);
 time_t rrd_client_first(rrd_client_t *client, const char *filename, int rraindex);
 int rrd_client_create(rrd_client_t *client, const char *filename,
     unsigned long pdp_step,
@@ -128,6 +133,11 @@ int rrdc_update (const char *filename, int values_num,
 rrd_info_t * rrdc_info (const char *filename);
 char *rrdc_list(int recursive, const char *dirname);
 time_t rrdc_last (const char *filename);
+int rrdc_lastupdate (const char *filename,
+    time_t *ret_last_update,
+    unsigned long *ret_ds_count,
+    char ***ret_ds_names,
+    char ***ret_last_ds);
 time_t rrdc_first (const char *filename, int rraindex);
 int rrdc_create (const char *filename,
     unsigned long pdp_step,

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -2516,6 +2516,57 @@ static int handle_request_last(
     return rc;
 }                       /* }}} static int handle_request_last  */
 
+static int handle_request_lastupdate(
+    HANDLER_PROTO)
+{                       /* {{{ */
+    char     *file = NULL, *pbuffile;
+    int       status, rc;
+    unsigned long i;
+    rrd_file_t *rrd_file;
+    rrd_t     rrd;
+    time_t    last_update;
+
+    /* obtain filename */
+    status = buffer_get_field(&buffer, &buffer_size, &pbuffile);
+    if (status != 0) {
+        rc = syntax_error(sock, cmd);
+        goto done;
+    }
+    /* get full pathname */
+    file = get_abs_path(pbuffile);
+    if (file == NULL) {
+        rc = send_response(sock, RESP_ERR, "%s\n", rrd_strerror(ENOMEM));
+        goto done;
+    }
+    if (!check_file_access(file, sock)) {
+        rc = send_response(sock, RESP_ERR, "%s: %s\n", file,
+                           rrd_strerror(EACCES));
+        goto done;
+    }
+    rrd_clear_error();
+    rrd_init(&rrd);
+    rrd_file = rrd_open(file, &rrd, RRD_READONLY | RRD_LOCK);
+    if (!rrd_file) {
+        rrd_free(&rrd);
+        rc = send_response(sock, RESP_ERR, "RRD Error: %s\n",
+                           rrd_get_error());
+        goto done;
+    }
+    last_update = rrd.live_head->last_up;
+    for (i = 0; i < rrd.stat_head->ds_cnt; i++) {
+        add_response_info(sock, "%s %s\n",
+                          rrd.ds_def[i].ds_nam,
+                          rrd.pdp_prep[i].last_ds);
+    }
+    rrd_close(rrd_file);
+    rrd_free(&rrd);
+    rc = send_response(sock, RESP_OK, "%lu LastUpdate values follow\n",
+                       (unsigned long) last_update);
+  done:
+    free(file);
+    return rc;
+}                       /* }}} static int handle_request_lastupdate */
+
 static int handle_request_create(
     HANDLER_PROTO)
 {                       /* {{{ */
@@ -3165,6 +3216,16 @@ static command_t list_of_commands[] = { /* {{{ */
      "Note that this is the time of the last update of the RRD file itself, not\n"
      "the last time data was received via rrdcached, so there may be pending\n"
      "updates in the queue.  If this bothers you, then first run a FLUSH.\n"},
+    {
+     "LASTUPDATE",
+     handle_request_lastupdate,
+     CMD_CONTEXT_CLIENT,
+     "LASTUPDATE <filename>\n",
+     "The LASTUPDATE command retrieves the last update time and DS values for\n"
+     "a specified RRD file.  Returns one line per DS with the DS name and its\n"
+     "last value, and the status line contains the timestamp.\n"
+     "Note that this reflects the data as of the last write to the RRD file.\n"
+     "If there are pending updates in the cache, run FLUSH first.\n"},
     {
      "CREATE",
      handle_request_create,

--- a/src/rrd_lastupdate.c
+++ b/src/rrd_lastupdate.c
@@ -62,14 +62,17 @@ int rrd_lastupdate (int argc, const char **argv)
         return (-1);
     }
 
-    status = rrdc_flush_if_daemon(opt_daemon, options.argv[options.optind]);
-    if (opt_daemon != NULL) {
-    	free (opt_daemon);
+    rrdc_connect(opt_daemon);
+    if (rrdc_is_connected(opt_daemon)) {
+        status = rrdc_lastupdate(options.argv[options.optind],
+                &last_update, &ds_count, &ds_names, &last_ds);
+    } else {
+        status = rrd_lastupdate_r(options.argv[options.optind],
+                &last_update, &ds_count, &ds_names, &last_ds);
     }
-    if (status) return (-1);
-
-    status = rrd_lastupdate_r(options.argv[options.optind],
-            &last_update, &ds_count, &ds_names, &last_ds);
+    if (opt_daemon != NULL) {
+        free(opt_daemon);
+    }
     if (status != 0)
         return (status);
 


### PR DESCRIPTION
## Problem

`rrdtool lastupdate --daemon host:port file.rrd` was failing with `ERROR: opening 'file.rrd': No such file or directory` because `rrd_lastupdate.c` only flushed the daemon cache but then tried to read the RRD file directly — which doesn't exist on the client machine when using a remote daemon. The analogous `rrd_last.c` correctly dispatches to `rrdc_last()`.

## Fix

- **`src/rrd_daemon.c`**: Added `handle_request_lastupdate()` that reads the RRD file on the daemon side and returns one response line per DS (`<dsname> <lastvalue>`), with the timestamp in the status message. Registered the `LASTUPDATE` command in the dispatch table.
- **`src/rrd_client.c`**: Added `rrd_client_lastupdate()` and `rrdc_lastupdate()` modelled on `rrd_client_last()` / `rrdc_last()`.
- **`src/rrd_client.h`**: Declared both new functions.
- **`src/librrd.sym`**: Exported `rrdc_lastupdate`.
- **`src/rrd_lastupdate.c`**: Now connects to the daemon and dispatches via `rrdc_lastupdate()` when connected, exactly mirroring how `rrd_last.c` uses `rrdc_last()`.

## Protocol

`LASTUPDATE <filename>` returns `<ds_count>` response lines, each `<dsname> <lastvalue>`, with the Unix timestamp in the status line message.

Closes #1293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)