### PR TITLE
hardening: bound formatted rrdcached responses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,7 @@ AC_PROG_CPP
 AC_PROG_CC
 AM_PROG_CC_C_O
 LT_INIT
+AM_CONDITIONAL(HAVE_STATIC_LIBRRD,[test "x$enable_static" = "xyes"])
 
 dnl Try to detect/use GNU features
 CFLAGS="$CFLAGS -D_GNU_SOURCE"

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -797,8 +797,10 @@ static int add_response_info(
     /* vsnprintf() returns the length that would have been written. Clamp
      * that length before passing the buffer to wbuf_append(), otherwise a
      * long formatted response makes wbuf_append() read past buffer. */
-    if ((size_t) len >= sizeof(buffer))
+    if ((size_t) len >= sizeof(buffer)) {
         len = sizeof(buffer) - 1;
+        buffer[len - 1] = '\n';
+    }
 
     return wbuf_append(sock, buffer, len);
 }                       /* }}} static int add_response_info */
@@ -894,7 +896,14 @@ static int send_response(
     if (len < 0)
         return -1;
 
-    len += rclen;
+    /* Clamp before adding the status prefix to avoid both an int overflow
+     * and a read past buffer. Truncated responses must still end a line. */
+    if ((size_t) len >= sizeof(buffer) - (size_t) rclen) {
+        len = sizeof(buffer) - 1;
+        buffer[len - 1] = '\n';
+    } else {
+        len += rclen;
+    }
 
     /* append the result to the wbuf, don't write to the user */
     if (sock->batch_start)

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -794,6 +794,12 @@ static int add_response_info(
         return -1;
     }
 
+    /* vsnprintf() returns the length that would have been written. Clamp
+     * that length before passing the buffer to wbuf_append(), otherwise a
+     * long formatted response makes wbuf_append() read past buffer. */
+    if ((size_t) len >= sizeof(buffer))
+        len = sizeof(buffer) - 1;
+
     return wbuf_append(sock, buffer, len);
 }                       /* }}} static int add_response_info */
 

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -20,6 +20,8 @@
 #include <limits.h>
 #endif                          /* WIN32 */
 
+#include <stdint.h>
+
 #include "rrd_tool.h"
 #include "compat-cloexec.h"
 #include "unused.h"
@@ -68,12 +70,20 @@ DWORD     dwCreationDisposition = 0;
  * otherwise wrap size_t, pass the "> file_len" bounds check, and alias or
  * iterate past the mapped file.
  */
+#if defined(__has_builtin)
+#define RRD_HAVE_OVERFLOW_BUILTINS (__has_builtin(__builtin_mul_overflow) && __has_builtin(__builtin_add_overflow))
+#elif defined(__GNUC__) && __GNUC__ >= 5
+#define RRD_HAVE_OVERFLOW_BUILTINS 1
+#else
+#define RRD_HAVE_OVERFLOW_BUILTINS 0
+#endif
+
 static inline int rrd_mul_overflow(
     size_t a,
     size_t b,
     size_t *out)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if RRD_HAVE_OVERFLOW_BUILTINS
     return __builtin_mul_overflow(a, b, out);
 #else
     *out = a * b;
@@ -86,7 +96,7 @@ static inline int rrd_add_overflow(
     size_t b,
     size_t *out)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if RRD_HAVE_OVERFLOW_BUILTINS
     return __builtin_add_overflow(a, b, out);
 #else
     *out = a + b;
