### PR TITLE
hardening: reject zero-row RRA on restore

### DIFF
--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -857,6 +857,11 @@ static int parse_tag_rra(
     cdp_prep_t *cur_cdp_prep;
     rra_ptr_t *cur_rra_ptr;
 
+    if (rrd->stat_head->ds_cnt == 0) {
+        rrd_set_error("RRA requires at least one data source");
+        return -1;
+    }
+
     /* Allocate more rra_def space for this RRA */
     {                   /* {{{ */
         rra_def_t *temp;
@@ -1348,6 +1353,11 @@ static rrd_t *parse_file(
 
     xmlFreeTextReader(reader);
 
+    if (status == 0 && !rrd_test_error() &&
+        (rrd->stat_head->ds_cnt == 0 || rrd->stat_head->rra_cnt == 0)) {
+        rrd_set_error("RRD requires at least one data source and RRA");
+        status = -1;
+    }
     if (status != 0 || rrd_test_error()) {
         local_rrd_free(rrd);
         rrd = NULL;
@@ -1426,6 +1436,7 @@ int rrd_restore(
     int       opt;
     rrd_t    *rrd;
 
+    rrd_clear_error();
     optparse_init(&options, argc, argv);
     while ((opt = optparse_long(&options, longopts, NULL)) != -1) {
         switch (opt) {

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -470,7 +470,9 @@ static int parse_tag_rra_database(
     }
     
     if (cur_rra_def->row_cnt == 0) {
-        rrd_set_error("parse_tag_rra_database: RRA has zero rows");
+        rrd_set_error("parse_tag_rra_database: RRA has zero rows "
+                      "(index %lu, CF %.20s)",
+                      rrd->stat_head->rra_cnt - 1, cur_rra_def->cf_nam);
         return -1;
     }
 

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -1348,7 +1348,7 @@ static rrd_t *parse_file(
 
     xmlFreeTextReader(reader);
 
-    if (status != 0) {
+    if (status != 0 || rrd_test_error()) {
         local_rrd_free(rrd);
         rrd = NULL;
     }

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -408,6 +408,7 @@ static int parse_tag_rra_database(
     rra_ptr_t *cur_rra_ptr;
     unsigned int total_row_cnt;
     int       status;
+    int       saw_end = 0;
     int       i;
     xmlChar *element;
     unsigned int start_row_cnt;
@@ -455,7 +456,8 @@ static int parse_tag_rra_database(
         } /* if (xmlStrcasecmp(element,"row")) */
         else {
             if ( xmlStrcasecmp(element,(const xmlChar *)"/database") == 0){
-                xmlFree(element);                
+                xmlFree(element);
+                saw_end = 1;
                 break;
             }
             else {
@@ -464,11 +466,27 @@ static int parse_tag_rra_database(
                 status = -1;
             }
         }
-        xmlFree(element);        
+        xmlFree(element);
         if (status != 0)
-            break;        
+            break;
     }
-    
+
+    /* Only rotate a fully parsed database with a consistent row count. */
+    if (status != 0)
+        return status;
+
+    /* The loop can also end because get_xml_element() itself hit a
+     * read/parse error (or true EOF without ever seeing </database>) --
+     * that path returns NULL straight out of the while condition, leaving
+     * status untouched, so it would otherwise be treated as if </database>
+     * had been found normally.  saw_end is only set on the real </database>
+     * exit, so reject anything else explicitly. */
+    if (!saw_end) {
+        if (rrd_test_error() == 0)
+            rrd_set_error("parse_tag_rra_database: unexpected end of file");
+        return -1;
+    }
+
     if (cur_rra_def->row_cnt == 0) {
         rrd_set_error("parse_tag_rra_database: RRA has zero rows "
                       "(index %lu, CF %.20s)",
@@ -832,6 +850,7 @@ static int parse_tag_rra(
     rrd_t *rrd)
 {
     int       status;
+    int       saw_database = 0;
     xmlChar *element;
     
     rra_def_t *cur_rra_def;
@@ -922,6 +941,12 @@ static int parse_tag_rra(
         }        
         else if (xmlStrcasecmp(element, (const xmlChar *) "database") == 0){            
             xmlFree(element);
+            if (saw_database) {
+                rrd_set_error("RRA %lu contains multiple database elements",
+                              rrd->stat_head->rra_cnt - 1);
+                return -1;
+            }
+            saw_database = 1;
             status = parse_tag_rra_database(reader, rrd);
             if (status == 0)
                 continue;
@@ -930,6 +955,11 @@ static int parse_tag_rra(
         }
         else if (xmlStrcasecmp(element,(const xmlChar *) "/rra") == 0){
             xmlFree(element);
+            if (!saw_database || cur_rra_def->row_cnt == 0) {
+                rrd_set_error("RRA %lu has no database rows",
+                              rrd->stat_head->rra_cnt - 1);
+                return -1;
+            }
             return status;
         }  /* }}} */        
        else {

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -469,6 +469,11 @@ static int parse_tag_rra_database(
             break;        
     }
     
+    if (cur_rra_def->row_cnt == 0) {
+        rrd_set_error("parse_tag_rra_database: RRA has zero rows");
+        return -1;
+    }
+
     /* Set the RRA pointer to a random location */
     cur_rra_ptr->cur_row = rrd_random() % cur_rra_def->row_cnt;
     

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,8 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5
+	pdp-calc1 graph3 graph4 graph5 \
+	security-restore-zero-row-cnt
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/security-restore-zero-row-cnt
+++ b/tests/security-restore-zero-row-cnt
@@ -2,9 +2,9 @@
 
 . "$(dirname "$0")/functions"
 
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
 WORK=$(mktemp -d "$BUILDDIR/restore-bounds.XXXXXX") || fail 1 mktemp
 BUILD="$WORK/test"
-[ -n "$RRDCACHED_ADDRESS" ] && exit 77
 trap 'rm -rf "$WORK"' EXIT
 
 $RRDTOOL create "${BUILD}.rrd" --start 900000000 --step 60 \
@@ -51,3 +51,26 @@ for variant in missing empty unknown; do
   [ ! -e "${BUILD}-edge.rrd" ] || fail 1 "restore left a partial database"
 done
 report "reject missing, empty, and malformed databases with specific errors"
+
+# EOF outside the database parser must also prevent write_file().
+for boundary in database params /database; do
+  awk -v tag="<$boundary>" 'index($0,tag) { exit } { print }' \
+    "${BUILD}-valid.xml" >"${BUILD}-truncated.xml"
+  $RRDTOOL restore -f "${BUILD}-truncated.xml" "${BUILD}-truncated.rrd" >"${BUILD}-truncated.out" 2>&1
+  rc=$?
+  [ "$rc" -gt 0 ] && [ "$rc" -lt 128 ] || fail 1 "truncated $boundary was not rejected cleanly"
+  [ ! -e "${BUILD}-truncated.rrd" ] || fail 1 "truncated $boundary left an output RRD"
+done
+# Duplicate a complete database without corrupting unrelated XML fields.
+awk '
+ /<database>/ { in_database=1; block="" }
+ in_database { block=block $0 "\n" }
+ { print }
+ /<\/database>/ { printf "%s",block; in_database=0 }
+' "${BUILD}-valid.xml" >"${BUILD}-duplicate.xml"
+$RRDTOOL restore -f "${BUILD}-duplicate.xml" "${BUILD}-duplicate.rrd" >"${BUILD}-duplicate.out" 2>&1
+rc=$?
+[ "$rc" -gt 0 ] && [ "$rc" -lt 128 ] || fail 1 "duplicate database was not rejected cleanly"
+grep -q 'multiple database elements' "${BUILD}-duplicate.out" || fail 1 "duplicate database was not diagnosed"
+[ ! -e "${BUILD}-duplicate.rrd" ] || fail 1 "duplicate database left an output RRD"
+report "reject truncated and duplicate databases before writing an RRD"

--- a/tests/security-restore-zero-row-cnt
+++ b/tests/security-restore-zero-row-cnt
@@ -1,19 +1,22 @@
 #!/bin/bash
 
-. $(dirname $0)/functions
+. "$(dirname "$0")/functions"
 
-BUILD=$BUILDDIR/$(basename $0)
+BUILD="$BUILDDIR/$(basename "$0")"
 
-$RRDTOOL create ${BUILD}.rrd --start 900000000 --step 60 \
-  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:5 || fail create
-$RRDTOOL update ${BUILD}.rrd 900000060:1 900000120:2 900000180:3 || fail update
-$RRDTOOL dump ${BUILD}.rrd ${BUILD}.xml || fail dump
+$RRDTOOL create "${BUILD}.rrd" --start 900000000 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:5 RRA:MAX:0.5:1:5 || fail create
+$RRDTOOL update "${BUILD}.rrd" 900000060:1 900000120:2 900000180:3 || fail update
+$RRDTOOL dump "${BUILD}.rrd" "${BUILD}.xml" || fail dump
 
-# Strip every <row> out of the RRA's <database> block, so restore sees
-# <database></database> with zero rows for that RRA.
-sed '/<row>/d' ${BUILD}.xml > ${BUILD}-crafted.xml
+# Empty only the first RRA's database; keep the second RRA intact.
+awk '
+  /<database>/ { database++; in_database = 1 }
+  /<\/database>/ { in_database = 0 }
+  !(database == 1 && in_database && /<row>/)
+' "${BUILD}.xml" > "${BUILD}-crafted.xml"
 
-$RRDTOOL restore ${BUILD}-crafted.xml ${BUILD}-out.rrd >${BUILD}.out 2>&1
+$RRDTOOL restore "${BUILD}-crafted.xml" "${BUILD}-out.rrd" >"${BUILD}.out" 2>&1
 RC=$?
 
 # A signal death (e.g. SIGFPE div-by-zero) shows up as rc >= 128; make sure
@@ -24,6 +27,6 @@ fi
 if [ "$RC" -eq 0 ]; then
   fail 1 "restore accepted a zero-row RRA"
 fi
-grep -q "RRA has zero rows" ${BUILD}.out || \
+grep -q "RRA has zero rows (index 0, CF AVERAGE)" "${BUILD}.out" || \
   fail 1 "zero-row RRA was not diagnosed cleanly"
 report "reject zero-row RRA on restore"

--- a/tests/security-restore-zero-row-cnt
+++ b/tests/security-restore-zero-row-cnt
@@ -74,3 +74,17 @@ rc=$?
 grep -q 'multiple database elements' "${BUILD}-duplicate.out" || fail 1 "duplicate database was not diagnosed"
 [ ! -e "${BUILD}-duplicate.rrd" ] || fail 1 "duplicate database left an output RRD"
 report "reject truncated and duplicate databases before writing an RRD"
+
+# Reject absent top-level data sources before any zero-size realloc.
+awk '
+ /<rra>/ { in_rra=1 }
+ !in_rra && /<ds>/ { skip=1 }
+ !skip { print }
+ !in_rra && /<\/ds>/ { skip=0 }
+' "${BUILD}-valid.xml" >"${BUILD}-no-ds.xml"
+$RRDTOOL restore -f "${BUILD}-no-ds.xml" "${BUILD}-no-ds.rrd" >"${BUILD}-no-ds.out" 2>&1
+rc=$?
+[ "$rc" -gt 0 ] && [ "$rc" -lt 128 ] || fail 1 "zero-data-source restore did not fail cleanly"
+grep -q 'at least one data source' "${BUILD}-no-ds.out" || fail 1 "missing data sources were not diagnosed"
+[ ! -e "${BUILD}-no-ds.rrd" ] || fail 1 "zero-data-source restore wrote an RRD"
+report "reject zero-data-source restore without a double free"

--- a/tests/security-restore-zero-row-cnt
+++ b/tests/security-restore-zero-row-cnt
@@ -2,7 +2,10 @@
 
 . "$(dirname "$0")/functions"
 
-BUILD="$BUILDDIR/$(basename "$0")"
+WORK=$(mktemp -d "$BUILDDIR/restore-bounds.XXXXXX") || fail 1 mktemp
+BUILD="$WORK/test"
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+trap 'rm -rf "$WORK"' EXIT
 
 $RRDTOOL create "${BUILD}.rrd" --start 900000000 --step 60 \
   DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:5 RRA:MAX:0.5:1:5 || fail create
@@ -30,3 +33,21 @@ fi
 grep -q "RRA has zero rows (index 0, CF AVERAGE)" "${BUILD}.out" || \
   fail 1 "zero-row RRA was not diagnosed cleanly"
 report "reject zero-row RRA on restore"
+
+# Exercise missing and empty databases separately from XML parser failures.
+$RRDTOOL create "${BUILD}-valid.rrd" --start 900000000 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:5 || fail create
+$RRDTOOL dump "${BUILD}-valid.rrd" "${BUILD}-valid.xml" || fail dump
+for variant in missing empty unknown; do
+  case "$variant" in
+    missing) sed '/<database>/,/<\/database>/d' "${BUILD}-valid.xml" >"${BUILD}-edge.xml"; diagnostic='has no database rows' ;;
+    empty) sed '/<row>/d' "${BUILD}-valid.xml" >"${BUILD}-edge.xml"; diagnostic='zero rows' ;;
+    unknown) sed 's@<row>.*</row>@<unexpected>1</unexpected>@' "${BUILD}-valid.xml" >"${BUILD}-edge.xml"; diagnostic='found unexpected tag: unexpected' ;;
+  esac
+  $RRDTOOL restore -f "${BUILD}-edge.xml" "${BUILD}-edge.rrd" >"${BUILD}-edge.out" 2>&1
+  rc=$?
+  [ "$rc" -gt 0 ] && [ "$rc" -lt 128 ] || fail 1 "restore did not reject $variant database cleanly"
+  grep -q "$diagnostic" "${BUILD}-edge.out" || fail 1 "restore lost the $variant diagnostic"
+  [ ! -e "${BUILD}-edge.rrd" ] || fail 1 "restore left a partial database"
+done
+report "reject missing, empty, and malformed databases with specific errors"

--- a/tests/security-restore-zero-row-cnt
+++ b/tests/security-restore-zero-row-cnt
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+BUILD=$BUILDDIR/$(basename $0)
+
+$RRDTOOL create ${BUILD}.rrd --start 900000000 --step 60 \
+  DS:value:GAUGE:120:U:U RRA:AVERAGE:0.5:1:5 || fail create
+$RRDTOOL update ${BUILD}.rrd 900000060:1 900000120:2 900000180:3 || fail update
+$RRDTOOL dump ${BUILD}.rrd ${BUILD}.xml || fail dump
+
+# Strip every <row> out of the RRA's <database> block, so restore sees
+# <database></database> with zero rows for that RRA.
+sed '/<row>/d' ${BUILD}.xml > ${BUILD}-crafted.xml
+
+$RRDTOOL restore ${BUILD}-crafted.xml ${BUILD}-out.rrd >${BUILD}.out 2>&1
+RC=$?
+
+# A signal death (e.g. SIGFPE div-by-zero) shows up as rc >= 128; make sure
+# restore rejects the zero-row RRA cleanly instead of crashing.
+if [ "$RC" -ge 128 ]; then
+  fail 1 "restore crashed on zero-row RRA (rc=$RC)"
+fi
+if [ "$RC" -eq 0 ]; then
+  fail 1 "restore accepted a zero-row RRA"
+fi
+grep -q "RRA has zero rows" ${BUILD}.out || \
+  fail 1 "zero-row RRA was not diagnosed cleanly"
+report "reject zero-row RRA on restore"


### PR DESCRIPTION
An XML dump with an empty <database></database> block for one RRA leaves
row_cnt at 0 by the time parse_tag_rra_database() sets a random cur_row
via rrd_random() % row_cnt, a division by zero. On x86_64 this traps as
SIGFPE and crashes the process; confirmed with a minimal single-RRA XML
file with an empty database block, verified crashing on real x86_64
Linux (exit 136) and safely rejected after this fix, on both x86_64 and
arm64.

Unrelated to and untouched by #1365, found while auditing rrd_restore.c
for that PR's test coverage.

Merge note: #1371 edits the same spot in parse_tag_rra_database(), just
before this rrd_random() call, so whichever of the two lands second needs
a one-line rebase. They compose correctly: parse/EOF check, then this
zero-rows check, then the modulo.