### PR TITLE
Fix rrdcached cache miss on paths with ./ prefix (#1071)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,15 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* rrdcached no longer returns stale all-NaN data when a FETCH uses a
+  path with a leading `./` (e.g. `./switch/foo.rrd`).  Previously
+  `get_abs_path()` would produce `<basedir>/./switch/foo.rrd` as the
+  cache key, which missed the UPDATE-time entry keyed on
+  `<basedir>/switch/foo.rrd`, so the in-memory cache was not flushed
+  and on-disk (possibly all-NaN) data was returned.  Fixed by adding
+  lexical-only normalization that collapses `./` and `//` segments
+  without calling `realpath(2)`. Issue #1071 reported by @tik-stbuehler,
+  fix by @oetiker
 * Pad the Perl `$RRDs::VERSION` / `$RRDp::VERSION` numeric encoding so
   two-digit minor releases compare monotonically. The numeric version
   now uses three-digit zero-padded minor and patch fields, e.g.

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -1379,27 +1379,66 @@ static int check_file_access(
     return 1;
 }                       /* }}} static int check_file_access */
 
+/* Lexically normalize a path in-place: collapse double slashes and
+ * dot-slash segments (e.g. "foo//./bar" -> "foo/bar").  Does NOT
+ * resolve ".." — that is intentionally left for check_file_access().
+ */
+static void normalize_path(
+    char *path)
+{                       /* {{{ */
+    char     *src;
+    char     *dst;
+
+    if (path == NULL)
+        return;
+
+    src = path;
+    dst = path;
+
+    while (*src != '\0') {
+        if (src[0] == '/' && src[1] == '/') {
+            /* collapse consecutive slashes */
+            src++;
+        } else if (src[0] == '/' && src[1] == '.' &&
+                   (src[2] == '/' || src[2] == '\0')) {
+            /* collapse "/./" -> "/" (or trailing "/.") */
+            src += 2;
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
+}                       /* }}} static void normalize_path */
+
 /* when using a base dir, convert relative paths to absolute paths.
  * The result must be free()'ed by the caller.
  */
 static char *get_abs_path(
     const char *filename)
-{
+{                       /* {{{ */
     char     *ret;
 
     assert(filename != NULL);
 
-    if (config_base_dir == NULL || *filename == '/')
-        return strdup(filename);
+    /* Skip leading "./" in relative paths before prepending the base dir */
+    while (filename[0] == '.' && filename[1] == '/')
+        filename += 2;
 
-    ret = malloc(strlen(config_base_dir) + 1 + strlen(filename) + 1);
-    if (ret == NULL)
-        RRDD_LOG(LOG_ERR, "get_abs_path: malloc failed.");
-    else
-        sprintf(ret, "%s/%s", config_base_dir, filename);
+    if (config_base_dir == NULL || *filename == '/') {
+        ret = strdup(filename);
+    } else {
+        ret = malloc(strlen(config_base_dir) + 1 + strlen(filename) + 1);
+        if (ret == NULL)
+            RRDD_LOG(LOG_ERR, "get_abs_path: malloc failed.");
+        else
+            sprintf(ret, "%s/%s", config_base_dir, filename);
+    }
+
+    if (ret != NULL)
+        normalize_path(ret);
 
     return ret;
-}                       /* }}} static int get_abs_path */
+}                       /* }}} static char *get_abs_path */
 
 static int flush_file(
     const char *filename)


### PR DESCRIPTION
Closes #1071.

## Problem

When a FETCH command uses a path with a leading `./` (e.g. `./switch/foo.rrd`), `get_abs_path()` was doing pure string concatenation, producing `<basedir>/./switch/foo.rrd` as the cache key. This missed the UPDATE-time entry keyed on `<basedir>/switch/foo.rrd`, so `flush_file()` found nothing to flush and `rrd_fetch()` returned stale on-disk (all-NaN) data.

## Fix

- Added `normalize_path()`: a lexical-only in-place helper that collapses `//` and `/./` segments. It intentionally leaves `../` untouched so the existing `check_file_access()` path-escape detection via `strstr(file, "../")` continues to work.
- In `get_abs_path()`: strip any leading `./` from relative filenames before prepending `config_base_dir`, then call `normalize_path()` on the result.
- Both UPDATE and FETCH go through `get_abs_path()`, so the normalization is applied symmetrically — no `realpath(2)` call on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)