### PR TITLE
hardening: check fetch allocation arithmetic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,7 @@ AC_PROG_CPP
 AC_PROG_CC
 AM_PROG_CC_C_O
 LT_INIT
+AM_CONDITIONAL(HAVE_STATIC_LIBRRD,[test "x$enable_static" = "xyes"])
 
 dnl Try to detect/use GNU features
 CFLAGS="$CFLAGS -D_GNU_SOURCE"

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -2244,7 +2244,7 @@ static int handle_request_fetch(
          t <= parsed.end_tm; t += parsed.step, j++) {
         add_response_info(sock, "%10lu:", (unsigned long) t);
         for (i = 0; i < parsed.field_cnt; i++) {
-            unsigned int idx = j * parsed.ds_cnt + parsed.field_idx[i];
+            size_t idx = (size_t) j * parsed.ds_cnt + parsed.field_idx[i];
 
             add_response_info(sock, " %0.17e", parsed.data[idx]);
         }
@@ -2274,6 +2274,10 @@ static int handle_request_fetchbin(
         return 0;
 
     /* create a buffer for the full binary line */
+    if (parsed.steps > (size_t) -1 / sizeof(double)) {
+        free_fetch_parsed(&parsed);
+        return send_response(sock, RESP_ERR, "Fetch range is too large\n");
+    }
     dbuffer_size = sizeof(double) * parsed.steps;
     dbuffer = calloc(1, dbuffer_size);
     if (!dbuffer) {
@@ -2292,7 +2296,7 @@ static int handle_request_fetchbin(
     for (i = 0; i < parsed.field_cnt; i++) {
         for (t = parsed.start_tm + parsed.step, j = 0;
              t <= parsed.end_tm; t += parsed.step, j++) {
-            unsigned int idx = j * parsed.ds_cnt + parsed.field_idx[i];
+            size_t idx = (size_t) j * parsed.ds_cnt + parsed.field_idx[i];
 
             dbuffer[j] = parsed.data[idx];
         }

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -797,8 +797,10 @@ static int add_response_info(
     /* vsnprintf() returns the length that would have been written. Clamp
      * that length before passing the buffer to wbuf_append(), otherwise a
      * long formatted response makes wbuf_append() read past buffer. */
-    if ((size_t) len >= sizeof(buffer))
+    if ((size_t) len >= sizeof(buffer)) {
         len = sizeof(buffer) - 1;
+        buffer[len - 1] = '\n';
+    }
 
     return wbuf_append(sock, buffer, len);
 }                       /* }}} static int add_response_info */
@@ -894,7 +896,14 @@ static int send_response(
     if (len < 0)
         return -1;
 
-    len += rclen;
+    /* Clamp before adding the status prefix to avoid both an int overflow
+     * and a read past buffer. Truncated responses must still end a line. */
+    if ((size_t) len >= sizeof(buffer) - (size_t) rclen) {
+        len = sizeof(buffer) - 1;
+        buffer[len - 1] = '\n';
+    } else {
+        len += rclen;
+    }
 
     /* append the result to the wbuf, don't write to the user */
     if (sock->batch_start)

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -794,6 +794,12 @@ static int add_response_info(
         return -1;
     }
 
+    /* vsnprintf() returns the length that would have been written. Clamp
+     * that length before passing the buffer to wbuf_append(), otherwise a
+     * long formatted response makes wbuf_append() read past buffer. */
+    if ((size_t) len >= sizeof(buffer))
+        len = sizeof(buffer) - 1;
+
     return wbuf_append(sock, buffer, len);
 }                       /* }}} static int add_response_info */
 

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -2169,6 +2169,11 @@ static int handle_request_fetch_parse(
         parsed->field_cnt = 0;
         parsed->field_idx =
             malloc(sizeof(*parsed->field_idx) * parsed->ds_cnt);
+        if (parsed->field_idx == NULL) {
+            free_fetch_parsed(parsed);
+            send_response(sock, RESP_ERR, "Failed memory allocation\n");
+            return -1;
+        }
 
         /* now parse the extra names */
         while (buffer_get_field(&buffer, &buffer_size, &field) == 0) {
@@ -2283,13 +2288,14 @@ static int handle_request_fetchbin(
         return 0;
 
     /* create a buffer for the full binary line */
-    if (parsed.steps > (size_t) -1 / sizeof(double)) {
+    if (parsed.steps > INT_MAX / sizeof(double)) {
         free_fetch_parsed(&parsed);
         return send_response(sock, RESP_ERR, "Fetch range is too large\n");
     }
     dbuffer_size = sizeof(double) * parsed.steps;
     dbuffer = calloc(1, dbuffer_size);
     if (!dbuffer) {
+        free_fetch_parsed(&parsed);
         return (send_response(sock, RESP_ERR, "Failed memory allocation\n"));
     }
 
@@ -2313,7 +2319,7 @@ static int handle_request_fetchbin(
         add_binary_response_info(sock,
                                  "DSName-",
                                  parsed.ds_namv[parsed.field_idx[i]],
-                                 dbuffer, parsed.steps, sizeof(double)
+                                 dbuffer, (int) parsed.steps, (int) sizeof(double)
             );
     }
 

--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -460,7 +460,14 @@ int rrd_fetch_fn(
 ** database is the one with time stamp (t+s) which means t to t+s.
 */
     *ds_cnt = rrd.stat_head->ds_cnt;
-    if (((*data) = (rrd_value_t*)malloc(*ds_cnt * rows * sizeof(rrd_value_t))) == NULL) {
+    if (*ds_cnt != 0 &&
+        (rows > (size_t) -1 / *ds_cnt ||
+         rows * *ds_cnt > (size_t) -1 / sizeof(rrd_value_t))) {
+        rrd_set_error("fetch data size overflow");
+        goto err_free_all_ds_namv;
+    }
+    if (((*data) = (rrd_value_t *) malloc(*ds_cnt * rows *
+                                          sizeof(rrd_value_t))) == NULL) {
         rrd_set_error("malloc fetch data area");
         goto err_free_all_ds_namv;
     }

--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -299,7 +299,8 @@ int rrd_fetch_fn(
     rrd_t     rrd;
     rrd_file_t *rrd_file;
     rrd_value_t *data_ptr;
-    unsigned long rows;
+    size_t    rows;
+    size_t    data_values;
 
 #ifdef DEBUG
     fprintf(stderr, "Entered rrd_fetch_fn() searching for the best match\n");
@@ -449,7 +450,7 @@ int rrd_fetch_fn(
 
 #ifdef DEBUG
     fprintf(stderr,
-            "We found:    start %10lu end %10lu step %5lu rows  %lu\n",
+            "We found:    start %10lu end %10lu step %5lu rows  %zu\n",
             *start, *end, *step, rows);
 #endif
 
@@ -460,14 +461,17 @@ int rrd_fetch_fn(
 ** database is the one with time stamp (t+s) which means t to t+s.
 */
     *ds_cnt = rrd.stat_head->ds_cnt;
-    if (*ds_cnt != 0 &&
-        (rows > (size_t) -1 / *ds_cnt ||
-         rows * *ds_cnt > (size_t) -1 / sizeof(rrd_value_t))) {
+    if (*ds_cnt != 0 && rows > (size_t) -1 / (size_t) *ds_cnt) {
         rrd_set_error("fetch data size overflow");
         goto err_free_all_ds_namv;
     }
-    if (((*data) = (rrd_value_t *) malloc(*ds_cnt * rows *
-                                          sizeof(rrd_value_t))) == NULL) {
+    /* Widen before multiplying: unsigned long is only 32 bits on LLP64. */
+    data_values = rows * (size_t) *ds_cnt;
+    if (data_values > (size_t) -1 / sizeof(rrd_value_t)) {
+        rrd_set_error("fetch data size overflow");
+        goto err_free_all_ds_namv;
+    }
+    if (((*data) = (rrd_value_t *) malloc(data_values * sizeof(rrd_value_t))) == NULL) {
         rrd_set_error("malloc fetch data area");
         goto err_free_all_ds_namv;
     }

--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -243,7 +243,7 @@ int rrd_fetch_empty(
     char ***ds_namv,    /* names of data_sources */
     rrd_value_t **data)
 {
-    unsigned long rows;
+    size_t    rows;
 
     if (((*ds_namv) =
          (char **) malloc(sizeof(char *))) == NULL) {
@@ -257,21 +257,37 @@ int rrd_fetch_empty(
     }
 
     *ds_cnt = 1;
+    if (*end < *start) {
+        rrd_set_error("fetch end precedes start");
+        goto out_error;
+    }
     if (*step == 0) *step = (*end - *start) / 100;
+    if (*step == 0) {
+        rrd_set_error("fetch step is zero");
+        goto out_error;
+    }
     *start -= (*start % *step);
     *end += (*step - *end % *step);
     rows = (*end - *start) / *step + 1;
 
+    if (rows == 0 || rows > (size_t) -1 / sizeof(rrd_value_t)) {
+        rrd_set_error("fetch data size overflow");
+        goto out_error;
+    }
     if (((*data) = (rrd_value_t*)malloc(rows * sizeof(rrd_value_t))) == NULL) {
         rrd_set_error("malloc fetch data area");
-        free((*ds_namv)[0]);
-        free(*ds_namv);
-        return (-1);
+        goto out_error;
     }
 
-    while (--rows)
-        (*data)[rows-1] = DNAN;
+    while (rows > 0)
+        (*data)[--rows] = DNAN;
     return (0);
+
+  out_error:
+    free((*ds_namv)[0]);
+    free(*ds_namv);
+    *ds_namv = NULL;
+    return (-1);
 }
 
 int rrd_fetch_fn(

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -20,6 +20,8 @@
 #include <limits.h>
 #endif                          /* WIN32 */
 
+#include <stdint.h>
+
 #include "rrd_tool.h"
 #include "compat-cloexec.h"
 #include "unused.h"
@@ -68,12 +70,20 @@ DWORD     dwCreationDisposition = 0;
  * otherwise wrap size_t, pass the "> file_len" bounds check, and alias or
  * iterate past the mapped file.
  */
+#if defined(__has_builtin)
+#define RRD_HAVE_OVERFLOW_BUILTINS (__has_builtin(__builtin_mul_overflow) && __has_builtin(__builtin_add_overflow))
+#elif defined(__GNUC__) && __GNUC__ >= 5
+#define RRD_HAVE_OVERFLOW_BUILTINS 1
+#else
+#define RRD_HAVE_OVERFLOW_BUILTINS 0
+#endif
+
 static inline int rrd_mul_overflow(
     size_t a,
     size_t b,
     size_t *out)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if RRD_HAVE_OVERFLOW_BUILTINS
     return __builtin_mul_overflow(a, b, out);
 #else
     *out = a * b;
@@ -86,7 +96,7 @@ static inline int rrd_add_overflow(
     size_t b,
     size_t *out)
 {
-#if defined(__GNUC__) || defined(__clang__)
+#if RRD_HAVE_OVERFLOW_BUILTINS
     return __builtin_add_overflow(a, b, out);
 #else
     *out = a + b;
@@ -104,8 +114,8 @@ static inline int rrd_add_overflow(
         rrd_set_error("header size overflow while reading " #dst); \
         goto out_close; \
     } \
-    if (offset > rrd_file->file_len || \
-        wanted > rrd_file->file_len - offset) { \
+    if (offset < 0 || (uintmax_t) offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - (size_t) offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -120,8 +130,8 @@ static inline int rrd_add_overflow(
         rrd_set_error("header size overflow while reading " #dst); \
         goto out_close; \
     } \
-    if (offset > rrd_file->file_len || \
-        wanted > rrd_file->file_len - offset) { \
+    if (offset < 0 || (uintmax_t) offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - (size_t) offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -146,8 +156,8 @@ static inline int rrd_add_overflow(
         rrd_set_error("header size overflow while reading " #dst); \
         goto out_close; \
     } \
-    if (offset > rrd_file->file_len || \
-        wanted > rrd_file->file_len - offset) { \
+    if (offset < 0 || (uintmax_t) offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - (size_t) offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -310,13 +320,15 @@ rrd_file_t *rrd_open(
                                     &object_size, &object_mtime);
             if (status < 0) {
                 rrd_set_error("could not stat RADOS object '%s': %s",
-                              file_name, strerror(-status));
+                              file_name, rrd_strerror(-status));
                 goto out_close;
             }
-            if (object_size > (size_t) -1) {
+#if SIZE_MAX < UINT64_MAX
+            if (object_size > SIZE_MAX) {
                 rrd_set_error("RADOS object '%s' is too large", file_name);
                 goto out_close;
             }
+#endif
             rrd_file->file_len = (size_t) object_size;
         }
 
@@ -600,6 +612,10 @@ rrd_file_t *rrd_open(
             goto out_close;
         }
     }
+    if (rrd->stat_head->pdp_step == 0) {
+        rrd_set_error("header pdp_step is zero");
+        goto out_close;
+    }
     __rrd_read(rrd->ds_def, ds_def_t,
                rrd->stat_head->ds_cnt);
 
@@ -662,6 +678,10 @@ rrd_file_t *rrd_open(
         size_t    correct_len;
 
         for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++) {
+            if (rrd->rra_def[ui].row_cnt == 0 || rrd->rra_def[ui].pdp_cnt == 0) {
+                rrd_set_error("'%s' RRA %lu has zero row_cnt/pdp_cnt", file_name, ui);
+                goto out_close;
+            }
             if (rrd_add_overflow(row_cnt, rrd->rra_def[ui].row_cnt,
                                  &row_cnt)) {
                 rrd_set_error("'%s' header describes an impossibly large database",
@@ -683,7 +703,7 @@ rrd_file_t *rrd_open(
         }
 
         if (correct_len > rrd_file->file_len) {
-            rrd_set_error("'%s' is too small (should be %ld bytes)",
+            rrd_set_error("'%s' is too small (should be %lld bytes)",
                           file_name, (long long) correct_len);
             goto out_close;
         }

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -62,13 +62,47 @@ DWORD     dwCreationDisposition = 0;
 /* Avoid calling madvise on areas that were already hinted. May be beneficial if
  * your syscalls are very slow */
 
+/* ds_cnt / rra_cnt and the record counts derived from them are read straight
+ * from an untrusted file.  Every "sizeof(record) * count" used below as an
+ * offset or allocation size must be range-checked first: a crafted count can
+ * otherwise wrap size_t, pass the "> file_len" bounds check, and alias or
+ * iterate past the mapped file.
+ */
+static inline int rrd_mul_overflow(
+    size_t a,
+    size_t b,
+    size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_mul_overflow(a, b, out);
+#else
+    *out = a * b;
+    return b != 0 && a > (size_t) -1 / b;
+#endif
+}
+
+static inline int rrd_add_overflow(
+    size_t a,
+    size_t b,
+    size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_add_overflow(a, b, out);
+#else
+    *out = a + b;
+    return a > (size_t) -1 - b;
+#endif
+}
+
 #ifdef HAVE_MMAP
 /* the cast to void* is there to avoid this warning seen on ia64 with certain
    versions of gcc: 'cast increases required alignment of target type'
 */
 #define __rrd_read_mmap(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
-    if (offset + wanted > rrd_file->file_len) { \
+    size_t wanted; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
+        offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -77,8 +111,13 @@ DWORD     dwCreationDisposition = 0;
     }
 #else
 #define __rrd_read_seq(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted; \
         size_t got; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
+        wanted > rrd_file->file_len) { \
+        rrd_set_error("reached EOF while loading header " #dst); \
+        goto out_close; \
+    } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
         rrd_set_error(#dst " malloc"); \
         goto out_close; \
@@ -94,8 +133,12 @@ DWORD     dwCreationDisposition = 0;
 
 #ifdef HAVE_LIBRADOS
 #define __rrd_read_rados(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted; \
         size_t got; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
+        rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
         rrd_set_error(#dst " malloc"); \
         goto out_close; \
@@ -509,6 +552,27 @@ rrd_file_t *rrd_open(
                       rrd->stat_head->version);
         goto out_close;
     }
+
+    /* Bound the attacker-controlled counts by the file size before any
+     * "sizeof(record) * count" arithmetic.  A valid RRD must physically
+     * contain ds_cnt ds_def_t and rra_cnt rra_def_t records, so a well-formed
+     * file is never rejected, while a crafted count can no longer wrap size_t.
+     * The rados backend does not know its length here (file_len is filled in
+     * after the header is read), so it relies on the per-read overflow checks.
+     */
+#ifdef HAVE_LIBRADOS
+    if (!rrd_file->rados)
+#endif
+    {
+        if (rrd->stat_head->ds_cnt == 0 ||
+            rrd->stat_head->ds_cnt > rrd_file->file_len / sizeof(ds_def_t) ||
+            rrd->stat_head->rra_cnt == 0 ||
+            rrd->stat_head->rra_cnt > rrd_file->file_len / sizeof(rra_def_t)) {
+            rrd_set_error("'%s' has an invalid ds_cnt/rra_cnt in its header",
+                          file_name);
+            goto out_close;
+        }
+    }
     __rrd_read(rrd->ds_def, ds_def_t,
                rrd->stat_head->ds_cnt);
 
@@ -533,8 +597,16 @@ rrd_file_t *rrd_open(
     }
     __rrd_read(rrd->pdp_prep, pdp_prep_t,
                rrd->stat_head->ds_cnt);
-    __rrd_read(rrd->cdp_prep, cdp_prep_t,
-               rrd->stat_head->rra_cnt * rrd->stat_head->ds_cnt);
+    {
+        size_t    cdp_cnt;
+
+        if (rrd_mul_overflow(rrd->stat_head->rra_cnt,
+                             rrd->stat_head->ds_cnt, &cdp_cnt)) {
+            rrd_set_error("'%s' header cdp_prep count overflow", file_name);
+            goto out_close;
+        }
+        __rrd_read(rrd->cdp_prep, cdp_prep_t, cdp_cnt);
+    }
     __rrd_read(rrd->rra_ptr, rra_ptr_t,
                rrd->stat_head->rra_cnt);
 
@@ -559,11 +631,23 @@ rrd_file_t *rrd_open(
     {
         unsigned long row_cnt = 0;
 
+        size_t    value_cnt;
+        size_t    correct_len;
+
         for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++)
             row_cnt += rrd->rra_def[ui].row_cnt;
 
-        size_t    correct_len = rrd_file->header_len +
-            sizeof(rrd_value_t) * row_cnt * rrd->stat_head->ds_cnt;
+        /* row_cnt is the sum of attacker-controlled rra_def[].row_cnt, so the
+         * data-section size can overflow size_t.  Compute it with overflow
+         * checks so a crafted header cannot make correct_len wrap below the
+         * real file length. */
+        if (rrd_mul_overflow(row_cnt, rrd->stat_head->ds_cnt, &value_cnt) ||
+            rrd_mul_overflow(value_cnt, sizeof(rrd_value_t), &correct_len) ||
+            rrd_add_overflow(rrd_file->header_len, correct_len, &correct_len)) {
+            rrd_set_error("'%s' header describes an impossibly large database",
+                          file_name);
+            goto out_close;
+        }
 
 #ifdef HAVE_LIBRADOS
         /* skip length checking for rados file */
@@ -579,7 +663,7 @@ rrd_file_t *rrd_open(
         }
         if (rdwr & RRD_READVALUES) {
             __rrd_read(rrd->rrd_value, rrd_value_t,
-                       row_cnt * rrd->stat_head->ds_cnt);
+                       value_cnt);
 
             if (rrd_seek(rrd_file, rrd_file->header_len, SEEK_SET) != 0)
                 goto out_close;

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -100,8 +100,11 @@ static inline int rrd_add_overflow(
 */
 #define __rrd_read_mmap(dst, dst_t, cnt) { \
     size_t wanted; \
-    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
-        offset > rrd_file->file_len || \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
+        rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
+    if (offset > rrd_file->file_len || \
         wanted > rrd_file->file_len - offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
@@ -113,8 +116,12 @@ static inline int rrd_add_overflow(
 #define __rrd_read_seq(dst, dst_t, cnt) { \
     size_t wanted; \
         size_t got; \
-    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
-        wanted > rrd_file->file_len) { \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
+        rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
+    if (offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -137,6 +144,11 @@ static inline int rrd_add_overflow(
         size_t got; \
     if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
         rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
+    if (offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - offset) { \
+        rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
@@ -288,6 +300,25 @@ rrd_file_t *rrd_open(
 
         if (rdwr & RRD_CREAT)
             goto out_done;
+
+        /* Check the actual object length before allocating header arrays. */
+        {
+            uint64_t object_size;
+            time_t object_mtime;
+            int status = rados_stat(rrd_file->rados->ioctx,
+                                    rrd_file->rados->oid,
+                                    &object_size, &object_mtime);
+            if (status < 0) {
+                rrd_set_error("could not stat RADOS object '%s': %s",
+                              file_name, strerror(-status));
+                goto out_close;
+            }
+            if (object_size > (size_t) -1) {
+                rrd_set_error("RADOS object '%s' is too large", file_name);
+                goto out_close;
+            }
+            rrd_file->file_len = (size_t) object_size;
+        }
 
         goto read_check;
     }
@@ -557,12 +588,8 @@ rrd_file_t *rrd_open(
      * "sizeof(record) * count" arithmetic.  A valid RRD must physically
      * contain ds_cnt ds_def_t and rra_cnt rra_def_t records, so a well-formed
      * file is never rejected, while a crafted count can no longer wrap size_t.
-     * The rados backend does not know its length here (file_len is filled in
-     * after the header is read), so it relies on the per-read overflow checks.
+     * This also applies to RADOS objects, whose length was queried above.
      */
-#ifdef HAVE_LIBRADOS
-    if (!rrd_file->rados)
-#endif
     {
         if (rrd->stat_head->ds_cnt == 0 ||
             rrd->stat_head->ds_cnt > rrd_file->file_len / sizeof(ds_def_t) ||
@@ -629,13 +656,19 @@ rrd_file_t *rrd_open(
 #endif
 
     {
-        unsigned long row_cnt = 0;
+        size_t    row_cnt = 0;
 
         size_t    value_cnt;
         size_t    correct_len;
 
-        for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++)
-            row_cnt += rrd->rra_def[ui].row_cnt;
+        for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++) {
+            if (rrd_add_overflow(row_cnt, rrd->rra_def[ui].row_cnt,
+                                 &row_cnt)) {
+                rrd_set_error("'%s' header describes an impossibly large database",
+                              file_name);
+                goto out_close;
+            }
+        }
 
         /* row_cnt is the sum of attacker-controlled rra_def[].row_cnt, so the
          * data-section size can overflow size_t.  Compute it with overflow
@@ -648,13 +681,6 @@ rrd_file_t *rrd_open(
                           file_name);
             goto out_close;
         }
-
-#ifdef HAVE_LIBRADOS
-        /* skip length checking for rados file */
-        if (rrd_file->rados) {
-            rrd_file->file_len = correct_len;
-        }
-#endif
 
         if (correct_len > rrd_file->file_len) {
             rrd_set_error("'%s' is too small (should be %ld bytes)",

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,7 +11,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	security-fetch-daemon-arithmetic rrd-open-security
 
 EXTRA_DIST = Makefile.am \
-	functions $(TESTS) \
+	functions $(filter-out $(check_PROGRAMS),$(TESTS)) \
 	modify-test1.create.dump modify-test1.mod1.dump \
 	modify2-testa-create.dump modify2-testb-mod1.dump modify2-testc-mod1.dump \
 	modify-test3.create.dump modify-test3.mod1.dump \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,7 +7,8 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
 	pdp-calc1 graph3 graph4 graph5 \
-	security-header-counts
+	security-header-counts security-fetch-arithmetic \
+	security-fetch-daemon-arithmetic
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,8 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5
+	pdp-calc1 graph3 graph4 graph5 \
+	security-header-counts
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,17 +1,15 @@
-TESTS = modify1 modify2 modify3 modify4 modify5 \
-	tune1 tune2 graph1 graph2 rpn1 rpn2 \
-	rrdcreate \
-	compat-cloexec \
-	dump-restore \
-	create-with-source-1 create-with-source-2 create-with-source-3 \
-	create-with-source-4 create-with-source-and-mapping-1 \
-	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5 \
-	security-header-counts security-fetch-arithmetic \
-	security-fetch-daemon-arithmetic rrd-open-security
+script_tests = modify1 modify2 modify3 modify4 modify5 \
+	tune1 tune2 graph1 graph2 rpn1 \
+	rpn2 rrdcreate dump-restore create-with-source-1 create-with-source-2 \
+	create-with-source-3 create-with-source-4 create-with-source-and-mapping-1 create-from-template-1 dcounter1 \
+	vformatter1 xport1 xport2 xport3 list1 \
+	pdp-calc1 graph3 graph4 graph5 security-header-counts \
+	security-fetch-arithmetic security-fetch-daemon-arithmetic
+
+TESTS = $(script_tests) compat-cloexec rrd-open-security
 
 EXTRA_DIST = Makefile.am \
-	functions $(filter-out $(check_PROGRAMS),$(TESTS)) \
+	functions $(script_tests) \
 	modify-test1.create.dump modify-test1.mod1.dump \
 	modify2-testa-create.dump modify2-testb-mod1.dump modify2-testc-mod1.dump \
 	modify-test3.create.dump modify-test3.mod1.dump \
@@ -51,3 +49,17 @@ rrd_open_security_SOURCES = \
 
 rrd_open_security_LDADD = \
 	${top_builddir}/src/librrd.la
+
+# Compile the real RADOS read path against a local mock; no Ceph service needed.
+EXTRA_DIST += mock-rados/rados/librados.h security-rados-bounds
+if !MINGW_W64
+script_tests += security-rados-bounds
+check_PROGRAMS += mock-rados-bounds
+mock_rados_bounds_SOURCES = test_rrd_rados_bounds.c ${top_srcdir}/src/rrd_open.c
+mock_rados_bounds_CPPFLAGS = $(AM_CPPFLAGS) -DHAVE_LIBRADOS \
+    -I$(srcdir)/mock-rados -I$(top_srcdir)/src -I$(top_builddir)/src
+mock_rados_bounds_LDFLAGS = -static
+mock_rados_bounds_LDADD = ${top_builddir}/src/librrd.la
+endif
+
+script_tests += security-rrdcached-response-bounds

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -53,6 +53,7 @@ rrd_open_security_LDADD = \
 # Compile the real RADOS read path against a local mock; no Ceph service needed.
 EXTRA_DIST += mock-rados/rados/librados.h security-rados-bounds
 if !MINGW_W64
+if HAVE_STATIC_LIBRRD
 script_tests += security-rados-bounds
 check_PROGRAMS += mock-rados-bounds
 mock_rados_bounds_SOURCES = test_rrd_rados_bounds.c ${top_srcdir}/src/rrd_open.c
@@ -63,3 +64,12 @@ mock_rados_bounds_LDADD = ${top_builddir}/src/librrd.la
 endif
 
 script_tests += security-rrdcached-response-bounds
+endif
+
+if HAVE_STATIC_LIBRRD
+check_PROGRAMS += fetch-empty-security
+TESTS += fetch-empty-security
+fetch_empty_security_SOURCES = test_fetch_empty_security.c
+fetch_empty_security_LDFLAGS = -static
+fetch_empty_security_LDADD = ${top_builddir}/src/librrd.la
+endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
 	pdp-calc1 graph3 graph4 graph5 \
 	security-header-counts security-fetch-arithmetic \
-	security-fetch-daemon-arithmetic
+	security-fetch-daemon-arithmetic rrd-open-security
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \
@@ -38,9 +38,16 @@ CLEANFILES = *.rrd \
 	rpn1.out rpn1.output.out
 
 check_PROGRAMS = \
-	compat-cloexec
+	compat-cloexec \
+	rrd-open-security
 
 compat_cloexec_SOURCES = \
 	test_compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.h
+
+rrd_open_security_SOURCES = \
+	test_rrd_open_security.c
+
+rrd_open_security_LDADD = \
+	${top_builddir}/src/librrd.la

--- a/tests/mock-rados/rados/librados.h
+++ b/tests/mock-rados/rados/librados.h
@@ -1,0 +1,9 @@
+#ifndef TEST_LIBRADOS_H
+#define TEST_LIBRADOS_H
+#include <stdint.h>
+#include <time.h>
+typedef void *rados_t;
+typedef void *rados_ioctx_t;
+typedef void *rados_write_op_t;
+int rados_stat(rados_ioctx_t, const char *, uint64_t *, time_t *);
+#endif

--- a/tests/security-fetch-arithmetic
+++ b/tests/security-fetch-arithmetic
@@ -2,6 +2,12 @@
 
 . $(dirname $0)/functions
 
+# rrdtool routes through RRDCACHED_ADDRESS when it's set, and the crafted
+# file lives outside the daemon's base directory, so fetch would fail
+# with "No such file or directory" rather than exercising the overflow
+# guard under test (same reasoning as security-header-counts).
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+
 # The size arithmetic being tested is computed in size_t, so this only
 # means something on the LP64 layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77

--- a/tests/security-fetch-arithmetic
+++ b/tests/security-fetch-arithmetic
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# The size arithmetic being tested is computed in size_t, so this only
+# means something on the LP64 layout used by the supported Unix builds.
+test "$(getconf LONG_BIT)" = 64 || exit 77
+
+BUILD=$BUILDDIR/$(basename $0)
+
+# rrd_fetch_fn() sizes its result buffer as ds_cnt * rows * sizeof(double).
+# A single RRA with pdp_cnt 1 makes the resolved step 1 second, so a wide
+# --start/--end range turns directly into a huge row count.  With enough
+# data sources the ds_cnt * rows * 8 product wraps size_t before the fix,
+# handing malloc() a tiny buffer that the fetch loop then writes far past.
+#
+# The DS count (128) and --end value below are chosen so that
+# rows * ds_cnt * 8 is just over 2^64 (one wrap), landing on a ~100KB
+# allocation instead of the ~140PB actually needed -- small enough that
+# malloc() succeeds and the overflow is immediately reachable.
+DS_ARGS=$(perl -e 'print join(" ", map { "DS:d$_:GAUGE:2:0:100" } (0..127))')
+
+eval "\$RRDTOOL create ${BUILD}.rrd --start 900000000 --step 1 \
+  $DS_ARGS RRA:AVERAGE:0.5:1:5" || fail create
+
+UPDATE_ARGS=$(perl -e 'print "900000001:" . join(":", map { 1 } (0..127))')
+$RRDTOOL update ${BUILD}.rrd $UPDATE_ARGS || fail update
+
+if $RRDTOOL fetch ${BUILD}.rrd AVERAGE \
+    --start 900000000 --end 18014399409482082 --resolution 1 \
+    >${BUILD}.out 2>&1; then
+  fail 1 "fetch size overflow was accepted"
+fi
+grep -q "fetch data size overflow" ${BUILD}.out || \
+  fail 1 "fetch size overflow was not diagnosed"
+report "reject fetch data size overflow"
+
+# a normal fetch on the same file still works
+$RRDTOOL fetch ${BUILD}.rrd AVERAGE --start 900000000 --end 900000005 \
+  >${BUILD}.out 2>&1 || fail 1 "normal fetch broken by overflow guard"
+report "normal fetch still works"

--- a/tests/security-fetch-arithmetic
+++ b/tests/security-fetch-arithmetic
@@ -14,10 +14,13 @@ BUILD=$BUILDDIR/$(basename $0)
 # data sources the ds_cnt * rows * 8 product wraps size_t before the fix,
 # handing malloc() a tiny buffer that the fetch loop then writes far past.
 #
-# The DS count (128) and --end value below are chosen so that
-# rows * ds_cnt * 8 is just over 2^64 (one wrap), landing on a ~100KB
-# allocation instead of the ~140PB actually needed -- small enough that
-# malloc() succeeds and the overflow is immediately reachable.
+# The DS count (128) and --end value below put rows * ds_cnt * 8 about
+# 35x past the size_t wrap point, not right on top of it -- landing
+# exactly on the boundary made this test sensitive to a few percent of
+# difference in how --end's raw timestamp gets turned into a row count
+# (observed to vary enough between environments to flip the test's
+# outcome). With this much margin the guard fires the same way
+# regardless of that kind of small platform arithmetic difference.
 DS_ARGS=$(perl -e 'print join(" ", map { "DS:d$_:GAUGE:2:0:100" } (0..127))')
 
 eval "\$RRDTOOL create ${BUILD}.rrd --start 900000000 --step 1 \
@@ -27,7 +30,7 @@ UPDATE_ARGS=$(perl -e 'print "900000001:" . join(":", map { 1 } (0..127))')
 $RRDTOOL update ${BUILD}.rrd $UPDATE_ARGS || fail update
 
 if $RRDTOOL fetch ${BUILD}.rrd AVERAGE \
-    --start 900000000 --end 18014399409482082 --resolution 1 \
+    --start 900000000 --end 40000000900000000 --resolution 1 \
     >${BUILD}.out 2>&1; then
   fail 1 "fetch size overflow was accepted"
 fi

--- a/tests/security-fetch-daemon-arithmetic
+++ b/tests/security-fetch-daemon-arithmetic
@@ -26,7 +26,8 @@ BUILD=$BUILDDIR/$(basename $0)
 # oversized DS count needed: with a single DS and a 1-second-step RRA, the
 # same rows * ds_cnt * sizeof(double) product that rrd_fetch_fn() guards
 # against overflows with this one request.
-SOCK=$(mktemp -u /tmp/rrdcached-fetch-arith-XXXXXX).sock
+SOCKDIR=$(mktemp -d /tmp/rrdcached-fetch-arith-XXXXXX) || fail 1 "mktemp failed"
+SOCK="$SOCKDIR/cached.sock"
 PIDFILE=${BUILD}.pid
 LOG=${BUILD}-cached.log
 
@@ -43,6 +44,7 @@ cleanup() {
     kill -9 "$CACHED_PID" 2>/dev/null
   fi
   rm -f "$SOCK" "$PIDFILE"
+  rmdir "$SOCKDIR"
 }
 trap cleanup EXIT
 

--- a/tests/security-fetch-daemon-arithmetic
+++ b/tests/security-fetch-daemon-arithmetic
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# The size arithmetic being tested is computed in size_t, so this only
+# means something on the LP64 layout used by the supported Unix builds.
+test "$(getconf LONG_BIT)" = 64 || exit 77
+
+perl -MIO::Socket::UNIX -e 1 >/dev/null 2>&1 || exit 77
+
+DAEMON="$TOP_BUILDDIR/src/rrdcached"
+[ -x "$DAEMON" ] || exit 77
+
+BUILD=$BUILDDIR/$(basename $0)
+
+# rrdcached's FETCH/FETCHBIN commands take <start>/<end> as plain integers
+# handed straight to strtol(), unlike the rrdtool CLI which routes them
+# through rrd_parsetime()'s calendar handling. That makes a start/end span
+# near LONG_MAX directly reachable over the wire, no crafted RRD header or
+# oversized DS count needed: with a single DS and a 1-second-step RRA, the
+# same rows * ds_cnt * sizeof(double) product that rrd_fetch_fn() guards
+# against overflows with this one request.
+SOCK=$(mktemp -u /tmp/rrdcached-fetch-arith-XXXXXX).sock
+PIDFILE=${BUILD}.pid
+LOG=${BUILD}-cached.log
+
+cleanup() {
+  # A daemon caught by the bug under test is spinning in the fetch loop
+  # rather than blocked on I/O, so a plain SIGTERM may not stop it in time.
+  if [ -f "$PIDFILE" ]; then
+    CACHED_PID="$(cat "$PIDFILE")"
+    kill "$CACHED_PID" 2>/dev/null
+    for i in $(seq 1 20); do
+      kill -0 "$CACHED_PID" 2>/dev/null || break
+      sleep 0.1
+    done
+    kill -9 "$CACHED_PID" 2>/dev/null
+  fi
+  rm -f "$SOCK" "$PIDFILE"
+}
+trap cleanup EXIT
+
+$RRDTOOL create ${BUILD}.rrd --start 900000000 --step 1 \
+  DS:value:GAUGE:2:0:100 RRA:AVERAGE:0.5:1:5 || fail create
+
+$RRDTOOL update ${BUILD}.rrd 900000001:1 || fail update
+
+"$DAEMON" -p "$PIDFILE" -l "unix:$SOCK" -b "$(readlink -f -- "$BUILDDIR")" \
+  -B -o "$LOG" || fail 1 "rrdcached would not start"
+
+for i in $(seq 1 50); do
+  [ -S "$SOCK" ] && break
+  sleep 0.1
+done
+[ -S "$SOCK" ] || fail 1 "rrdcached did not open its listen socket"
+
+RESPONSE=$(perl -e '
+  use strict;
+  use warnings;
+  use IO::Socket::UNIX;
+  use IO::Select;
+
+  my ($sockpath, $cmd) = @ARGV;
+  my $sock = IO::Socket::UNIX->new(Peer => $sockpath, Type => SOCK_STREAM)
+    or die "connect failed: $!\n";
+  $sock->autoflush(1);
+  syswrite($sock, "$cmd\n") or die "write failed: $!\n";
+
+  my $sel = IO::Select->new($sock);
+  my $all = "";
+  my $deadline = time() + 15;
+  while (time() < $deadline) {
+    last unless $sel->can_read(1);
+    my $buf;
+    my $n = sysread($sock, $buf, 65536);
+    last if !defined($n) || $n == 0;
+    $all .= $buf;
+    last if $all =~ /\n/;
+  }
+  print $all eq "" ? "TIMEOUT\n" : $all;
+' "$SOCK" "FETCHBIN $(basename ${BUILD}.rrd) AVERAGE 900000000 2305843010113694050")
+
+case "$RESPONSE" in
+  *TIMEOUT*)
+    fail 1 "rrdcached did not respond to the oversized FETCHBIN request" ;;
+  *"fetch data size overflow"*)
+    : ;;
+  *)
+    fail 1 "unexpected rrdcached response: $RESPONSE" ;;
+esac
+report "reject FETCHBIN size overflow over the daemon protocol"

--- a/tests/security-fetch-daemon-arithmetic
+++ b/tests/security-fetch-daemon-arithmetic
@@ -2,6 +2,12 @@
 
 . $(dirname $0)/functions
 
+# This test starts and talks to its own private rrdcached instance over
+# a dedicated socket; running it nested inside the outer harness's own
+# daemon-transport styles conflicts with that setup rather than
+# exercising it (same reasoning as security-header-counts).
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+
 # The size arithmetic being tested is computed in size_t, so this only
 # means something on the LP64 layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -8,6 +8,7 @@
 
 # The on-disk format stores these counters as unsigned long.  The crafted
 # values below exercise the LP64 layout used by the supported Unix builds.
+[ -n "$MSYSTEM" ] && exit 77 # getconf describes MSYS, not the MinGW binary.
 test "$(getconf LONG_BIT)" = 64 || exit 77
 
 # RRDTOOL may contain the test harness command and wrapper arguments.
@@ -68,3 +69,23 @@ fi
 grep -q "reached EOF while loading header" "${BUILD}.out" || \
   fail 1 "truncated RRA header was not rejected before allocation"
 report "reject header array larger than remaining file bytes"
+
+# LP64 offsets: ds_cnt, rra_cnt, pdp_step, first RRA row_cnt and pdp_cnt.
+for offset in 24 32 40 272 280; do
+  cp "${BUILD}-ds.rrd" "${BUILD}-zero.rrd"
+  perl -0777 -pi -e 'BEGIN { $offset = shift @ARGV; } substr($_, $offset, 8, pack("Q", 0));' \
+    "$offset" "${BUILD}-zero.rrd"
+  for command in info fetch update; do
+    case "$command" in
+      info) args=() ;;
+      fetch) args=(AVERAGE --start 900000000 --end 900000120) ;;
+      update) args=(900000060:1) ;;
+    esac
+    $RRDTOOL "$command" "${BUILD}-zero.rrd" "${args[@]}" >"${BUILD}.out" 2>&1
+    status=$?
+    [ "$status" -ne 0 ] && [ "$status" -lt 128 ] || fail 1 "zero counter crashed or was accepted"
+    grep -Eq 'invalid ds_cnt/rra_cnt|pdp_step is zero|zero row_cnt/pdp_cnt' "${BUILD}.out" || \
+      fail 1 "zero counter was not diagnosed"
+  done
+done
+report "reject zero counters before info, fetch, and update"

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname $0)/functions
+. "$(dirname "$0")/functions"
 
 # This test mutates the local RRD file and is not meaningful through the
 # rrdcached transport variants of the test suite.
@@ -10,17 +10,61 @@
 # values below exercise the LP64 layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77
 
-BUILD=$BUILDDIR/$(basename $0)
+# RRDTOOL may contain the test harness command and wrapper arguments.
+BUILD="$BUILDDIR/$(basename "$0")"
 
-$RRDTOOL create ${BUILD}-ds.rrd --start 0 --step 60 \
+$RRDTOOL create "${BUILD}-ds.rrd" --start 0 --step 60 \
   DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail create-ds
 
-cp ${BUILD}-ds.rrd ${BUILD}-ds-overflow.rrd
-perl -0777 -pi -e 'substr($_, 24, 8, pack("Q<", 0x2000000000000001))' \
-  ${BUILD}-ds-overflow.rrd
-if $RRDTOOL info ${BUILD}-ds-overflow.rrd >${BUILD}.out 2>&1; then
+# Native LP64 layout: stat_head_t.ds_cnt is at byte 24. With one
+# ds_def_t, rra_def_t[0].row_cnt is at 272; each RRA record is 120 bytes,
+# so rra_def_t[1].row_cnt is at 392. RRD uses native byte order.
+cp "${BUILD}-ds.rrd" "${BUILD}-ds-overflow.rrd"
+perl -0777 -pi -e 'substr($_, 24, 8, pack("Q", 0x2000000000000001))' \
+  "${BUILD}-ds-overflow.rrd"
+if $RRDTOOL info "${BUILD}-ds-overflow.rrd" >"${BUILD}.out" 2>&1; then
   fail 1 "header ds_cnt overflow was accepted"
 fi
-grep -q "invalid ds_cnt/rra_cnt" ${BUILD}.out || \
+grep -q "invalid ds_cnt/rra_cnt" "${BUILD}.out" || \
   fail 1 "header ds_cnt overflow was not diagnosed"
 report "reject ds_cnt overflow"
+
+$RRDTOOL create "${BUILD}-rows.rrd" --start 0 --step 60 \
+  DS:value:GAUGE:120:U:U \
+  RRA:AVERAGE:0.5:1:2 RRA:AVERAGE:0.5:1:2 || fail create-rows
+
+cp "${BUILD}-rows.rrd" "${BUILD}-rows-overflow.rrd"
+perl -0777 -pi -e '
+  substr($_, 272, 8, pack("Q", 0x8000000000000000));
+  substr($_, 392, 8, pack("Q", 0x8000000000000000));
+' "${BUILD}-rows-overflow.rrd"
+if $RRDTOOL info "${BUILD}-rows-overflow.rrd" >"${BUILD}.out" 2>&1; then
+  fail 1 "cumulative RRA row-count overflow was accepted"
+fi
+grep -q "impossibly large database" "${BUILD}.out" || \
+  fail 1 "cumulative RRA row-count overflow was not diagnosed"
+report "reject cumulative RRA row-count overflow"
+
+# Each count fits size_t, but their product (the CDP record count) does not.
+# The file-size guard should reject this before attempting any large allocation.
+cp "${BUILD}-ds.rrd" "${BUILD}-cdp-overflow.rrd"
+perl -0777 -pi -e '
+  substr($_, 24, 8, pack("Q", 0x100000000));
+  substr($_, 32, 8, pack("Q", 0x100000000));
+' "${BUILD}-cdp-overflow.rrd"
+if $RRDTOOL info "${BUILD}-cdp-overflow.rrd" >"${BUILD}.out" 2>&1; then
+  fail 1 "overflowing CDP count was accepted"
+fi
+grep -q "invalid ds_cnt/rra_cnt" "${BUILD}.out" || \
+  fail 1 "overflowing CDP count was not rejected before allocation"
+report "reject counts whose CDP product overflows"
+
+# LP64: the RRA array begins at 248 and needs 120 bytes. A 350-byte file
+# passes the individual count limits but has only 102 bytes remaining.
+head -c 350 "${BUILD}-ds.rrd" > "${BUILD}-truncated.rrd"
+if $RRDTOOL info "${BUILD}-truncated.rrd" >"${BUILD}.out" 2>&1; then
+  fail 1 "truncated RRA header was accepted"
+fi
+grep -q "reached EOF while loading header" "${BUILD}.out" || \
+  fail 1 "truncated RRA header was not rejected before allocation"
+report "reject header array larger than remaining file bytes"

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -2,6 +2,10 @@
 
 . $(dirname $0)/functions
 
+# This test mutates the local RRD file and is not meaningful through the
+# rrdcached transport variants of the test suite.
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+
 # The on-disk format stores these counters as unsigned long.  The crafted
 # values below exercise the LP64 layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# The on-disk format stores these counters as unsigned long.  The crafted
+# values below exercise the LP64 layout used by the supported Unix builds.
+test "$(getconf LONG_BIT)" = 64 || exit 77
+
+BUILD=$BUILDDIR/$(basename $0)
+
+$RRDTOOL create ${BUILD}-ds.rrd --start 0 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail create-ds
+
+cp ${BUILD}-ds.rrd ${BUILD}-ds-overflow.rrd
+perl -0777 -pi -e 'substr($_, 24, 8, pack("Q<", 0x2000000000000001))' \
+  ${BUILD}-ds-overflow.rrd
+if $RRDTOOL info ${BUILD}-ds-overflow.rrd >${BUILD}.out 2>&1; then
+  fail 1 "header ds_cnt overflow was accepted"
+fi
+grep -q "invalid ds_cnt/rra_cnt" ${BUILD}.out || \
+  fail 1 "header ds_cnt overflow was not diagnosed"
+report "reject ds_cnt overflow"

--- a/tests/security-rados-bounds
+++ b/tests/security-rados-bounds
@@ -1,6 +1,7 @@
 #!/bin/bash
 . "$(dirname "$0")/functions"
 [ -n "$RRDCACHED_ADDRESS" ] && exit 77
+[ -x "$BUILDDIR/mock-rados-bounds" ] || exit 77
 [ "$(getconf LONG_BIT)" = 64 ] || exit 77
 WORK=$(mktemp -d "$BUILDDIR/rados-bounds.XXXXXX") || fail 1 mktemp
 trap 'rm -rf "$WORK"' EXIT

--- a/tests/security-rados-bounds
+++ b/tests/security-rados-bounds
@@ -1,0 +1,10 @@
+#!/bin/bash
+. "$(dirname "$0")/functions"
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+[ "$(getconf LONG_BIT)" = 64 ] || exit 77
+WORK=$(mktemp -d "$BUILDDIR/rados-bounds.XXXXXX") || fail 1 mktemp
+trap 'rm -rf "$WORK"' EXIT
+$RRDTOOL create "$WORK/object.rrd" --start 900000000 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail 1 create
+"$BUILDDIR/mock-rados-bounds" "$WORK/object.rrd" || fail 1 "RADOS bounds regression"
+report "RADOS read/write, stat failure, and truncated object bounds"

--- a/tests/security-rrdcached-response-bounds
+++ b/tests/security-rrdcached-response-bounds
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# add_response_info() (src/rrd_daemon.c) formats each "extra" response
+# line into a fixed RRD_CMD_MAX-sized stack buffer with vsnprintf(), then
+# used vsnprintf()'s return value as the byte count for wbuf_append().
+# vsnprintf() returns the length that *would* have been written, not the
+# length actually written, so a formatted line longer than the buffer
+# made wbuf_append() read past the end of that stack buffer and send the
+# overrun bytes to the client. PENDING echoes back queued UPDATE values
+# verbatim via "%s\n", so one oversized UPDATE value reaches the bug.
+#
+# This talks to rrdcached's line protocol directly over its unix socket
+# (rather than through the rrdtool CLI) so the raw response bytes can be
+# inspected for the overrun.
+
+command -v python3 >/dev/null 2>&1 || exit 77
+[ -n "$MSYSTEM" ] && exit 77
+
+# AF_UNIX socket paths are capped at ~104 bytes on BSD/macOS; a checkout
+# under a long path (e.g. a deep CI workspace, or macOS's $TMPDIR) can
+# push run_cached's default $BUILDDIR/cached/<test>-rrdcached.sock past
+# that. Point the cache base dir at a short directory under /tmp instead.
+SHORTBASE=$(mktemp -d /tmp/rc-bounds.XXXXXX) || fail 1 "mktemp failed"
+mkdir -p "$SHORTBASE/cached"
+BUILDDIR=$SHORTBASE
+
+RRDCACHED_SOCK=unix
+run_cached
+trap 'stop_cached; rm -rf "$SHORTBASE"' EXIT
+
+BUILD=$BUILDDIR/$(basename $0)
+RELFILE=$(basename $0).rrd
+
+$RRDTOOL create ${BUILD}.rrd --start 0 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail 1 create
+
+SOCKPATH=${RRDCACHED_ADDRESS#unix:}
+
+python3 - "$SOCKPATH" "$RELFILE" <<'PYEOF'
+import socket
+import sys
+
+sockpath, relfile = sys.argv[1], sys.argv[2]
+
+# RRD_CMD_MAX (src/rrd_client.h); add_response_info()'s stack buffer.
+RRD_CMD_MAX = 4096
+
+ts_colon = "9999999999:"
+value = ts_colon + "A" * 6000  # well past RRD_CMD_MAX once formatted
+
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(5)
+s.connect(sockpath)
+
+buf = b""
+
+
+def read_line():
+    global buf
+    while b"\n" not in buf:
+        chunk = s.recv(65536)
+        if not chunk:
+            break
+        buf += chunk
+    line, _, buf = buf.partition(b"\n")
+    return line
+
+
+s.sendall(("UPDATE " + relfile + " " + value + "\n").encode())
+update_resp = read_line()
+if not update_resp.startswith(b"0 "):
+    print("unexpected UPDATE response: %r" % update_resp)
+    sys.exit(1)
+
+s.sendall(("PENDING " + relfile + "\n").encode())
+assert read_line().startswith(b"1 "), "PENDING must advertise its one body line"
+body = read_line()
+expected = (ts_colon + "A" * (RRD_CMD_MAX - 2 - len(ts_colon))).encode()
+assert body == expected, "PENDING must clamp its body and preserve the newline"
+
+
+def ping():
+    s.sendall(b"PING\n")
+    assert read_line().startswith(b"0 "), "connection is out of sync"
+
+
+ping()
+s.sendall(b"X" * 8000 + b"\n")
+error = read_line()
+assert error.startswith(b"-1 "), "oversized unknown command must fail"
+assert len(error) == RRD_CMD_MAX - 2, "status response is not bounded"
+ping()
+
+s.sendall(b"BATCH\n")
+assert read_line().startswith(b"0 "), "BATCH did not start"
+s.sendall(b"X" * 8000 + b"\n.\n")
+assert read_line().startswith(b"1 "), "BATCH must advertise its one error line"
+error = read_line()
+assert len(error) == RRD_CMD_MAX - 2, "BATCH error is not bounded"
+ping()
+s.close()
+print("PENDING, status, and BATCH responses are bounded and keep the connection in sync")
+
+PYEOF
+STATUS=$?
+
+test $STATUS -eq 0 || fail 1 "oversized PENDING response was not bounded to the formatting buffer"
+report "PENDING response to an oversized cached UPDATE value is bounded"

--- a/tests/security-rrdcached-response-bounds
+++ b/tests/security-rrdcached-response-bounds
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname $0)/functions
+. "$(dirname "$0")/functions"
 
 # add_response_info() (src/rrd_daemon.c) formats each "extra" response
 # line into a fixed RRD_CMD_MAX-sized stack buffer with vsnprintf(), then
@@ -17,6 +17,8 @@
 
 command -v python3 >/dev/null 2>&1 || exit 77
 [ -n "$MSYSTEM" ] && exit 77
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+[ -x "$TOP_BUILDDIR/src/rrdcached" ] || exit 77
 
 # AF_UNIX socket paths are capped at ~104 bytes on BSD/macOS; a checkout
 # under a long path (e.g. a deep CI workspace, or macOS's $TMPDIR) can

--- a/tests/test_fetch_empty_security.c
+++ b/tests/test_fetch_empty_security.c
@@ -1,0 +1,49 @@
+#include "rrd_tool.h"
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int run_case(time_t end, unsigned long step, const char *error)
+{
+    time_t start = 900000000;
+    unsigned long ds_cnt = 0;
+    char **names = NULL;
+    rrd_value_t *values = NULL;
+    int status;
+    rrd_clear_error();
+    status = rrd_fetch_empty(&start, &end, &step, &ds_cnt, "value", &names, &values);
+    if (error != NULL) {
+        if (status == 0 || !strstr(rrd_get_error(), error)) {
+            fprintf(stderr, "expected %s, got %s\n", error, rrd_get_error());
+            return 1;
+        }
+        return 0;
+    }
+    if (status != 0 || ds_cnt != 1)
+        return 1;
+    for (size_t i = 0; i < (size_t)((end - start) / step + 1); ++i) {
+        if (!isnan(values[i]))
+            return 1;
+    }
+    free(names[0]);
+    free(names);
+    free(values);
+    return 0;
+}
+
+int main(void)
+{
+    if (run_case(900000010, 0, "fetch step is zero") ||
+        run_case(899999999, 1, "fetch end precedes start") ||
+        run_case(900000010, 1, NULL))
+        return 1;
+    /* On narrower time_t ABIs this allocation boundary is unreachable. */
+    if (sizeof(time_t) >= sizeof(size_t) && sizeof(time_t) >= 8) {
+        time_t end = (time_t)(SIZE_MAX / sizeof(rrd_value_t) + 900000001);
+        if (run_case(end, 1, "fetch data size overflow"))
+            return 1;
+    }
+    return 0;
+}

--- a/tests/test_rrd_open_security.c
+++ b/tests/test_rrd_open_security.c
@@ -1,0 +1,82 @@
+#ifdef HAVE_CONFIG_H
+#include "rrd_config.h"
+#endif
+
+#include "rrd_tool.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int fail(
+    const char *message)
+{
+    fprintf(stderr, "%s", message);
+    if (rrd_test_error())
+        fprintf(stderr, ": %s", rrd_get_error());
+    fputc('\n', stderr);
+    return 1;
+}
+
+int main(void)
+{
+#ifndef HAVE_MMAP
+    return 77;
+#else
+    const char *args[] = {
+        "DS:value:GAUGE:120:U:U",
+        "RRA:AVERAGE:0.5:1:2"
+    };
+    const char *builddir;
+    char      path[4096];
+    rrd_t     rrd;
+    rrd_file_t *rrd_file;
+    int       status;
+
+    builddir = getenv("BUILDDIR");
+    if (builddir == NULL)
+        builddir = ".";
+    status = snprintf(path, sizeof(path), "%s/rrd-open-security.rrd",
+                      builddir);
+    if (status < 0 || (size_t) status >= sizeof(path))
+        return fail("temporary RRD path is too long");
+
+    remove(path);
+    rrd_clear_error();
+    if (rrd_create_r(path, 60, 1, 2, args) != 0)
+        return fail("could not create the test RRD");
+
+    rrd_init(&rrd);
+    rrd_file = rrd_open(path, &rrd, RRD_READWRITE | RRD_LOCK_NONE);
+    if (rrd_file == NULL) {
+        rrd_free(&rrd);
+        remove(path);
+        return fail("could not open the test RRD for mutation");
+    }
+
+    rrd.rra_def[0].row_cnt = ULONG_MAX;
+    rrd_close(rrd_file);
+    rrd_free(&rrd);
+
+    rrd_clear_error();
+    rrd_init(&rrd);
+    rrd_file = rrd_open(path, &rrd, RRD_READONLY | RRD_LOCK_NONE);
+    if (rrd_file != NULL) {
+        rrd_close(rrd_file);
+        rrd_free(&rrd);
+        remove(path);
+        return fail("RRD with an overflowing row count was accepted");
+    }
+    rrd_free(&rrd);
+
+    if (!rrd_test_error() ||
+        strstr(rrd_get_error(), "impossibly large database") == NULL) {
+        remove(path);
+        return fail("row-count overflow was not diagnosed");
+    }
+
+    remove(path);
+    return 0;
+#endif
+}

--- a/tests/test_rrd_open_security.c
+++ b/tests/test_rrd_open_security.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 static int fail(
     const char *message)
@@ -33,19 +34,32 @@ int main(void)
     rrd_t     rrd;
     rrd_file_t *rrd_file;
     int       status;
+    int       fd;
+
+    /* ULONG_MAX must overflow the size_t byte count, not just allocate GBs. */
+    if (ULONG_MAX <= (size_t) -1 / sizeof(rrd_value_t))
+        return 77;
 
     builddir = getenv("BUILDDIR");
     if (builddir == NULL)
         builddir = ".";
-    status = snprintf(path, sizeof(path), "%s/rrd-open-security.rrd",
+    status = snprintf(path, sizeof(path), "%s/rrd-open-security-XXXXXX",
                       builddir);
     if (status < 0 || (size_t) status >= sizeof(path))
         return fail("temporary RRD path is too long");
 
-    remove(path);
+    fd = mkstemp(path);
+    if (fd < 0)
+        return fail("could not reserve the temporary RRD path");
+    if (close(fd) != 0) {
+        remove(path);
+        return fail("could not close the temporary RRD file");
+    }
     rrd_clear_error();
-    if (rrd_create_r(path, 60, 1, 2, args) != 0)
+    if (rrd_create_r(path, 60, 1, 2, args) != 0) {
+        remove(path);
         return fail("could not create the test RRD");
+    }
 
     rrd_init(&rrd);
     rrd_file = rrd_open(path, &rrd, RRD_READWRITE | RRD_LOCK_NONE);
@@ -56,8 +70,12 @@ int main(void)
     }
 
     rrd.rra_def[0].row_cnt = ULONG_MAX;
-    rrd_close(rrd_file);
+    status = rrd_close(rrd_file);
     rrd_free(&rrd);
+    if (status != 0) {
+        remove(path);
+        return fail("could not persist the test RRD mutation");
+    }
 
     rrd_clear_error();
     rrd_init(&rrd);

--- a/tests/test_rrd_rados_bounds.c
+++ b/tests/test_rrd_rados_bounds.c
@@ -1,0 +1,134 @@
+/* Exercise the real RADOS branch of rrd_open without a Ceph cluster. */
+#include "rrd_rados.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int object_fd, stat_fail, reads;
+
+int rados_stat(rados_ioctx_t io, const char *oid, uint64_t *size, time_t *mtime)
+{
+    struct stat st;
+    (void) io;
+    (void) oid;
+    if (stat_fail)
+        return -EACCES;
+    if (fstat(object_fd, &st))
+        return -errno;
+    *size = st.st_size;
+    *mtime = st.st_mtime;
+    return 0;
+}
+
+rrd_rados_t *rrd_rados_open(const char *oid)
+{
+    rrd_rados_t *r = calloc(1, sizeof(*r));
+    if (r == NULL)
+        return NULL;
+    object_fd = open(oid, O_RDWR);
+    if (object_fd < 0) {
+        free(r);
+        return NULL;
+    }
+    r->oid = oid;
+    return r;
+}
+
+int rrd_rados_close(rrd_rados_t *r)
+{
+    int status = close(object_fd);
+    free(r);
+    return status;
+}
+
+int rrd_rados_flush(rrd_rados_t *r)
+{
+    (void) r;
+    return 0;
+}
+
+int rrd_rados_lock(rrd_rados_t *r)
+{
+    (void) r;
+    return 0;
+}
+
+int rrd_rados_create(const char *oid, rrd_t *rrd)
+{
+    (void) oid;
+    (void) rrd;
+    return -1; /* The fixture is created through the local-file backend. */
+}
+
+size_t rrd_rados_read(rrd_rados_t *r, void *buf, size_t len, uint64_t off)
+{
+    (void) r;
+    reads++;
+    return pread(object_fd, buf, len, off);
+}
+
+size_t rrd_rados_write(rrd_rados_t *r, const void *buf, size_t len, uint64_t off)
+{
+    (void) r;
+    return pwrite(object_fd, buf, len, off);
+}
+
+static int fail(const char *message)
+{
+    fprintf(stderr, "%s: %s\n", message, rrd_get_error());
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    rrd_t rrd;
+    rrd_file_t *f;
+    rrd_value_t value = 42.0, actual;
+    char path[4096];
+    int length;
+
+    if (argc != 2)
+        return 1;
+    length = snprintf(path, sizeof(path), "ceph//%s", argv[1]);
+    if (length < 0 || (size_t) length >= sizeof(path))
+        return fail("fixture path is too long");
+    rrd_init(&rrd);
+    f = rrd_open(path, &rrd, RRD_READWRITE | RRD_LOCK_NONE);
+    if (!f)
+        return fail("could not open mocked RADOS object");
+    if (rrd_seek(f, f->header_len, SEEK_SET) ||
+        rrd_write(f, &value, sizeof(value)) != sizeof(value))
+        return fail("could not update mocked RADOS object");
+    if (rrd_seek(f, f->header_len, SEEK_SET) ||
+        rrd_read(f, &actual, sizeof(actual)) != sizeof(actual) || actual != value)
+        return fail("RADOS read did not return the updated value");
+    if (rrd_close(f))
+        return fail("could not close mocked RADOS object");
+    rrd_free(&rrd);
+
+    stat_fail = 1;
+    reads = 0;
+    rrd_init(&rrd);
+    rrd_clear_error();
+    f = rrd_open(path, &rrd, RRD_READONLY | RRD_LOCK_NONE);
+    if (f || reads || !strstr(rrd_get_error(), "could not stat RADOS"))
+        return fail("stat failure did not prevent header reads");
+    rrd_free(&rrd);
+
+    stat_fail = 0;
+    reads = 0;
+    /* LP64: the RRA starts at 248 and needs another 120 bytes. */
+    if (truncate(argv[1], 350))
+        return fail("could not truncate the fixture");
+    rrd_init(&rrd);
+    rrd_clear_error();
+    f = rrd_open(path, &rrd, RRD_READONLY | RRD_LOCK_NONE);
+    if (f || reads != 2 || !strstr(rrd_get_error(), "reached EOF"))
+        return fail("truncated RRA was read instead of rejected");
+    rrd_free(&rrd);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- check fetch buffer multiplication before allocation
- use size_t for fetch indexing and reject oversized FETCHBIN buffers

## Testing
- includes `tests/security-header-counts` in the Automake test suite
- existing fetch coverage in `tests/dcounter1` and `tests/pdp-calc1`
- `CCACHE_DISABLE=1 make -j4`

This branch includes prerequisite hardening commits because GitHub cannot target a fork-only prerequisite branch.