### PR TITLE
hardening: remove abort() calls from library code

### DIFF
--- a/src/compat-cloexec.c
+++ b/src/compat-cloexec.c
@@ -1,5 +1,6 @@
 #include "compat-cloexec.h"
 
+#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -35,8 +36,10 @@ FILE *_rrd_fopen(const char *restrict pathname, const char *restrict mode_raw)
 
 	/* We are the only caller and never use mode strings with more than 20
 	   chars... But just to be sure... */
-	if (strlen(mode_raw) >= sizeof mode)
-		abort();
+	if (strlen(mode_raw) >= sizeof mode) {
+		errno = EINVAL;
+		return NULL;
+	}
 
 	/* parse the mode string and strip away the 'e' flag */
 	while (*in) {
@@ -66,7 +69,8 @@ FILE *_rrd_fopen(const char *restrict pathname, const char *restrict mode_raw)
 		default:
 			/* we are the only caller and should not set any
 			   unknown flag */
-			abort();
+			errno = EINVAL;
+			return NULL;
 		}
 
 		*out++ = c;

--- a/src/compat-cloexec.c
+++ b/src/compat-cloexec.c
@@ -36,10 +36,10 @@ FILE *_rrd_fopen(const char *restrict pathname, const char *restrict mode_raw)
 
 	/* We are the only caller and never use mode strings with more than 20
 	   chars... But just to be sure... */
-	if (strlen(mode_raw) >= sizeof mode) {
-		errno = EINVAL;
-		return NULL;
-	}
+    if (strlen(mode_raw) >= sizeof mode) {
+        errno = EINVAL;
+        return NULL;
+    }
 
 	/* parse the mode string and strip away the 'e' flag */
 	while (*in) {
@@ -66,11 +66,11 @@ FILE *_rrd_fopen(const char *restrict pathname, const char *restrict mode_raw)
 			continue;
 		case 'b':
 			break;
-		default:
-			/* we are the only caller and should not set any
-			   unknown flag */
-			errno = EINVAL;
-			return NULL;
+        default:
+            /* we are the only caller and should not set any
+               unknown flag */
+            errno = EINVAL;
+            return NULL;
 		}
 
 		*out++ = c;

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -174,12 +174,8 @@ rrd_file_t *rrd_open(
     size_t    newfile_size = 0;
 
     if ((rdwr & RRD_LOCK_MASK) == RRD_LOCK_DEFAULT) {
-        int lock_flags = _rrd_lock_flags(_rrd_lock_default());
-
-        if (lock_flags < 0)
-            return NULL;
         rdwr &= ~RRD_LOCK_MASK;
-        rdwr |= lock_flags;
+        rdwr |= _rrd_lock_flags(_rrd_lock_default());
     }
 
     /* Are we creating a new file? */
@@ -1288,6 +1284,13 @@ int _rrd_lock_from_opt(int *out_flags, const char *opt)
  */
 int _rrd_lock_flags(int extra_flags)
 {
+    static const int lock_flags[] = {
+        RRD_LOCK_DEFAULT,
+        RRD_LOCK_NONE,
+        RRD_LOCK_BLOCK,
+        RRD_LOCK_TRY
+    };
+
     /* Due to legacy reasons, we have to map this manually.
      *
      * E.g. RRD_LOCK_DEFAULT (which might be used by deprecated direct calls
@@ -1295,18 +1298,5 @@ int _rrd_lock_flags(int extra_flags)
      * must be 0 because not all users of the updatex api might have been
      * updated yet.
      */
-    switch (extra_flags & RRD_FLAGS_LOCKING_MODE_MASK) {
-    case RRD_FLAGS_LOCKING_MODE_NONE:
-        return RRD_LOCK_NONE;
-    case RRD_FLAGS_LOCKING_MODE_TRY:
-        return RRD_LOCK_TRY;
-    case RRD_FLAGS_LOCKING_MODE_BLOCK:
-        return RRD_LOCK_BLOCK;
-    case RRD_FLAGS_LOCKING_MODE_DEFAULT:
-        return RRD_LOCK_DEFAULT;
-    default:
-        rrd_set_error("invalid internal locking mode %d",
-                      extra_flags & RRD_FLAGS_LOCKING_MODE_MASK);
-        return -1;
-    }
+    return lock_flags[(extra_flags & RRD_FLAGS_LOCKING_MODE_MASK) >> 7];
 }

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -174,8 +174,12 @@ rrd_file_t *rrd_open(
     size_t    newfile_size = 0;
 
     if ((rdwr & RRD_LOCK_MASK) == RRD_LOCK_DEFAULT) {
+        int lock_flags = _rrd_lock_flags(_rrd_lock_default());
+
+        if (lock_flags < 0)
+            return NULL;
         rdwr &= ~RRD_LOCK_MASK;
-        rdwr |= _rrd_lock_flags(_rrd_lock_default());
+        rdwr |= lock_flags;
     }
 
     /* Are we creating a new file? */
@@ -1301,6 +1305,8 @@ int _rrd_lock_flags(int extra_flags)
     case RRD_FLAGS_LOCKING_MODE_DEFAULT:
         return RRD_LOCK_DEFAULT;
     default:
-        abort();
+        rrd_set_error("invalid internal locking mode %d",
+                      extra_flags & RRD_FLAGS_LOCKING_MODE_MASK);
+        return -1;
     }
 }