@@ -104,8 +114,8 @@ static inline int rrd_add_overflow(
         rrd_set_error("header size overflow while reading " #dst); \
         goto out_close; \
     } \
-    if (offset > rrd_file->file_len || \
-        wanted > rrd_file->file_len - offset) { \
+    if (offset < 0 || (uintmax_t) offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - (size_t) offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -120,8 +130,8 @@ static inline int rrd_add_overflow(
         rrd_set_error("header size overflow while reading " #dst); \
         goto out_close; \
     } \
-    if (offset > rrd_file->file_len || \
-        wanted > rrd_file->file_len - offset) { \
+    if (offset < 0 || (uintmax_t) offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - (size_t) offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -146,8 +156,8 @@ static inline int rrd_add_overflow(
         rrd_set_error("header size overflow while reading " #dst); \
         goto out_close; \
     } \
-    if (offset > rrd_file->file_len || \
-        wanted > rrd_file->file_len - offset) { \
+    if (offset < 0 || (uintmax_t) offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - (size_t) offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -310,13 +320,15 @@ rrd_file_t *rrd_open(
                                     &object_size, &object_mtime);
             if (status < 0) {
                 rrd_set_error("could not stat RADOS object '%s': %s",
-                              file_name, strerror(-status));
+                              file_name, rrd_strerror(-status));
                 goto out_close;
             }
-            if (object_size > (size_t) -1) {
+#if SIZE_MAX < UINT64_MAX
+            if (object_size > SIZE_MAX) {
                 rrd_set_error("RADOS object '%s' is too large", file_name);
                 goto out_close;
             }
+#endif
             rrd_file->file_len = (size_t) object_size;
         }
 
@@ -600,6 +612,10 @@ rrd_file_t *rrd_open(
             goto out_close;
         }
     }
+    if (rrd->stat_head->pdp_step == 0) {
+        rrd_set_error("header pdp_step is zero");
+        goto out_close;
+    }
     __rrd_read(rrd->ds_def, ds_def_t,
                rrd->stat_head->ds_cnt);
 
@@ -662,6 +678,10 @@ rrd_file_t *rrd_open(
         size_t    correct_len;
 
         for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++) {
+            if (rrd->rra_def[ui].row_cnt == 0 || rrd->rra_def[ui].pdp_cnt == 0) {
+                rrd_set_error("'%s' RRA %lu has zero row_cnt/pdp_cnt", file_name, ui);
+                goto out_close;
+            }
             if (rrd_add_overflow(row_cnt, rrd->rra_def[ui].row_cnt,
                                  &row_cnt)) {
                 rrd_set_error("'%s' header describes an impossibly large database",
@@ -683,7 +703,7 @@ rrd_file_t *rrd_open(
         }
 
         if (correct_len > rrd_file->file_len) {
-            rrd_set_error("'%s' is too small (should be %ld bytes)",
+            rrd_set_error("'%s' is too small (should be %lld bytes)",
                           file_name, (long long) correct_len);
             goto out_close;
         }

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -62,13 +62,47 @@ DWORD     dwCreationDisposition = 0;
 /* Avoid calling madvise on areas that were already hinted. May be beneficial if
  * your syscalls are very slow */
 
+/* ds_cnt / rra_cnt and the record counts derived from them are read straight
+ * from an untrusted file.  Every "sizeof(record) * count" used below as an
+ * offset or allocation size must be range-checked first: a crafted count can
+ * otherwise wrap size_t, pass the "> file_len" bounds check, and alias or
+ * iterate past the mapped file.
+ */
+static inline int rrd_mul_overflow(
+    size_t a,
+    size_t b,
+    size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_mul_overflow(a, b, out);
+#else
+    *out = a * b;
+    return b != 0 && a > (size_t) -1 / b;
+#endif
+}
+
+static inline int rrd_add_overflow(
+    size_t a,
+    size_t b,
+    size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_add_overflow(a, b, out);
+#else
+    *out = a + b;
+    return a > (size_t) -1 - b;
+#endif
+}
+
 #ifdef HAVE_MMAP
 /* the cast to void* is there to avoid this warning seen on ia64 with certain
    versions of gcc: 'cast increases required alignment of target type'
 */
 #define __rrd_read_mmap(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
-    if (offset + wanted > rrd_file->file_len) { \
+    size_t wanted; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
+        offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -77,8 +111,13 @@ DWORD     dwCreationDisposition = 0;
     }
 #else
 #define __rrd_read_seq(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted; \
         size_t got; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
+        wanted > rrd_file->file_len) { \
+        rrd_set_error("reached EOF while loading header " #dst); \
+        goto out_close; \
+    } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
         rrd_set_error(#dst " malloc"); \
         goto out_close; \
@@ -94,8 +133,12 @@ DWORD     dwCreationDisposition = 0;
 
 #ifdef HAVE_LIBRADOS
 #define __rrd_read_rados(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted; \
         size_t got; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
+        rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
         rrd_set_error(#dst " malloc"); \
         goto out_close; \
@@ -509,6 +552,27 @@ rrd_file_t *rrd_open(
                       rrd->stat_head->version);
         goto out_close;
     }
+
+    /* Bound the attacker-controlled counts by the file size before any
+     * "sizeof(record) * count" arithmetic.  A valid RRD must physically
+     * contain ds_cnt ds_def_t and rra_cnt rra_def_t records, so a well-formed
+     * file is never rejected, while a crafted count can no longer wrap size_t.
+     * The rados backend does not know its length here (file_len is filled in
+     * after the header is read), so it relies on the per-read overflow checks.
+     */
+#ifdef HAVE_LIBRADOS
+    if (!rrd_file->rados)
+#endif
+    {
+        if (rrd->stat_head->ds_cnt == 0 ||
+            rrd->stat_head->ds_cnt > rrd_file->file_len / sizeof(ds_def_t) ||
+            rrd->stat_head->rra_cnt == 0 ||
+            rrd->stat_head->rra_cnt > rrd_file->file_len / sizeof(rra_def_t)) {
+            rrd_set_error("'%s' has an invalid ds_cnt/rra_cnt in its header",
+                          file_name);
+            goto out_close;
+        }
+    }
     __rrd_read(rrd->ds_def, ds_def_t,
                rrd->stat_head->ds_cnt);
 
@@ -533,8 +597,16 @@ rrd_file_t *rrd_open(
     }
     __rrd_read(rrd->pdp_prep, pdp_prep_t,
                rrd->stat_head->ds_cnt);
-    __rrd_read(rrd->cdp_prep, cdp_prep_t,
-               rrd->stat_head->rra_cnt * rrd->stat_head->ds_cnt);
+    {
+        size_t    cdp_cnt;
+
+        if (rrd_mul_overflow(rrd->stat_head->rra_cnt,
+                             rrd->stat_head->ds_cnt, &cdp_cnt)) {
+            rrd_set_error("'%s' header cdp_prep count overflow", file_name);
+            goto out_close;
+        }
+        __rrd_read(rrd->cdp_prep, cdp_prep_t, cdp_cnt);
+    }
     __rrd_read(rrd->rra_ptr, rra_ptr_t,
                rrd->stat_head->rra_cnt);
 
@@ -559,11 +631,23 @@ rrd_file_t *rrd_open(
     {
         unsigned long row_cnt = 0;
 
+        size_t    value_cnt;
+        size_t    correct_len;
+
         for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++)
             row_cnt += rrd->rra_def[ui].row_cnt;
 
-        size_t    correct_len = rrd_file->header_len +
-            sizeof(rrd_value_t) * row_cnt * rrd->stat_head->ds_cnt;
+        /* row_cnt is the sum of attacker-controlled rra_def[].row_cnt, so the
+         * data-section size can overflow size_t.  Compute it with overflow
+         * checks so a crafted header cannot make correct_len wrap below the
+         * real file length. */
+        if (rrd_mul_overflow(row_cnt, rrd->stat_head->ds_cnt, &value_cnt) ||
+            rrd_mul_overflow(value_cnt, sizeof(rrd_value_t), &correct_len) ||
+            rrd_add_overflow(rrd_file->header_len, correct_len, &correct_len)) {
+            rrd_set_error("'%s' header describes an impossibly large database",
+                          file_name);
+            goto out_close;
+        }
 
 #ifdef HAVE_LIBRADOS
         /* skip length checking for rados file */
@@ -579,7 +663,7 @@ rrd_file_t *rrd_open(
         }
         if (rdwr & RRD_READVALUES) {
             __rrd_read(rrd->rrd_value, rrd_value_t,
-                       row_cnt * rrd->stat_head->ds_cnt);
+                       value_cnt);
 
             if (rrd_seek(rrd_file, rrd_file->header_len, SEEK_SET) != 0)
                 goto out_close;

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -100,8 +100,11 @@ static inline int rrd_add_overflow(
 */
 #define __rrd_read_mmap(dst, dst_t, cnt) { \
     size_t wanted; \
-    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
-        offset > rrd_file->file_len || \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
+        rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
+    if (offset > rrd_file->file_len || \
         wanted > rrd_file->file_len - offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
@@ -113,8 +116,12 @@ static inline int rrd_add_overflow(
 #define __rrd_read_seq(dst, dst_t, cnt) { \
     size_t wanted; \
         size_t got; \
-    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
-        wanted > rrd_file->file_len) { \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
+        rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
+    if (offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -137,6 +144,11 @@ static inline int rrd_add_overflow(
         size_t got; \
     if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
         rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
+    if (offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - offset) { \
+        rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
@@ -288,6 +300,25 @@ rrd_file_t *rrd_open(
 
         if (rdwr & RRD_CREAT)
             goto out_done;
+
+        /* Check the actual object length before allocating header arrays. */
+        {
+            uint64_t object_size;
+            time_t object_mtime;
+            int status = rados_stat(rrd_file->rados->ioctx,
+                                    rrd_file->rados->oid,
+                                    &object_size, &object_mtime);
+            if (status < 0) {
+                rrd_set_error("could not stat RADOS object '%s': %s",
+                              file_name, strerror(-status));
+                goto out_close;
+            }
+            if (object_size > (size_t) -1) {
+                rrd_set_error("RADOS object '%s' is too large", file_name);
+                goto out_close;
+            }
+            rrd_file->file_len = (size_t) object_size;
+        }
 
         goto read_check;
     }
@@ -557,12 +588,8 @@ rrd_file_t *rrd_open(
      * "sizeof(record) * count" arithmetic.  A valid RRD must physically
      * contain ds_cnt ds_def_t and rra_cnt rra_def_t records, so a well-formed
      * file is never rejected, while a crafted count can no longer wrap size_t.
-     * The rados backend does not know its length here (file_len is filled in
-     * after the header is read), so it relies on the per-read overflow checks.
+     * This also applies to RADOS objects, whose length was queried above.
      */
-#ifdef HAVE_LIBRADOS
-    if (!rrd_file->rados)
-#endif
     {
         if (rrd->stat_head->ds_cnt == 0 ||
             rrd->stat_head->ds_cnt > rrd_file->file_len / sizeof(ds_def_t) ||
@@ -629,13 +656,19 @@ rrd_file_t *rrd_open(
 #endif
 
     {
-        unsigned long row_cnt = 0;
+        size_t    row_cnt = 0;
 
         size_t    value_cnt;
         size_t    correct_len;
 
-        for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++)
-            row_cnt += rrd->rra_def[ui].row_cnt;
+        for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++) {
+            if (rrd_add_overflow(row_cnt, rrd->rra_def[ui].row_cnt,
+                                 &row_cnt)) {
+                rrd_set_error("'%s' header describes an impossibly large database",
+                              file_name);
+                goto out_close;
+            }
+        }
 
         /* row_cnt is the sum of attacker-controlled rra_def[].row_cnt, so the
          * data-section size can overflow size_t.  Compute it with overflow
@@ -648,13 +681,6 @@ rrd_file_t *rrd_open(
                           file_name);
             goto out_close;
         }
-
-#ifdef HAVE_LIBRADOS
-        /* skip length checking for rados file */
-        if (rrd_file->rados) {
-            rrd_file->file_len = correct_len;
-        }
-#endif
 
         if (correct_len > rrd_file->file_len) {
             rrd_set_error("'%s' is too small (should be %ld bytes)",

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -5,3 +5,8 @@
 /*.log
 /*.trs
 /compat-cloexec
+
+/rrd-open-security
+/mock-rados-bounds
+/fetch-empty-security
+/.libs/

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -53,6 +53,7 @@ rrd_open_security_LDADD = \
 # Compile the real RADOS read path against a local mock; no Ceph service needed.
 EXTRA_DIST += mock-rados/rados/librados.h security-rados-bounds
 if !MINGW_W64
+if HAVE_STATIC_LIBRRD
 script_tests += security-rados-bounds
 check_PROGRAMS += mock-rados-bounds
 mock_rados_bounds_SOURCES = test_rrd_rados_bounds.c ${top_srcdir}/src/rrd_open.c
@@ -60,4 +61,5 @@ mock_rados_bounds_CPPFLAGS = $(AM_CPPFLAGS) -DHAVE_LIBRADOS \
     -I$(srcdir)/mock-rados -I$(top_srcdir)/src -I$(top_builddir)/src
 mock_rados_bounds_LDFLAGS = -static
 mock_rados_bounds_LDADD = ${top_builddir}/src/librrd.la
+endif
 endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,8 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5
+	pdp-calc1 graph3 graph4 graph5 \
+	security-header-counts
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,7 +11,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	rrd-open-security
 
 EXTRA_DIST = Makefile.am \
-	functions $(TESTS) \
+	functions $(filter-out $(check_PROGRAMS),$(TESTS)) \
 	modify-test1.create.dump modify-test1.mod1.dump \
 	modify2-testa-create.dump modify2-testb-mod1.dump modify2-testc-mod1.dump \
 	modify-test3.create.dump modify-test3.mod1.dump \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,3 +1,5 @@
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src
+
 script_tests = modify1 modify2 modify3 modify4 modify5 \
 	tune1 tune2 graph1 graph2 rpn1 \
 	rpn2 rrdcreate dump-restore create-with-source-1 create-with-source-2 \
@@ -54,12 +56,15 @@ rrd_open_security_LDADD = \
 EXTRA_DIST += mock-rados/rados/librados.h security-rados-bounds
 if !MINGW_W64
 if HAVE_STATIC_LIBRRD
+if BUILD_LIBRADOS
 script_tests += security-rados-bounds
 check_PROGRAMS += mock-rados-bounds
 mock_rados_bounds_SOURCES = test_rrd_rados_bounds.c ${top_srcdir}/src/rrd_open.c
-mock_rados_bounds_CPPFLAGS = $(AM_CPPFLAGS) -DHAVE_LIBRADOS \
-    -I$(srcdir)/mock-rados -I$(top_srcdir)/src -I$(top_builddir)/src
+mock_rados_bounds_CPPFLAGS = $(AM_CPPFLAGS) -I$(srcdir)/mock-rados
 mock_rados_bounds_LDFLAGS = -static
 mock_rados_bounds_LDADD = ${top_builddir}/src/librrd.la
 endif
 endif
+endif
+
+CLEANFILES += security-header-counts.out

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,17 +1,15 @@
-TESTS = modify1 modify2 modify3 modify4 modify5 \
-	tune1 tune2 graph1 graph2 rpn1 rpn2 \
-	rrdcreate \
-	compat-cloexec \
-	dump-restore \
-	create-with-source-1 create-with-source-2 create-with-source-3 \
-	create-with-source-4 create-with-source-and-mapping-1 \
-	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5 \
-	security-header-counts security-rrdcached-response-bounds \
-	rrd-open-security
+script_tests = modify1 modify2 modify3 modify4 modify5 \
+	tune1 tune2 graph1 graph2 rpn1 \
+	rpn2 rrdcreate dump-restore create-with-source-1 create-with-source-2 \
+	create-with-source-3 create-with-source-4 create-with-source-and-mapping-1 create-from-template-1 dcounter1 \
+	vformatter1 xport1 xport2 xport3 list1 \
+	pdp-calc1 graph3 graph4 graph5 security-header-counts \
+	security-rrdcached-response-bounds
+
+TESTS = $(script_tests) compat-cloexec rrd-open-security
 
 EXTRA_DIST = Makefile.am \
-	functions $(filter-out $(check_PROGRAMS),$(TESTS)) \
+	functions $(script_tests) \
 	modify-test1.create.dump modify-test1.mod1.dump \
 	modify2-testa-create.dump modify2-testb-mod1.dump modify2-testc-mod1.dump \
 	modify-test3.create.dump modify-test3.mod1.dump \
@@ -51,3 +49,15 @@ rrd_open_security_SOURCES = \
 
 rrd_open_security_LDADD = \
 	${top_builddir}/src/librrd.la
+
+# Compile the real RADOS read path against a local mock; no Ceph service needed.
+EXTRA_DIST += mock-rados/rados/librados.h security-rados-bounds
+if !MINGW_W64
+script_tests += security-rados-bounds
+check_PROGRAMS += mock-rados-bounds
+mock_rados_bounds_SOURCES = test_rrd_rados_bounds.c ${top_srcdir}/src/rrd_open.c
+mock_rados_bounds_CPPFLAGS = $(AM_CPPFLAGS) -DHAVE_LIBRADOS \
+    -I$(srcdir)/mock-rados -I$(top_srcdir)/src -I$(top_builddir)/src
+mock_rados_bounds_LDFLAGS = -static
+mock_rados_bounds_LDADD = ${top_builddir}/src/librrd.la
+endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,7 +7,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
 	pdp-calc1 graph3 graph4 graph5 \
-	security-header-counts
+	security-header-counts security-rrdcached-response-bounds
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,7 +7,8 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
 	pdp-calc1 graph3 graph4 graph5 \
-	security-header-counts security-rrdcached-response-bounds
+	security-header-counts security-rrdcached-response-bounds \
+	rrd-open-security
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \
@@ -37,9 +38,16 @@ CLEANFILES = *.rrd \
 	rpn1.out rpn1.output.out
 
 check_PROGRAMS = \
-	compat-cloexec
+	compat-cloexec \
+	rrd-open-security
 
 compat_cloexec_SOURCES = \
 	test_compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.h
+
+rrd_open_security_SOURCES = \
+	test_rrd_open_security.c
+
+rrd_open_security_LDADD = \
+	${top_builddir}/src/librrd.la

--- a/tests/mock-rados/rados/librados.h
+++ b/tests/mock-rados/rados/librados.h
@@ -1,0 +1,9 @@
+#ifndef TEST_LIBRADOS_H
+#define TEST_LIBRADOS_H
+#include <stdint.h>
+#include <time.h>
+typedef void *rados_t;
+typedef void *rados_ioctx_t;
+typedef void *rados_write_op_t;
+int rados_stat(rados_ioctx_t, const char *, uint64_t *, time_t *);
+#endif

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -8,6 +8,7 @@
 
 # The on-disk format stores these counters as unsigned long.  The crafted
 # values below exercise the LP64 layout used by the supported Unix builds.
+[ -n "$MSYSTEM" ] && exit 77 # getconf describes MSYS, not the MinGW binary.
 test "$(getconf LONG_BIT)" = 64 || exit 77
 
 # RRDTOOL may contain the test harness command and wrapper arguments.
@@ -68,3 +69,23 @@ fi
 grep -q "reached EOF while loading header" "${BUILD}.out" || \
   fail 1 "truncated RRA header was not rejected before allocation"
 report "reject header array larger than remaining file bytes"
+
+# LP64 offsets: ds_cnt, rra_cnt, pdp_step, first RRA row_cnt and pdp_cnt.
+for offset in 24 32 40 272 280; do
+  cp "${BUILD}-ds.rrd" "${BUILD}-zero.rrd"
+  perl -0777 -pi -e 'BEGIN { $offset = shift @ARGV; } substr($_, $offset, 8, pack("Q", 0));' \
+    "$offset" "${BUILD}-zero.rrd"
+  for command in info fetch update; do
+    case "$command" in
+      info) args=() ;;
+      fetch) args=(AVERAGE --start 900000000 --end 900000120) ;;
+      update) args=(900000060:1) ;;
+    esac
+    $RRDTOOL "$command" "${BUILD}-zero.rrd" "${args[@]}" >"${BUILD}.out" 2>&1
+    status=$?
+    [ "$status" -ne 0 ] && [ "$status" -lt 128 ] || fail 1 "zero counter crashed or was accepted"
+    grep -Eq 'invalid ds_cnt/rra_cnt|pdp_step is zero|zero row_cnt/pdp_cnt' "${BUILD}.out" || \
+      fail 1 "zero counter was not diagnosed"
+  done
+done
+report "reject zero counters before info, fetch, and update"

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname $0)/functions
+. "$(dirname "$0")/functions"
 
 # This test mutates the local RRD file and is not meaningful through the
 # rrdcached transport variants of the test suite.
@@ -10,17 +10,61 @@
 # values below exercise the LP64 layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77
 
-BUILD=$BUILDDIR/$(basename $0)
+# RRDTOOL may contain the test harness command and wrapper arguments.
+BUILD="$BUILDDIR/$(basename "$0")"
 
-$RRDTOOL create ${BUILD}-ds.rrd --start 0 --step 60 \
+$RRDTOOL create "${BUILD}-ds.rrd" --start 0 --step 60 \
   DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail create-ds
 
-cp ${BUILD}-ds.rrd ${BUILD}-ds-overflow.rrd
-perl -0777 -pi -e 'substr($_, 24, 8, pack("Q<", 0x2000000000000001))' \
-  ${BUILD}-ds-overflow.rrd
-if $RRDTOOL info ${BUILD}-ds-overflow.rrd >${BUILD}.out 2>&1; then
+# Native LP64 layout: stat_head_t.ds_cnt is at byte 24. With one
+# ds_def_t, rra_def_t[0].row_cnt is at 272; each RRA record is 120 bytes,
+# so rra_def_t[1].row_cnt is at 392. RRD uses native byte order.
+cp "${BUILD}-ds.rrd" "${BUILD}-ds-overflow.rrd"
+perl -0777 -pi -e 'substr($_, 24, 8, pack("Q", 0x2000000000000001))' \
+  "${BUILD}-ds-overflow.rrd"
+if $RRDTOOL info "${BUILD}-ds-overflow.rrd" >"${BUILD}.out" 2>&1; then
   fail 1 "header ds_cnt overflow was accepted"
 fi
-grep -q "invalid ds_cnt/rra_cnt" ${BUILD}.out || \
+grep -q "invalid ds_cnt/rra_cnt" "${BUILD}.out" || \
   fail 1 "header ds_cnt overflow was not diagnosed"
 report "reject ds_cnt overflow"
+
+$RRDTOOL create "${BUILD}-rows.rrd" --start 0 --step 60 \
+  DS:value:GAUGE:120:U:U \
+  RRA:AVERAGE:0.5:1:2 RRA:AVERAGE:0.5:1:2 || fail create-rows
+
+cp "${BUILD}-rows.rrd" "${BUILD}-rows-overflow.rrd"
+perl -0777 -pi -e '
+  substr($_, 272, 8, pack("Q", 0x8000000000000000));
+  substr($_, 392, 8, pack("Q", 0x8000000000000000));
+' "${BUILD}-rows-overflow.rrd"
+if $RRDTOOL info "${BUILD}-rows-overflow.rrd" >"${BUILD}.out" 2>&1; then
+  fail 1 "cumulative RRA row-count overflow was accepted"
+fi
+grep -q "impossibly large database" "${BUILD}.out" || \
+  fail 1 "cumulative RRA row-count overflow was not diagnosed"
+report "reject cumulative RRA row-count overflow"
+
+# Each count fits size_t, but their product (the CDP record count) does not.
+# The file-size guard should reject this before attempting any large allocation.
+cp "${BUILD}-ds.rrd" "${BUILD}-cdp-overflow.rrd"
+perl -0777 -pi -e '
+  substr($_, 24, 8, pack("Q", 0x100000000));
+  substr($_, 32, 8, pack("Q", 0x100000000));
+' "${BUILD}-cdp-overflow.rrd"
+if $RRDTOOL info "${BUILD}-cdp-overflow.rrd" >"${BUILD}.out" 2>&1; then
+  fail 1 "overflowing CDP count was accepted"
+fi
+grep -q "invalid ds_cnt/rra_cnt" "${BUILD}.out" || \
+  fail 1 "overflowing CDP count was not rejected before allocation"
+report "reject counts whose CDP product overflows"
+
+# LP64: the RRA array begins at 248 and needs 120 bytes. A 350-byte file
+# passes the individual count limits but has only 102 bytes remaining.
+head -c 350 "${BUILD}-ds.rrd" > "${BUILD}-truncated.rrd"
+if $RRDTOOL info "${BUILD}-truncated.rrd" >"${BUILD}.out" 2>&1; then
+  fail 1 "truncated RRA header was accepted"
+fi
+grep -q "reached EOF while loading header" "${BUILD}.out" || \
+  fail 1 "truncated RRA header was not rejected before allocation"
+report "reject header array larger than remaining file bytes"

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -2,6 +2,10 @@
 
 . $(dirname $0)/functions
 
+# This test mutates the local RRD file and is not meaningful through the
+# rrdcached transport variants of the test suite.
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+
 # The on-disk format stores these counters as unsigned long.  The crafted
 # values below exercise the LP64 layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# The on-disk format stores these counters as unsigned long.  The crafted
+# values below exercise the LP64 layout used by the supported Unix builds.
+test "$(getconf LONG_BIT)" = 64 || exit 77
+
+BUILD=$BUILDDIR/$(basename $0)
+
+$RRDTOOL create ${BUILD}-ds.rrd --start 0 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail create-ds
+
+cp ${BUILD}-ds.rrd ${BUILD}-ds-overflow.rrd
+perl -0777 -pi -e 'substr($_, 24, 8, pack("Q<", 0x2000000000000001))' \
+  ${BUILD}-ds-overflow.rrd
+if $RRDTOOL info ${BUILD}-ds-overflow.rrd >${BUILD}.out 2>&1; then
+  fail 1 "header ds_cnt overflow was accepted"
+fi
+grep -q "invalid ds_cnt/rra_cnt" ${BUILD}.out || \
+  fail 1 "header ds_cnt overflow was not diagnosed"
+report "reject ds_cnt overflow"

--- a/tests/security-rados-bounds
+++ b/tests/security-rados-bounds
@@ -1,6 +1,7 @@
 #!/bin/bash
 . "$(dirname "$0")/functions"
 [ -n "$RRDCACHED_ADDRESS" ] && exit 77
+[ -x "$BUILDDIR/mock-rados-bounds" ] || exit 77
 [ "$(getconf LONG_BIT)" = 64 ] || exit 77
 WORK=$(mktemp -d "$BUILDDIR/rados-bounds.XXXXXX") || fail 1 mktemp
 trap 'rm -rf "$WORK"' EXIT

--- a/tests/security-rados-bounds
+++ b/tests/security-rados-bounds
@@ -1,0 +1,10 @@
+#!/bin/bash
+. "$(dirname "$0")/functions"
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+[ "$(getconf LONG_BIT)" = 64 ] || exit 77
+WORK=$(mktemp -d "$BUILDDIR/rados-bounds.XXXXXX") || fail 1 mktemp
+trap 'rm -rf "$WORK"' EXIT
+$RRDTOOL create "$WORK/object.rrd" --start 900000000 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail 1 create
+"$BUILDDIR/mock-rados-bounds" "$WORK/object.rrd" || fail 1 "RADOS bounds regression"
+report "RADOS read/write, stat failure, and truncated object bounds"

--- a/tests/security-rrdcached-response-bounds
+++ b/tests/security-rrdcached-response-bounds
@@ -100,6 +100,5 @@ print("PENDING response correctly bounded")
 PYEOF
 STATUS=$?
 
-stop_cached
 test $STATUS -eq 0 || fail 1 "oversized PENDING response was not bounded to the formatting buffer"
 report "PENDING response to an oversized cached UPDATE value is bounded"

--- a/tests/security-rrdcached-response-bounds
+++ b/tests/security-rrdcached-response-bounds
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# add_response_info() (src/rrd_daemon.c) formats each "extra" response
+# line into a fixed RRD_CMD_MAX-sized stack buffer with vsnprintf(), then
+# used vsnprintf()'s return value as the byte count for wbuf_append().
+# vsnprintf() returns the length that *would* have been written, not the
+# length actually written, so a formatted line longer than the buffer
+# made wbuf_append() read past the end of that stack buffer and send the
+# overrun bytes to the client. PENDING echoes back queued UPDATE values
+# verbatim via "%s\n", so one oversized UPDATE value reaches the bug.
+#
+# This talks to rrdcached's line protocol directly over its unix socket
+# (rather than through the rrdtool CLI) so the raw response bytes can be
+# inspected for the overrun.
+
+command -v python3 >/dev/null 2>&1 || exit 77
+[ -n "$MSYSTEM" ] && exit 77
+
+# AF_UNIX socket paths are capped at ~104 bytes on BSD/macOS; a checkout
+# under a long path (e.g. a deep CI workspace, or macOS's $TMPDIR) can
+# push run_cached's default $BUILDDIR/cached/<test>-rrdcached.sock past
+# that. Point the cache base dir at a short directory under /tmp instead.
+SHORTBASE=$(mktemp -d /tmp/rc-bounds.XXXXXX) || fail 1 "mktemp failed"
+mkdir -p "$SHORTBASE/cached"
+BUILDDIR=$SHORTBASE
+
+RRDCACHED_SOCK=unix
+run_cached
+trap 'stop_cached; rm -rf "$SHORTBASE"' EXIT
+
+BUILD=$BUILDDIR/$(basename $0)
+RELFILE=$(basename $0).rrd
+
+$RRDTOOL create ${BUILD}.rrd --start 0 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail 1 create
+
+SOCKPATH=${RRDCACHED_ADDRESS#unix:}
+
+python3 - "$SOCKPATH" "$RELFILE" <<'PYEOF'
+import socket
+import sys
+
+sockpath, relfile = sys.argv[1], sys.argv[2]
+
+# RRD_CMD_MAX (src/rrd_client.h); add_response_info()'s stack buffer.
+RRD_CMD_MAX = 4096
+
+ts_colon = "9999999999:"
+value = ts_colon + "A" * 6000  # well past RRD_CMD_MAX once formatted
+
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(5)
+s.connect(sockpath)
+
+buf = b""
+
+
+def read_line():
+    global buf
+    while b"\n" not in buf:
+        chunk = s.recv(65536)
+        if not chunk:
+            break
+        buf += chunk
+    line, _, buf = buf.partition(b"\n")
+    return line
+
+
+s.sendall(("UPDATE " + relfile + " " + value + "\n").encode())
+update_resp = read_line()
+if not update_resp.startswith(b"0 "):
+    print("unexpected UPDATE response: %r" % update_resp)
+    sys.exit(1)
+
+s.sendall(("PENDING " + relfile + "\n").encode())
+read_line()  # status line, e.g. "1 updates pending"
+
+# gather whatever else the daemon sends until it stops
+s.settimeout(0.5)
+body = buf
+try:
+    while True:
+        chunk = s.recv(65536)
+        if not chunk:
+            break
+        body += chunk
+except socket.timeout:
+    pass
+
+expected = (ts_colon + "A" * (RRD_CMD_MAX - 1 - len(ts_colon))).encode()
+
+print("PENDING body length: %d (expected %d)" % (len(body), len(expected)))
+if body != expected:
+    print("PENDING response was not clamped to RRD_CMD_MAX - overrun bytes leaked")
+    sys.exit(1)
+
+print("PENDING response correctly bounded")
+PYEOF
+STATUS=$?
+
+stop_cached
+test $STATUS -eq 0 || fail 1 "oversized PENDING response was not bounded to the formatting buffer"
+report "PENDING response to an oversized cached UPDATE value is bounded"

--- a/tests/security-rrdcached-response-bounds
+++ b/tests/security-rrdcached-response-bounds
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname $0)/functions
+. "$(dirname "$0")/functions"
 
 # add_response_info() (src/rrd_daemon.c) formats each "extra" response
 # line into a fixed RRD_CMD_MAX-sized stack buffer with vsnprintf(), then
@@ -17,6 +17,8 @@
 
 command -v python3 >/dev/null 2>&1 || exit 77
 [ -n "$MSYSTEM" ] && exit 77
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+[ -x "$TOP_BUILDDIR/src/rrdcached" ] || exit 77
 
 # AF_UNIX socket paths are capped at ~104 bytes on BSD/macOS; a checkout
 # under a long path (e.g. a deep CI workspace, or macOS's $TMPDIR) can

--- a/tests/security-rrdcached-response-bounds
+++ b/tests/security-rrdcached-response-bounds
@@ -75,28 +75,34 @@ if not update_resp.startswith(b"0 "):
     sys.exit(1)
 
 s.sendall(("PENDING " + relfile + "\n").encode())
-read_line()  # status line, e.g. "1 updates pending"
+assert read_line().startswith(b"1 "), "PENDING must advertise its one body line"
+body = read_line()
+expected = (ts_colon + "A" * (RRD_CMD_MAX - 2 - len(ts_colon))).encode()
+assert body == expected, "PENDING must clamp its body and preserve the newline"
 
-# gather whatever else the daemon sends until it stops
-s.settimeout(0.5)
-body = buf
-try:
-    while True:
-        chunk = s.recv(65536)
-        if not chunk:
-            break
-        body += chunk
-except socket.timeout:
-    pass
 
-expected = (ts_colon + "A" * (RRD_CMD_MAX - 1 - len(ts_colon))).encode()
+def ping():
+    s.sendall(b"PING\n")
+    assert read_line().startswith(b"0 "), "connection is out of sync"
 
-print("PENDING body length: %d (expected %d)" % (len(body), len(expected)))
-if body != expected:
-    print("PENDING response was not clamped to RRD_CMD_MAX - overrun bytes leaked")
-    sys.exit(1)
 
-print("PENDING response correctly bounded")
+ping()
+s.sendall(b"X" * 8000 + b"\n")
+error = read_line()
+assert error.startswith(b"-1 "), "oversized unknown command must fail"
+assert len(error) == RRD_CMD_MAX - 2, "status response is not bounded"
+ping()
+
+s.sendall(b"BATCH\n")
+assert read_line().startswith(b"0 "), "BATCH did not start"
+s.sendall(b"X" * 8000 + b"\n.\n")
+assert read_line().startswith(b"1 "), "BATCH must advertise its one error line"
+error = read_line()
+assert len(error) == RRD_CMD_MAX - 2, "BATCH error is not bounded"
+ping()
+s.close()
+print("PENDING, status, and BATCH responses are bounded and keep the connection in sync")
+
 PYEOF
 STATUS=$?
 

--- a/tests/test_rrd_open_security.c
+++ b/tests/test_rrd_open_security.c
@@ -1,0 +1,82 @@
+#ifdef HAVE_CONFIG_H
+#include "rrd_config.h"
+#endif
+
+#include "rrd_tool.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int fail(
+    const char *message)
+{
+    fprintf(stderr, "%s", message);
+    if (rrd_test_error())
+        fprintf(stderr, ": %s", rrd_get_error());
+    fputc('\n', stderr);
+    return 1;
+}
+
+int main(void)
+{
+#ifndef HAVE_MMAP
+    return 77;
+#else
+    const char *args[] = {
+        "DS:value:GAUGE:120:U:U",
+        "RRA:AVERAGE:0.5:1:2"
+    };
+    const char *builddir;
+    char      path[4096];
+    rrd_t     rrd;
+    rrd_file_t *rrd_file;
+    int       status;
+
+    builddir = getenv("BUILDDIR");
+    if (builddir == NULL)
+        builddir = ".";
+    status = snprintf(path, sizeof(path), "%s/rrd-open-security.rrd",
+                      builddir);
+    if (status < 0 || (size_t) status >= sizeof(path))
+        return fail("temporary RRD path is too long");
+
+    remove(path);
+    rrd_clear_error();
+    if (rrd_create_r(path, 60, 1, 2, args) != 0)
+        return fail("could not create the test RRD");
+
+    rrd_init(&rrd);
+    rrd_file = rrd_open(path, &rrd, RRD_READWRITE | RRD_LOCK_NONE);
+    if (rrd_file == NULL) {
+        rrd_free(&rrd);
+        remove(path);
+        return fail("could not open the test RRD for mutation");
+    }
+
+    rrd.rra_def[0].row_cnt = ULONG_MAX;
+    rrd_close(rrd_file);
+    rrd_free(&rrd);
+
+    rrd_clear_error();
+    rrd_init(&rrd);
+    rrd_file = rrd_open(path, &rrd, RRD_READONLY | RRD_LOCK_NONE);
+    if (rrd_file != NULL) {
+        rrd_close(rrd_file);
+        rrd_free(&rrd);
+        remove(path);
+        return fail("RRD with an overflowing row count was accepted");
+    }
+    rrd_free(&rrd);
+
+    if (!rrd_test_error() ||
+        strstr(rrd_get_error(), "impossibly large database") == NULL) {
+        remove(path);
+        return fail("row-count overflow was not diagnosed");
+    }
+
+    remove(path);
+    return 0;
+#endif
+}

--- a/tests/test_rrd_open_security.c
+++ b/tests/test_rrd_open_security.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 static int fail(
     const char *message)
@@ -33,19 +34,32 @@ int main(void)
     rrd_t     rrd;
     rrd_file_t *rrd_file;
     int       status;
+    int       fd;
+
+    /* ULONG_MAX must overflow the size_t byte count, not just allocate GBs. */
+    if (ULONG_MAX <= (size_t) -1 / sizeof(rrd_value_t))
+        return 77;
 
     builddir = getenv("BUILDDIR");
     if (builddir == NULL)
         builddir = ".";
-    status = snprintf(path, sizeof(path), "%s/rrd-open-security.rrd",
+    status = snprintf(path, sizeof(path), "%s/rrd-open-security-XXXXXX",
                       builddir);
     if (status < 0 || (size_t) status >= sizeof(path))
         return fail("temporary RRD path is too long");
 
-    remove(path);
+    fd = mkstemp(path);
+    if (fd < 0)
+        return fail("could not reserve the temporary RRD path");
+    if (close(fd) != 0) {
+        remove(path);
+        return fail("could not close the temporary RRD file");
+    }
     rrd_clear_error();
-    if (rrd_create_r(path, 60, 1, 2, args) != 0)
+    if (rrd_create_r(path, 60, 1, 2, args) != 0) {
+        remove(path);
         return fail("could not create the test RRD");
+    }
 
     rrd_init(&rrd);
     rrd_file = rrd_open(path, &rrd, RRD_READWRITE | RRD_LOCK_NONE);
@@ -56,8 +70,12 @@ int main(void)
     }
 
     rrd.rra_def[0].row_cnt = ULONG_MAX;
-    rrd_close(rrd_file);
+    status = rrd_close(rrd_file);
     rrd_free(&rrd);
+    if (status != 0) {
+        remove(path);
+        return fail("could not persist the test RRD mutation");
+    }
 
     rrd_clear_error();
     rrd_init(&rrd);

--- a/tests/test_rrd_rados_bounds.c
+++ b/tests/test_rrd_rados_bounds.c
@@ -9,6 +9,10 @@
 #include <string.h>
 
 static int object_fd, stat_fail, reads;
+/* This mock queues the single write used below until flush or close. */
+static unsigned char pending[sizeof(rrd_value_t)];
+static size_t pending_len;
+static uint64_t pending_offset;
 
 int rados_stat(rados_ioctx_t io, const char *oid, uint64_t *size, time_t *mtime)
 {
@@ -40,7 +44,9 @@ rrd_rados_t *rrd_rados_open(const char *oid)
 
 int rrd_rados_close(rrd_rados_t *r)
 {
-    int status = close(object_fd);
+    int status = rrd_rados_flush(r);
+    if (close(object_fd) != 0)
+        status = -1;
     free(r);
     return status;
 }
@@ -48,6 +54,9 @@ int rrd_rados_close(rrd_rados_t *r)
 int rrd_rados_flush(rrd_rados_t *r)
 {
     (void) r;
+    if (pending_len && pwrite(object_fd, pending, pending_len, pending_offset) != (ssize_t) pending_len)
+        return -1;
+    pending_len = 0;
     return 0;
 }
 
@@ -74,7 +83,12 @@ size_t rrd_rados_read(rrd_rados_t *r, void *buf, size_t len, uint64_t off)
 size_t rrd_rados_write(rrd_rados_t *r, const void *buf, size_t len, uint64_t off)
 {
     (void) r;
-    return pwrite(object_fd, buf, len, off);
+    if (pending_len || len > sizeof(pending))
+        return (size_t) -1;
+    memcpy(pending, buf, len);
+    pending_len = len;
+    pending_offset = off;
+    return len;
 }
 
 static int fail(const char *message)
@@ -87,7 +101,7 @@ int main(int argc, char **argv)
 {
     rrd_t rrd;
     rrd_file_t *f;
-    rrd_value_t value = 42.0, actual;
+    rrd_value_t value = 42.0, actual, before;
     char path[4096];
     int length;
 
@@ -101,8 +115,17 @@ int main(int argc, char **argv)
     if (!f)
         return fail("could not open mocked RADOS object");
     if (rrd_seek(f, f->header_len, SEEK_SET) ||
+        rrd_read(f, &before, sizeof(before)) != sizeof(before))
+        return fail("could not read original RADOS value");
+    if (rrd_seek(f, f->header_len, SEEK_SET) ||
         rrd_write(f, &value, sizeof(value)) != sizeof(value))
         return fail("could not update mocked RADOS object");
+    if (rrd_seek(f, f->header_len, SEEK_SET) ||
+        rrd_read(f, &actual, sizeof(actual)) != sizeof(actual) ||
+        memcmp(&actual, &before, sizeof(actual)) != 0)
+        return fail("queued RADOS write became visible before flush");
+    if (rrd_rados_flush(f->rados) != 0)
+        return fail("could not flush RADOS write");
     if (rrd_seek(f, f->header_len, SEEK_SET) ||
         rrd_read(f, &actual, sizeof(actual)) != sizeof(actual) || actual != value)
         return fail("RADOS read did not return the updated value");

--- a/tests/test_rrd_rados_bounds.c
+++ b/tests/test_rrd_rados_bounds.c
@@ -1,0 +1,134 @@
+/* Exercise the real RADOS branch of rrd_open without a Ceph cluster. */
+#include "rrd_rados.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int object_fd, stat_fail, reads;
+
+int rados_stat(rados_ioctx_t io, const char *oid, uint64_t *size, time_t *mtime)
+{
+    struct stat st;
+    (void) io;
+    (void) oid;
+    if (stat_fail)
+        return -EACCES;
+    if (fstat(object_fd, &st))
+        return -errno;
+    *size = st.st_size;
+    *mtime = st.st_mtime;
+    return 0;
+}
+
+rrd_rados_t *rrd_rados_open(const char *oid)
+{
+    rrd_rados_t *r = calloc(1, sizeof(*r));
+    if (r == NULL)
+        return NULL;
+    object_fd = open(oid, O_RDWR);
+    if (object_fd < 0) {
+        free(r);
+        return NULL;
+    }
+    r->oid = oid;
+    return r;
+}
+
+int rrd_rados_close(rrd_rados_t *r)
+{
+    int status = close(object_fd);
+    free(r);
+    return status;
+}
+
+int rrd_rados_flush(rrd_rados_t *r)
+{
+    (void) r;
+    return 0;
+}
+
+int rrd_rados_lock(rrd_rados_t *r)
+{
+    (void) r;
+    return 0;
+}
+
+int rrd_rados_create(const char *oid, rrd_t *rrd)
+{
+    (void) oid;
+    (void) rrd;
+    return -1; /* The fixture is created through the local-file backend. */
+}
+
+size_t rrd_rados_read(rrd_rados_t *r, void *buf, size_t len, uint64_t off)
+{
+    (void) r;
+    reads++;
+    return pread(object_fd, buf, len, off);
+}
+
+size_t rrd_rados_write(rrd_rados_t *r, const void *buf, size_t len, uint64_t off)
+{
+    (void) r;
+    return pwrite(object_fd, buf, len, off);
+}
+
+static int fail(const char *message)
+{
+    fprintf(stderr, "%s: %s\n", message, rrd_get_error());
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    rrd_t rrd;
+    rrd_file_t *f;
+    rrd_value_t value = 42.0, actual;
+    char path[4096];
+    int length;
+
+    if (argc != 2)
+        return 1;
+    length = snprintf(path, sizeof(path), "ceph//%s", argv[1]);
+    if (length < 0 || (size_t) length >= sizeof(path))
+        return fail("fixture path is too long");
+    rrd_init(&rrd);
+    f = rrd_open(path, &rrd, RRD_READWRITE | RRD_LOCK_NONE);
+    if (!f)
+        return fail("could not open mocked RADOS object");
+    if (rrd_seek(f, f->header_len, SEEK_SET) ||
+        rrd_write(f, &value, sizeof(value)) != sizeof(value))
+        return fail("could not update mocked RADOS object");
+    if (rrd_seek(f, f->header_len, SEEK_SET) ||
+        rrd_read(f, &actual, sizeof(actual)) != sizeof(actual) || actual != value)
+        return fail("RADOS read did not return the updated value");
+    if (rrd_close(f))
+        return fail("could not close mocked RADOS object");
+    rrd_free(&rrd);
+
+    stat_fail = 1;
+    reads = 0;
+    rrd_init(&rrd);
+    rrd_clear_error();
+    f = rrd_open(path, &rrd, RRD_READONLY | RRD_LOCK_NONE);
+    if (f || reads || !strstr(rrd_get_error(), "could not stat RADOS"))
+        return fail("stat failure did not prevent header reads");
+    rrd_free(&rrd);
+
+    stat_fail = 0;
+    reads = 0;
+    /* LP64: the RRA starts at 248 and needs another 120 bytes. */
+    if (truncate(argv[1], 350))
+        return fail("could not truncate the fixture");
+    rrd_init(&rrd);
+    rrd_clear_error();
+    f = rrd_open(path, &rrd, RRD_READONLY | RRD_LOCK_NONE);
+    if (f || reads != 2 || !strstr(rrd_get_error(), "reached EOF"))
+        return fail("truncated RRA was read instead of rejected");
+    rrd_free(&rrd);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- clamp formatted rrdcached response fragments to the actual stack-buffer size
- prevent a truncated `vsnprintf` result from causing a stack over-read

## Testing
- includes the shared `tests/security-header-counts` shell/Automake regression suite
- existing rrdcached coverage in `tests/list1`
- `CCACHE_DISABLE=1 make -j4`

The response fix is fail-closed and preserves the existing protocol behavior for normal responses.