### PR TITLE
hardening: check XML restore allocation arithmetic

### DIFF
--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -2244,7 +2244,7 @@ static int handle_request_fetch(
          t <= parsed.end_tm; t += parsed.step, j++) {
         add_response_info(sock, "%10lu:", (unsigned long) t);
         for (i = 0; i < parsed.field_cnt; i++) {
-            unsigned int idx = j * parsed.ds_cnt + parsed.field_idx[i];
+            size_t idx = (size_t) j * parsed.ds_cnt + parsed.field_idx[i];
 
             add_response_info(sock, " %0.17e", parsed.data[idx]);
         }
@@ -2274,6 +2274,10 @@ static int handle_request_fetchbin(
         return 0;
 
     /* create a buffer for the full binary line */
+    if (parsed.steps > (size_t) -1 / sizeof(double)) {
+        free_fetch_parsed(&parsed);
+        return send_response(sock, RESP_ERR, "Fetch range is too large\n");
+    }
     dbuffer_size = sizeof(double) * parsed.steps;
     dbuffer = calloc(1, dbuffer_size);
     if (!dbuffer) {
@@ -2292,7 +2296,7 @@ static int handle_request_fetchbin(
     for (i = 0; i < parsed.field_cnt; i++) {
         for (t = parsed.start_tm + parsed.step, j = 0;
              t <= parsed.end_tm; t += parsed.step, j++) {
-            unsigned int idx = j * parsed.ds_cnt + parsed.field_idx[i];
+            size_t idx = (size_t) j * parsed.ds_cnt + parsed.field_idx[i];
 
             dbuffer[j] = parsed.data[idx];
         }

--- a/src/rrd_daemon.c
+++ b/src/rrd_daemon.c
@@ -794,6 +794,12 @@ static int add_response_info(
         return -1;
     }
 
+    /* vsnprintf() returns the length that would have been written. Clamp
+     * that length before passing the buffer to wbuf_append(), otherwise a
+     * long formatted response makes wbuf_append() read past buffer. */
+    if ((size_t) len >= sizeof(buffer))
+        len = sizeof(buffer) - 1;
+
     return wbuf_append(sock, buffer, len);
 }                       /* }}} static int add_response_info */
 

--- a/src/rrd_fetch.c
+++ b/src/rrd_fetch.c
@@ -460,7 +460,14 @@ int rrd_fetch_fn(
 ** database is the one with time stamp (t+s) which means t to t+s.
 */
     *ds_cnt = rrd.stat_head->ds_cnt;
-    if (((*data) = (rrd_value_t*)malloc(*ds_cnt * rows * sizeof(rrd_value_t))) == NULL) {
+    if (*ds_cnt != 0 &&
+        (rows > (size_t) -1 / *ds_cnt ||
+         rows * *ds_cnt > (size_t) -1 / sizeof(rrd_value_t))) {
+        rrd_set_error("fetch data size overflow");
+        goto err_free_all_ds_namv;
+    }
+    if (((*data) = (rrd_value_t *) malloc(*ds_cnt * rows *
+                                          sizeof(rrd_value_t))) == NULL) {
         rrd_set_error("malloc fetch data area");
         goto err_free_all_ds_namv;
     }

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -62,13 +62,47 @@ DWORD     dwCreationDisposition = 0;
 /* Avoid calling madvise on areas that were already hinted. May be beneficial if
  * your syscalls are very slow */
 
+/* ds_cnt / rra_cnt and the record counts derived from them are read straight
+ * from an untrusted file.  Every "sizeof(record) * count" used below as an
+ * offset or allocation size must be range-checked first: a crafted count can
+ * otherwise wrap size_t, pass the "> file_len" bounds check, and alias or
+ * iterate past the mapped file.
+ */
+static inline int rrd_mul_overflow(
+    size_t a,
+    size_t b,
+    size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_mul_overflow(a, b, out);
+#else
+    *out = a * b;
+    return b != 0 && a > (size_t) -1 / b;
+#endif
+}
+
+static inline int rrd_add_overflow(
+    size_t a,
+    size_t b,
+    size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_add_overflow(a, b, out);
+#else
+    *out = a + b;
+    return a > (size_t) -1 - b;
+#endif
+}
+
 #ifdef HAVE_MMAP
 /* the cast to void* is there to avoid this warning seen on ia64 with certain
    versions of gcc: 'cast increases required alignment of target type'
 */
 #define __rrd_read_mmap(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
-    if (offset + wanted > rrd_file->file_len) { \
+    size_t wanted; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
+        offset > rrd_file->file_len || \
+        wanted > rrd_file->file_len - offset) { \
         rrd_set_error("reached EOF while loading header " #dst); \
         goto out_close; \
     } \
@@ -77,8 +111,13 @@ DWORD     dwCreationDisposition = 0;
     }
 #else
 #define __rrd_read_seq(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted; \
         size_t got; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted) || \
+        wanted > rrd_file->file_len) { \
+        rrd_set_error("reached EOF while loading header " #dst); \
+        goto out_close; \
+    } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
         rrd_set_error(#dst " malloc"); \
         goto out_close; \
@@ -94,8 +133,12 @@ DWORD     dwCreationDisposition = 0;
 
 #ifdef HAVE_LIBRADOS
 #define __rrd_read_rados(dst, dst_t, cnt) { \
-    size_t wanted = sizeof(dst_t)*(cnt); \
+    size_t wanted; \
         size_t got; \
+    if (rrd_mul_overflow(sizeof(dst_t), (size_t)(cnt), &wanted)) { \
+        rrd_set_error("header size overflow while reading " #dst); \
+        goto out_close; \
+    } \
     if ((dst = (dst_t*)malloc(wanted)) == NULL) { \
         rrd_set_error(#dst " malloc"); \
         goto out_close; \
@@ -509,6 +552,27 @@ rrd_file_t *rrd_open(
                       rrd->stat_head->version);
         goto out_close;
     }
+
+    /* Bound the attacker-controlled counts by the file size before any
+     * "sizeof(record) * count" arithmetic.  A valid RRD must physically
+     * contain ds_cnt ds_def_t and rra_cnt rra_def_t records, so a well-formed
+     * file is never rejected, while a crafted count can no longer wrap size_t.
+     * The rados backend does not know its length here (file_len is filled in
+     * after the header is read), so it relies on the per-read overflow checks.
+     */
+#ifdef HAVE_LIBRADOS
+    if (!rrd_file->rados)
+#endif
+    {
+        if (rrd->stat_head->ds_cnt == 0 ||
+            rrd->stat_head->ds_cnt > rrd_file->file_len / sizeof(ds_def_t) ||
+            rrd->stat_head->rra_cnt == 0 ||
+            rrd->stat_head->rra_cnt > rrd_file->file_len / sizeof(rra_def_t)) {
+            rrd_set_error("'%s' has an invalid ds_cnt/rra_cnt in its header",
+                          file_name);
+            goto out_close;
+        }
+    }
     __rrd_read(rrd->ds_def, ds_def_t,
                rrd->stat_head->ds_cnt);
 
@@ -533,8 +597,16 @@ rrd_file_t *rrd_open(
     }
     __rrd_read(rrd->pdp_prep, pdp_prep_t,
                rrd->stat_head->ds_cnt);
-    __rrd_read(rrd->cdp_prep, cdp_prep_t,
-               rrd->stat_head->rra_cnt * rrd->stat_head->ds_cnt);
+    {
+        size_t    cdp_cnt;
+
+        if (rrd_mul_overflow(rrd->stat_head->rra_cnt,
+                             rrd->stat_head->ds_cnt, &cdp_cnt)) {
+            rrd_set_error("'%s' header cdp_prep count overflow", file_name);
+            goto out_close;
+        }
+        __rrd_read(rrd->cdp_prep, cdp_prep_t, cdp_cnt);
+    }
     __rrd_read(rrd->rra_ptr, rra_ptr_t,
                rrd->stat_head->rra_cnt);
 
@@ -559,11 +631,23 @@ rrd_file_t *rrd_open(
     {
         unsigned long row_cnt = 0;
 
+        size_t    value_cnt;
+        size_t    correct_len;
+
         for (ui = 0; ui < rrd->stat_head->rra_cnt; ui++)
             row_cnt += rrd->rra_def[ui].row_cnt;
 
-        size_t    correct_len = rrd_file->header_len +
-            sizeof(rrd_value_t) * row_cnt * rrd->stat_head->ds_cnt;
+        /* row_cnt is the sum of attacker-controlled rra_def[].row_cnt, so the
+         * data-section size can overflow size_t.  Compute it with overflow
+         * checks so a crafted header cannot make correct_len wrap below the
+         * real file length. */
+        if (rrd_mul_overflow(row_cnt, rrd->stat_head->ds_cnt, &value_cnt) ||
+            rrd_mul_overflow(value_cnt, sizeof(rrd_value_t), &correct_len) ||
+            rrd_add_overflow(rrd_file->header_len, correct_len, &correct_len)) {
+            rrd_set_error("'%s' header describes an impossibly large database",
+                          file_name);
+            goto out_close;
+        }
 
 #ifdef HAVE_LIBRADOS
         /* skip length checking for rados file */
@@ -579,7 +663,7 @@ rrd_file_t *rrd_open(
         }
         if (rdwr & RRD_READVALUES) {
             __rrd_read(rrd->rrd_value, rrd_value_t,
-                       row_cnt * rrd->stat_head->ds_cnt);
+                       value_cnt);
 
             if (rrd_seek(rrd_file, rrd_file->header_len, SEEK_SET) != 0)
                 goto out_close;

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -10,6 +10,30 @@
  *************************************************************************** */
 
 #include "rrd_tool.h"
+
+static int restore_mul_overflow(size_t a, size_t b, size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_mul_overflow(a, b, out);
+#else
+    if (b != 0 && a > (size_t) -1 / b)
+        return 1;
+    *out = a * b;
+    return 0;
+#endif
+}
+
+static int restore_add_overflow(size_t a, size_t b, size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_add_overflow(a, b, out);
+#else
+    if (a > (size_t) -1 - b)
+        return 1;
+    *out = a + b;
+    return 0;
+#endif
+}
 #include "rrd_rpncalc.h"
 #include "rrd_restore.h"
 #include "unused.h"
@@ -406,18 +430,23 @@ static int parse_tag_rra_database(
 {
     rra_def_t *cur_rra_def;
     rra_ptr_t *cur_rra_ptr;
-    unsigned int total_row_cnt;
+    size_t    total_row_cnt;
     int       status;
     int       i;
     xmlChar *element;
-    unsigned int start_row_cnt;
-    int       ds_cnt;
+    size_t    start_row_cnt;
+    size_t    ds_cnt;
     
     ds_cnt = rrd->stat_head->ds_cnt;
     
     total_row_cnt = 0;
     for (i = 0; i < (((int) rrd->stat_head->rra_cnt) - 1); i++)
-        total_row_cnt += rrd->rra_def[i].row_cnt;
+        if (restore_add_overflow(total_row_cnt,
+                                 (size_t) rrd->rra_def[i].row_cnt,
+                                 &total_row_cnt)) {
+            rrd_set_error("parse_tag_rra_database: row count overflow");
+            return -1;
+        }
 
     cur_rra_def = rrd->rra_def + i;
     cur_rra_ptr = rrd->rra_ptr + i;
@@ -428,13 +457,22 @@ static int parse_tag_rra_database(
         if (xmlStrcasecmp(element,(const xmlChar *)"row") == 0){
            rrd_value_t *temp;
            rrd_value_t *cur_rrd_value;
-           unsigned int total_values_count = rrd->stat_head->ds_cnt
-               * (total_row_cnt + 1);
+           size_t total_values_count;
+           size_t total_rows;
+           size_t total_values_bytes;
+
+            if (restore_add_overflow(total_row_cnt, 1, &total_rows) ||
+                restore_mul_overflow(ds_cnt, total_rows, &total_values_count) ||
+                restore_mul_overflow(sizeof(rrd_value_t), total_values_count,
+                                     &total_values_bytes)) {
+                rrd_set_error("parse_tag_rra_database: data size overflow");
+                status = -1;
+                break;
+            }
 
             /* Allocate space for the new values.. */
             temp = (rrd_value_t *) realloc(rrd->rrd_value,
-                                           sizeof(rrd_value_t) *
-                                           total_values_count);
+                                           total_values_bytes);
             if (temp == NULL) {
                 rrd_set_error("parse_tag_rra_database: realloc failed.");
                 status = -1;
@@ -502,9 +540,17 @@ static int parse_tag_rra_database(
      copy temp buffer to position after where we moved n to
      */
     
-    int a = cur_rra_def->row_cnt - cur_rra_ptr->cur_row - 1;
-    
-    rrd_value_t *temp = malloc(ds_cnt * sizeof(rrd_value_t) * a);
+    size_t a = (size_t) cur_rra_def->row_cnt -
+               (size_t) cur_rra_ptr->cur_row - 1;
+    size_t temp_count;
+
+    if (restore_mul_overflow(ds_cnt, a, &temp_count) ||
+        restore_mul_overflow(sizeof(rrd_value_t), temp_count, &temp_count)) {
+        rrd_set_error("parse_tag_rra: data size overflow");
+        return -1;
+    }
+
+    rrd_value_t *temp = malloc(temp_count);
     if (temp == NULL) {
         rrd_set_error("parse_tag_rra: malloc failed.");
         return -1;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,8 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5
+	pdp-calc1 graph3 graph4 graph5 \
+	security-header-counts
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,7 +7,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
 	pdp-calc1 graph3 graph4 graph5 \
-	security-header-counts
+	security-header-counts rrd-open-security
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \
@@ -37,9 +37,16 @@ CLEANFILES = *.rrd \
 	rpn1.out rpn1.output.out
 
 check_PROGRAMS = \
-	compat-cloexec
+	compat-cloexec \
+	rrd-open-security
 
 compat_cloexec_SOURCES = \
 	test_compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.h
+
+rrd_open_security_SOURCES = \
+	test_rrd_open_security.c
+
+rrd_open_security_LDADD = \
+	${top_builddir}/src/librrd.la

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -2,6 +2,10 @@
 
 . $(dirname $0)/functions
 
+# This test mutates the local RRD file and is not meaningful through the
+# rrdcached transport variants of the test suite.
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+
 # The on-disk format stores these counters as unsigned long.  The crafted
 # values below exercise the LP64 layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77

--- a/tests/security-header-counts
+++ b/tests/security-header-counts
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# The on-disk format stores these counters as unsigned long.  The crafted
+# values below exercise the LP64 layout used by the supported Unix builds.
+test "$(getconf LONG_BIT)" = 64 || exit 77
+
+BUILD=$BUILDDIR/$(basename $0)
+
+$RRDTOOL create ${BUILD}-ds.rrd --start 0 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:2 || fail create-ds
+
+cp ${BUILD}-ds.rrd ${BUILD}-ds-overflow.rrd
+perl -0777 -pi -e 'substr($_, 24, 8, pack("Q<", 0x2000000000000001))' \
+  ${BUILD}-ds-overflow.rrd
+if $RRDTOOL info ${BUILD}-ds-overflow.rrd >${BUILD}.out 2>&1; then
+  fail 1 "header ds_cnt overflow was accepted"
+fi
+grep -q "invalid ds_cnt/rra_cnt" ${BUILD}.out || \
+  fail 1 "header ds_cnt overflow was not diagnosed"
+report "reject ds_cnt overflow"

--- a/tests/test_rrd_open_security.c
+++ b/tests/test_rrd_open_security.c
@@ -1,0 +1,82 @@
+#ifdef HAVE_CONFIG_H
+#include "rrd_config.h"
+#endif
+
+#include "rrd_tool.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int fail(
+    const char *message)
+{
+    fprintf(stderr, "%s", message);
+    if (rrd_test_error())
+        fprintf(stderr, ": %s", rrd_get_error());
+    fputc('\n', stderr);
+    return 1;
+}
+
+int main(void)
+{
+#ifndef HAVE_MMAP
+    return 77;
+#else
+    const char *args[] = {
+        "DS:value:GAUGE:120:U:U",
+        "RRA:AVERAGE:0.5:1:2"
+    };
+    const char *builddir;
+    char      path[4096];
+    rrd_t     rrd;
+    rrd_file_t *rrd_file;
+    int       status;
+
+    builddir = getenv("BUILDDIR");
+    if (builddir == NULL)
+        builddir = ".";
+    status = snprintf(path, sizeof(path), "%s/rrd-open-security.rrd",
+                      builddir);
+    if (status < 0 || (size_t) status >= sizeof(path))
+        return fail("temporary RRD path is too long");
+
+    remove(path);
+    rrd_clear_error();
+    if (rrd_create_r(path, 60, 1, 2, args) != 0)
+        return fail("could not create the test RRD");
+
+    rrd_init(&rrd);
+    rrd_file = rrd_open(path, &rrd, RRD_READWRITE | RRD_LOCK_NONE);
+    if (rrd_file == NULL) {
+        rrd_free(&rrd);
+        remove(path);
+        return fail("could not open the test RRD for mutation");
+    }
+
+    rrd.rra_def[0].row_cnt = ULONG_MAX;
+    rrd_close(rrd_file);
+    rrd_free(&rrd);
+
+    rrd_clear_error();
+    rrd_init(&rrd);
+    rrd_file = rrd_open(path, &rrd, RRD_READONLY | RRD_LOCK_NONE);
+    if (rrd_file != NULL) {
+        rrd_close(rrd_file);
+        rrd_free(&rrd);
+        remove(path);
+        return fail("RRD with an overflowing row count was accepted");
+    }
+    rrd_free(&rrd);
+
+    if (!rrd_test_error() ||
+        strstr(rrd_get_error(), "impossibly large database") == NULL) {
+        remove(path);
+        return fail("row-count overflow was not diagnosed");
+    }
+
+    remove(path);
+    return 0;
+#endif
+}


### PR DESCRIPTION
## Summary
- use checked size arithmetic while restoring XML RRA databases
- reject cumulative row-count and temporary-buffer size overflow before allocation

## Testing
- includes `tests/security-header-counts` in the Automake shell-test suite
- existing `tests/dump-restore` round-trip coverage
- `CCACHE_DISABLE=1 make -j4`

This branch includes prerequisite hardening commits because GitHub cannot target a fork-only prerequisite branch.