### PR TITLE
hardening: check CDEF/VDEF buffer size arithmetic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,7 @@ AC_PROG_CPP
 AC_PROG_CC
 AM_PROG_CC_C_O
 LT_INIT
+AM_CONDITIONAL(HAVE_STATIC_LIBRRD,[test "x$enable_static" = "xyes"])
 
 dnl Try to detect/use GNU features
 CFLAGS="$CFLAGS -D_GNU_SOURCE"

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -64,6 +64,27 @@
 #include "rrd_graph.h"
 #include "rrd_client.h"
 
+/* CDEF/VDEF result buffers are sized from a row count derived as
+ * (end - start) / step, where start/end come from --start/--end (or a
+ * DEF's own fetched range) and step can be as small as an RRA's native
+ * resolution.  A wide time range over a fine-grained RRA turns directly
+ * into a row count large enough for "row_cnt * sizeof(double)" to wrap
+ * size_t, so that arithmetic has to be range-checked before malloc(). */
+static int graph_mul_overflow(
+    size_t a,
+    size_t b,
+    size_t *out)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_mul_overflow(a, b, out);
+#else
+    if (b != 0 && a > (size_t) -1 / b)
+        return 1;
+    *out = a * b;
+    return 0;
+#endif
+}
+
 /* some constant definitions */
 
 