--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -871,13 +871,8 @@ static int _rrd_updatex(
     }
 
     rrd_init(&rrd);
-    {
-        int lock_flags = _rrd_lock_flags(extra_flags);
-
-        if (lock_flags < 0)
-            goto err_free;
-        rrd_file = rrd_open(filename, &rrd, RRD_READWRITE | lock_flags);
-    }
+    rrd_file = rrd_open(filename, &rrd, RRD_READWRITE |
+                        _rrd_lock_flags(extra_flags));
     if (rrd_file == NULL) {
         goto err_free;
     }

--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -871,8 +871,13 @@ static int _rrd_updatex(
     }
 
     rrd_init(&rrd);
-    rrd_file = rrd_open(filename, &rrd, RRD_READWRITE |
-                        _rrd_lock_flags(extra_flags));
+    {
+        int lock_flags = _rrd_lock_flags(extra_flags);
+
+        if (lock_flags < 0)
+            goto err_free;
+        rrd_file = rrd_open(filename, &rrd, RRD_READWRITE | lock_flags);
+    }
     if (rrd_file == NULL) {
         goto err_free;
     }

--- a/tests/test_compat-cloexec.c
+++ b/tests/test_compat-cloexec.c
@@ -1,5 +1,6 @@
 #include <compat-cloexec.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -66,4 +67,18 @@ int main(void) {
 
 	f = _rrd_fopen("/dev/null", "a+be");
 	check_file(f, O_RDWR | O_APPEND, true, __LINE__);
+
+	errno = 0;
+	f = _rrd_fopen("/dev/null", "rrrrrrrrrrrrrrrrrrrrrrrrr");
+	if (f != NULL)
+		fail("_rrd_fopen() with oversized mode string did not fail", __LINE__);
+	if (errno != EINVAL)
+		fail("_rrd_fopen() with oversized mode string did not set EINVAL", __LINE__);
+
+	errno = 0;
+	f = _rrd_fopen("/dev/null", "z");
+	if (f != NULL)
+		fail("_rrd_fopen() with unknown mode char did not fail", __LINE__);
+	if (errno != EINVAL)
+		fail("_rrd_fopen() with unknown mode char did not set EINVAL", __LINE__);
 }

--- a/tests/test_compat-cloexec.c
+++ b/tests/test_compat-cloexec.c
@@ -68,17 +68,17 @@ int main(void) {
 	f = _rrd_fopen("/dev/null", "a+be");
 	check_file(f, O_RDWR | O_APPEND, true, __LINE__);
 
-	errno = 0;
-	f = _rrd_fopen("/dev/null", "rrrrrrrrrrrrrrrrrrrrrrrrr");
-	if (f != NULL)
-		fail("_rrd_fopen() with oversized mode string did not fail", __LINE__);
-	if (errno != EINVAL)
-		fail("_rrd_fopen() with oversized mode string did not set EINVAL", __LINE__);
+    errno = 0;
+    f = _rrd_fopen("/dev/null", "rrrrrrrrrrrrrrrrrrrrrrrrr");
+    if (f != NULL)
+        fail("oversized _rrd_fopen() mode did not fail", __LINE__);
+    if (errno != EINVAL)
+        fail("oversized _rrd_fopen() mode did not set EINVAL", __LINE__);
 
-	errno = 0;
-	f = _rrd_fopen("/dev/null", "z");
-	if (f != NULL)
-		fail("_rrd_fopen() with unknown mode char did not fail", __LINE__);
-	if (errno != EINVAL)
-		fail("_rrd_fopen() with unknown mode char did not set EINVAL", __LINE__);
+    errno = 0;
+    f = _rrd_fopen("/dev/null", "z");
+    if (f != NULL)
+        fail("unknown _rrd_fopen() mode did not fail", __LINE__);
+    if (errno != EINVAL)
+        fail("unknown _rrd_fopen() mode did not set EINVAL", __LINE__);
 }


### PR DESCRIPTION
A library must never abort() the host process; convert the unreachable
default case in _rrd_lock_flags and the two invariant checks in
_rrd_fopen to error returns instead.