### PR TITLE
rrd_graph_helper: guard NULL from getFirstUnusedArgument in parse_def

### DIFF
--- a/src/rrd_graph_helper.c
+++ b/src/rrd_graph_helper.c
@@ -1263,6 +1263,11 @@ static int parse_def(
         /* get the first parameter */
         keyvalue_t *first = getFirstUnusedArgument(0, pa);
 
+        if (!first) {
+            rrd_set_error("No argument for definition in %s", pa->arg_orig);
+            return 1;
+        }
+
         /* if it is any of the "original" positional args, then we terminate immediately */
         for (int i = 0; i < 10; i++) {
             if (poskeys[i] == first->key) {


### PR DESCRIPTION
Fixes #1353.

In the retry path of `parse_def()`, `getFirstUnusedArgument(0, pa)` can return NULL when every argument has already been consumed, but `first->key` is dereferenced immediately in the following loop. A malformed `DEF` with no usable arguments (e.g. `rrdtool graph out.png DEF`) crashes instead of reporting an error.

This adds the same NULL check the other `getFirstUnusedArgument` call sites in this file already use, setting an error and returning so the caller reports it cleanly.