@@ -1285,13 +1306,25 @@ int data_calc(
             im->gdes[gdi].step = rrd_lcd(steparray);
             free(steparray);
 
-            if ((im->gdes[gdi].data = (rrd_value_t *)
-                 malloc(((im->gdes[gdi].end - im->gdes[gdi].start)
-                         / im->gdes[gdi].step)
-                        * sizeof(double))) == NULL) {
-                rrd_set_error("malloc im->gdes[gdi].data");
-                rpnstack_free(&rpnstack);
-                return -1;
+            {
+                size_t    cdef_rows = (im->gdes[gdi].end -
+                                       im->gdes[gdi].start)
+                    / im->gdes[gdi].step;
+                size_t    cdef_len;
+
+                if (graph_mul_overflow(cdef_rows, sizeof(double),
+                                       &cdef_len)) {
+                    rrd_set_error("CDEF '%s' covers an impossibly "
+                                  "large data range", im->gdes[gdi].vname);
+                    rpnstack_free(&rpnstack);
+                    return -1;
+                }
+                if ((im->gdes[gdi].data =
+                     (rrd_value_t *) malloc(cdef_len)) == NULL) {
+                    rrd_set_error("malloc im->gdes[gdi].data");
+                    rpnstack_free(&rpnstack);
+                    return -1;
+                }
             }
 
             /* Step through the new cdef results array and
@@ -6033,7 +6066,18 @@ int vdef_calc(
             dst->vf.never = 1;
             break;
         }
-        if ((array = (rrd_value_t *) malloc(steps * sizeof(double))) == NULL) {
+        {
+            size_t    arraylen;
+
+            if (graph_mul_overflow((size_t) steps, sizeof(double),
+                                   &arraylen)) {
+                rrd_set_error("VDEF '%s' covers an impossibly large "
+                              "data range", dst->vname);
+                return -1;
+            }
+            array = (rrd_value_t *) malloc(arraylen);
+        }
+        if (array == NULL) {
             rrd_set_error("malloc VDEV_PERCENT");
             return -1;
         }

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -62,6 +62,7 @@
 #endif
 
 #include "rrd_graph.h"
+#include <stdint.h>
 #include "rrd_client.h"
 
 /* CDEF/VDEF result buffers are sized from a row count derived as
@@ -1303,12 +1304,20 @@ int data_calc(
             free(steparray);
 
             {
-                size_t    cdef_rows = (im->gdes[gdi].end -
-                                       im->gdes[gdi].start)
-                    / im->gdes[gdi].step;
+                uintmax_t cdef_rows;
                 size_t    cdef_len;
-
-                if (graph_mul_overflow(cdef_rows, sizeof(rrd_value_t),
+                if (im->gdes[gdi].step == 0 ||
+                    im->gdes[gdi].end < im->gdes[gdi].start) {
+                    rrd_set_error("CDEF '%s' has an invalid data range",
+                                  im->gdes[gdi].vname);
+                    rpnstack_free(&rpnstack);
+                    return -1;
+                }
+                cdef_rows = ((uintmax_t) im->gdes[gdi].end -
+                             (uintmax_t) im->gdes[gdi].start) /
+                    im->gdes[gdi].step;
+                if (cdef_rows > (size_t) -1 / sizeof(rrd_value_t) ||
+                    graph_mul_overflow((size_t) cdef_rows, sizeof(rrd_value_t),
                                        &cdef_len)) {
                     rrd_set_error("CDEF '%s' covers an impossibly "
                                   "large data range", im->gdes[gdi].vname);
@@ -6045,7 +6054,18 @@ int vdef_calc(
     src = &im->gdes[dst->vidx];
     data = src->data + src->ds;
 
-    steps = (src->end - src->start) / src->step;
+    if (src->step == 0 || src->end < src->start) {
+        rrd_set_error("VDEF '%s' has an invalid data range", dst->vname);
+        return -1;
+    }
+    {
+        uintmax_t count = ((uintmax_t) src->end - (uintmax_t) src->start) / src->step;
+        if (count > LONG_MAX || count > (size_t) -1 / sizeof(rrd_value_t)) {
+            rrd_set_error("VDEF '%s' covers an impossibly large data range", dst->vname);
+            return -1;
+        }
+        steps = (long) count;
+    }
 #if 0
     printf
         ("DEBUG: start == %lu, end == %lu, %lu steps\n",

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -6054,7 +6054,7 @@ int vdef_calc(
     switch (dst->vf.op) {
     case VDEF_PERCENT:{
         rrd_value_t *array;
-        int       field;
+        size_t    field;
 
         if (steps == 0) {
             dst->vf.val = DNAN;
@@ -6080,8 +6080,10 @@ int vdef_calc(
         for (step = 0; step < steps; step++) {
             array[step] = data[step * src->ds_cnt];
         }
-        qsort(array, step, sizeof(double), vdef_percent_compar);
+        qsort(array, step, sizeof(rrd_value_t), vdef_percent_compar);
         field = round((dst->vf.param * (double) (steps - 1)) / 100.0);
+        if (field >= (size_t) steps)
+            field = (size_t) steps - 1;
         dst->vf.val = array[field];
         dst->vf.when = 0;   /* no time component */
         dst->vf.never = 1;

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -75,14 +75,10 @@ static int graph_mul_overflow(
     size_t b,
     size_t *out)
 {
-#if defined(__GNUC__) || defined(__clang__)
-    return __builtin_mul_overflow(a, b, out);
-#else
     if (b != 0 && a > (size_t) -1 / b)
         return 1;
     *out = a * b;
     return 0;
-#endif
 }
 
 /* some constant definitions */
@@ -6099,10 +6095,11 @@ int vdef_calc(
         break;
     case VDEF_PERCENTNAN:{
         rrd_value_t *array;
-        int       field;
+        size_t    field;
+        size_t    array_bytes;
 
         /* count number of "valid" values */
-        int       nancount = 0;
+        size_t    nancount = 0;
 
         for (step = 0; step < steps; step++) {
             if (!isnan(data[step * src->ds_cnt])) {
@@ -6116,8 +6113,11 @@ int vdef_calc(
             dst->vf.never = 1;
             break;
         }
-        if ((array =
-             (rrd_value_t *) malloc(nancount * sizeof(double))) == NULL) {
+        if (graph_mul_overflow(nancount, sizeof(rrd_value_t), &array_bytes)) {
+            rrd_set_error("VDEF_PERCENTNAN: impossibly large allocation");
+            return -1;
+        }
+        if ((array = (rrd_value_t *) malloc(array_bytes)) == NULL) {
             rrd_set_error("malloc VDEV_PERCENT");
             return -1;
         }
@@ -6129,7 +6129,7 @@ int vdef_calc(
                 field++;
             }
         }
-        qsort(array, nancount, sizeof(double), vdef_percent_compar);
+        qsort(array, nancount, sizeof(rrd_value_t), vdef_percent_compar);
         field = round(dst->vf.param * (double) (nancount - 1) / 100.0);
         dst->vf.val = array[field];
         dst->vf.when = 0;   /* no time component */

--- a/src/rrd_graph.c
+++ b/src/rrd_graph.c
@@ -1312,7 +1312,7 @@ int data_calc(
                     / im->gdes[gdi].step;
                 size_t    cdef_len;
 
-                if (graph_mul_overflow(cdef_rows, sizeof(double),
+                if (graph_mul_overflow(cdef_rows, sizeof(rrd_value_t),
                                        &cdef_len)) {
                     rrd_set_error("CDEF '%s' covers an impossibly "
                                   "large data range", im->gdes[gdi].vname);
@@ -6069,7 +6069,7 @@ int vdef_calc(
         {
             size_t    arraylen;
 
-            if (graph_mul_overflow((size_t) steps, sizeof(double),
+            if (graph_mul_overflow((size_t) steps, sizeof(rrd_value_t),
                                    &arraylen)) {
                 rrd_set_error("VDEF '%s' covers an impossibly large "
                               "data range", dst->vname);

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -5,3 +5,5 @@
 /*.log
 /*.trs
 /compat-cloexec
+
+/graph-security

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5
+	pdp-calc1 graph3 graph4 graph5 graph-security
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \
@@ -36,9 +36,13 @@ CLEANFILES = *.rrd \
 	rpn1.out rpn1.output.out
 
 check_PROGRAMS = \
-	compat-cloexec
+	compat-cloexec \
+	graph-security
 
 compat_cloexec_SOURCES = \
 	test_compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.c \
 	${top_srcdir}/src/compat-cloexec.h
+
+graph_security_SOURCES = test_graph_security.c
+graph_security_LDADD = ${top_builddir}/src/librrd.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,7 +9,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	pdp-calc1 graph3 graph4 graph5 graph-security
 
 EXTRA_DIST = Makefile.am \
-	functions $(TESTS) \
+	functions $(filter-out $(check_PROGRAMS),$(TESTS)) \
 	modify-test1.create.dump modify-test1.mod1.dump \
 	modify2-testa-create.dump modify2-testb-mod1.dump modify2-testc-mod1.dump \
 	modify-test3.create.dump modify-test3.mod1.dump \
@@ -45,4 +45,6 @@ compat_cloexec_SOURCES = \
 	${top_srcdir}/src/compat-cloexec.h
 
 graph_security_SOURCES = test_graph_security.c
+# Exercise internal graph functions that are not exported by the shared library.
+graph_security_LDFLAGS = -static
 graph_security_LDADD = ${top_builddir}/src/librrd.la

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,7 +36,9 @@ CLEANFILES = *.rrd \
 
 check_PROGRAMS = compat-cloexec
 if HAVE_STATIC_LIBRRD
+if BUILD_RRDGRAPH
 check_PROGRAMS += graph-security
+endif
 endif
 
 compat_cloexec_SOURCES = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,3 +1,5 @@
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_builddir)/src
+
 script_tests = modify1 modify2 modify3 modify4 modify5 \
 	tune1 tune2 graph1 graph2 rpn1 \
 	rpn2 rrdcreate dump-restore create-with-source-1 create-with-source-2 \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,15 +1,14 @@
-TESTS = modify1 modify2 modify3 modify4 modify5 \
-	tune1 tune2 graph1 graph2 rpn1 rpn2 \
-	rrdcreate \
-	compat-cloexec \
-	dump-restore \
-	create-with-source-1 create-with-source-2 create-with-source-3 \
-	create-with-source-4 create-with-source-and-mapping-1 \
-	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5 graph-security
+script_tests = modify1 modify2 modify3 modify4 modify5 \
+	tune1 tune2 graph1 graph2 rpn1 \
+	rpn2 rrdcreate dump-restore create-with-source-1 create-with-source-2 \
+	create-with-source-3 create-with-source-4 create-with-source-and-mapping-1 create-from-template-1 dcounter1 \
+	vformatter1 xport1 xport2 xport3 list1 \
+	pdp-calc1 graph3 graph4 graph5
+
+TESTS = $(script_tests) $(check_PROGRAMS)
 
 EXTRA_DIST = Makefile.am \
-	functions $(filter-out $(check_PROGRAMS),$(TESTS)) \
+	functions $(script_tests) \
 	modify-test1.create.dump modify-test1.mod1.dump \
 	modify2-testa-create.dump modify2-testb-mod1.dump modify2-testc-mod1.dump \
 	modify-test3.create.dump modify-test3.mod1.dump \
@@ -35,9 +34,10 @@ CLEANFILES = *.rrd \
 	modify5-testa1-mod.dump.tmp modify5-testa2-mod.dump.tmp \
 	rpn1.out rpn1.output.out
 
-check_PROGRAMS = \
-	compat-cloexec \
-	graph-security
+check_PROGRAMS = compat-cloexec
+if HAVE_STATIC_LIBRRD
+check_PROGRAMS += graph-security
+endif
 
 compat_cloexec_SOURCES = \
 	test_compat-cloexec.c \

--- a/tests/test_graph_security.c
+++ b/tests/test_graph_security.c
@@ -32,7 +32,7 @@ static int test_cdef_overflow(void)
     gdes[0].ds_cnt = 1;
     gdes[0].step = 1;
     gdes[0].start = 0;
-    gdes[0].end = (long) ((size_t) -1 / sizeof(rrd_value_t) + 1);
+    gdes[0].end = (time_t) ((size_t) -1 / sizeof(rrd_value_t) + 1);
     gdes[0].data = &value;
     gdes[1].gf = GF_CDEF;
     strcpy(gdes[1].vname, "overflow");
@@ -61,7 +61,7 @@ static int test_vdef_overflow(void)
     gdes[0].ds_cnt = 1;
     gdes[0].step = 1;
     gdes[0].start = 0;
-    gdes[0].end = (long) ((size_t) -1 / sizeof(rrd_value_t) + 1);
+    gdes[0].end = (time_t) ((size_t) -1 / sizeof(rrd_value_t) + 1);
     gdes[0].data = &value;
     gdes[1].vidx = 0;
     gdes[1].vf.op = VDEF_PERCENT;
@@ -110,9 +110,11 @@ int main(void)
 {
     int result = test_percentiles();
     /* Skip only overflow cases when their row count cannot fit in long. */
-    if ((size_t) -1 / sizeof(rrd_value_t) < (unsigned long) LONG_MAX) {
+    if (sizeof(time_t) >= sizeof(size_t)) {
         result |= test_cdef_overflow();
         result |= test_vdef_overflow();
     }
+    else if (result == 0)
+        return 77;
     return result;
 }

--- a/tests/test_graph_security.c
+++ b/tests/test_graph_security.c
@@ -1,6 +1,7 @@
 #include "rrd_graph.h"
 
 #include <limits.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -72,10 +73,46 @@ static int test_vdef_overflow(void)
     return expect_overflow("VDEF");
 }
 
+static int test_percentiles(void)
+{
+    image_desc_t im;
+    graph_desc_t gdes[2];
+    rrd_value_t values[] = { NAN, 1.0, 3.0, 2.0 };
+    memset(&im, 0, sizeof(im));
+    memset(gdes, 0, sizeof(gdes));
+    im.gdes = gdes;
+    im.gdes_c = 2;
+    gdes[0].ds_cnt = 1;
+    gdes[0].step = 1;
+    gdes[0].end = 4;
+    gdes[0].data = values;
+    gdes[1].vidx = 0;
+    for (int variant = 0; variant < 2; ++variant) {
+        gdes[1].vf.op = variant ? VDEF_PERCENTNAN : VDEF_PERCENT;
+        for (int percentile = 0; percentile <= 100; percentile += 50) {
+            double expected = percentile == 100 ? 3 : percentile == 50 ? 2 : 1;
+            gdes[1].vf.param = percentile;
+            rrd_clear_error();
+            if (vdef_calc(&im, 1) != 0)
+                return 1;
+            if (!variant && percentile == 0) {
+                if (!isnan(gdes[1].vf.val))
+                    return 1;
+            } else if (gdes[1].vf.val != expected) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
 int main(void)
 {
-    /* Skip when the first overflowing row count cannot fit in long. */
-    if ((size_t) -1 / sizeof(rrd_value_t) >= (unsigned long) LONG_MAX)
-        return 77;
-    return test_cdef_overflow() || test_vdef_overflow();
+    int result = test_percentiles();
+    /* Skip only overflow cases when their row count cannot fit in long. */
+    if ((size_t) -1 / sizeof(rrd_value_t) < (unsigned long) LONG_MAX) {
+        result |= test_cdef_overflow();
+        result |= test_vdef_overflow();
+    }
+    return result;
 }

--- a/tests/test_graph_security.c
+++ b/tests/test_graph_security.c
@@ -1,0 +1,77 @@
+#include "rrd_graph.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int expect_overflow(
+    const char *context)
+{
+    if (rrd_test_error() && strstr(rrd_get_error(), "impossibly large"))
+        return 0;
+    fprintf(stderr, "%s overflow was not diagnosed\n", context);
+    return 1;
+}
+
+static int test_cdef_overflow(void)
+{
+    image_desc_t im;
+    graph_desc_t gdes[2];
+    rpnp_t    expression[2];
+    double    value = 1.0;
+
+    memset(&im, 0, sizeof(im));
+    memset(gdes, 0, sizeof(gdes));
+    memset(expression, 0, sizeof(expression));
+
+    im.gdes = gdes;
+    im.gdes_c = 2;
+    gdes[0].ds_cnt = 1;
+    gdes[0].step = 1;
+    gdes[0].start = 0;
+    gdes[0].end = LONG_MAX;
+    gdes[0].data = &value;
+    gdes[1].gf = GF_CDEF;
+    strcpy(gdes[1].vname, "overflow");
+    gdes[1].rpnp = expression;
+    expression[0].op = OP_VARIABLE;
+    expression[0].ptr = 0;
+    expression[1].op = OP_END;
+
+    rrd_clear_error();
+    if (data_calc(&im) == 0)
+        return 1;
+    return expect_overflow("CDEF");
+}
+
+static int test_vdef_overflow(void)
+{
+    image_desc_t im;
+    graph_desc_t gdes[2];
+    double    value = 1.0;
+
+    memset(&im, 0, sizeof(im));
+    memset(gdes, 0, sizeof(gdes));
+
+    im.gdes = gdes;
+    im.gdes_c = 2;
+    gdes[0].ds_cnt = 1;
+    gdes[0].step = 1;
+    gdes[0].start = 0;
+    gdes[0].end = LONG_MAX;
+    gdes[0].data = &value;
+    gdes[1].vidx = 0;
+    gdes[1].vf.op = VDEF_PERCENT;
+    strcpy(gdes[1].vname, "overflow");
+
+    rrd_clear_error();
+    if (vdef_calc(&im, 1) == 0)
+        return 1;
+    return expect_overflow("VDEF");
+}
+
+int main(void)
+{
+    return test_cdef_overflow() || test_vdef_overflow();
+}

--- a/tests/test_graph_security.c
+++ b/tests/test_graph_security.c
@@ -10,7 +10,8 @@ static int expect_overflow(
 {
     if (rrd_test_error() && strstr(rrd_get_error(), "impossibly large"))
         return 0;
-    fprintf(stderr, "%s overflow was not diagnosed\n", context);
+    fprintf(stderr, "%s overflow was not diagnosed: %s\n", context,
+            rrd_test_error() ? rrd_get_error() : "no librrd error");
     return 1;
 }
 
@@ -19,7 +20,7 @@ static int test_cdef_overflow(void)
     image_desc_t im;
     graph_desc_t gdes[2];
     rpnp_t    expression[2];
-    double    value = 1.0;
+    rrd_value_t value = 1.0;
 
     memset(&im, 0, sizeof(im));
     memset(gdes, 0, sizeof(gdes));
@@ -30,7 +31,7 @@ static int test_cdef_overflow(void)
     gdes[0].ds_cnt = 1;
     gdes[0].step = 1;
     gdes[0].start = 0;
-    gdes[0].end = LONG_MAX;
+    gdes[0].end = (long) ((size_t) -1 / sizeof(rrd_value_t) + 1);
     gdes[0].data = &value;
     gdes[1].gf = GF_CDEF;
     strcpy(gdes[1].vname, "overflow");
@@ -49,7 +50,7 @@ static int test_vdef_overflow(void)
 {
     image_desc_t im;
     graph_desc_t gdes[2];
-    double    value = 1.0;
+    rrd_value_t value = 1.0;
 
     memset(&im, 0, sizeof(im));
     memset(gdes, 0, sizeof(gdes));
@@ -59,7 +60,7 @@ static int test_vdef_overflow(void)
     gdes[0].ds_cnt = 1;
     gdes[0].step = 1;
     gdes[0].start = 0;
-    gdes[0].end = LONG_MAX;
+    gdes[0].end = (long) ((size_t) -1 / sizeof(rrd_value_t) + 1);
     gdes[0].data = &value;
     gdes[1].vidx = 0;
     gdes[1].vf.op = VDEF_PERCENT;
@@ -73,5 +74,8 @@ static int test_vdef_overflow(void)
 
 int main(void)
 {
+    /* Skip when the first overflowing row count cannot fit in long. */
+    if ((size_t) -1 / sizeof(rrd_value_t) >= (unsigned long) LONG_MAX)
+        return 77;
     return test_cdef_overflow() || test_vdef_overflow();
 }


### PR DESCRIPTION
CDEF and VDEF calculations now validate time ranges and row counts before narrowing values or allocating result arrays. CDEF also bounds its int output index and step width, and advances timestamps only for rows that exist. Percentile indexing uses size_t and allocation sizes follow rrd_value_t.

Regression tests cover overflowing and invalid ranges, the INT_MAX output-index boundary, empty percentile inputs, all-NaN inputs, and percentile results for positive, negative, and cross-epoch ranges. Once the row-count bound is established, allocation sizes use that bound directly rather than repeating unreachable overflow checks.

Validation: Ubuntu 24.04 ARM64, all 31 tests passed. Hosted checks will validate the final coverage report.

Coverage reporting merges static-library, shared-library, and regression-test counters with gcovr. Codecov receives one LCOV report containing every line count, including zero-hit lines, to match the existing line-coverage baseline. Full line and branch reports remain downloadable as CI artifacts. Automatic gcov processing is disabled to avoid duplicate reports; coverage thresholds are unchanged.
