### PR TITLE
hardening: bound FAILURES RRA window_len before use

### DIFF
--- a/src/rrd_dump.c
+++ b/src/rrd_dump.c
@@ -381,12 +381,27 @@ int rrd_dump_cb_r(
             case CF_FAILURES:
             {
                 unsigned short vidx;
+                unsigned long window_len =
+                    rrd.rra_def[i].par[RRA_window_len].u_cnt;
                 char *violations_array = (char *) ((void *)
                     rrd.cdp_prep[i * rrd.stat_head->ds_cnt + ii].scratch);
+
+                /* window_len is read straight from the file and is only
+                 * bounded to MAX_FAILURES_WINDOW_LEN when it is set via
+                 * rrd_create/rrd_tune; a hand-crafted file can carry an
+                 * arbitrary value here, which would otherwise walk
+                 * violations_array (a fixed MAX_CDP_PAR_EN-element buffer)
+                 * out of bounds. */
+                if (window_len > MAX_FAILURES_WINDOW_LEN) {
+                    rrd_set_error("invalid RRA %u: window_len %lu out of range",
+                                  i, window_len);
+                    rrd_free(&rrd);
+                    rrd_close(rrd_file);
+                    return (-1);
+                }
+
                 CB_PUTS("\t\t\t<history>");
-                for (vidx = 0;
-                    vidx < rrd.rra_def[i].par[RRA_window_len].u_cnt;
-                    ++vidx) {
+                for (vidx = 0; vidx < window_len; ++vidx) {
                     CB_FMTS("%d", violations_array[vidx]);
                 }
                 CB_PUTS("</history>\n");

--- a/src/rrd_hw.c
+++ b/src/rrd_hw.c
@@ -82,12 +82,12 @@ int lookup_seasonal(
 /* For the specified CDP prep area and the FAILURES RRA,
  * erase all history of past violations.
  */
-void erase_violations(
+int erase_violations(
     rrd_t *rrd,
     unsigned long cdp_idx,
     unsigned long rra_idx)
 {
-    unsigned short i;
+    unsigned long i;
     unsigned long window_len;
     char     *violations_array;
 
@@ -97,7 +97,7 @@ void erase_violations(
         fprintf(stderr, "erase_violations called for non-FAILURES RRA: %s\n",
                 rrd->rra_def[rra_idx].cf_nam);
 #endif
-        return;
+        return 0;
     }
 
     /* window_len comes straight from the on-disk rra_def and is not tied
@@ -110,7 +110,7 @@ void erase_violations(
     if (window_len > MAX_FAILURES_WINDOW_LEN) {
         rrd_set_error("erase_violations: window_len %lu for RRA %lu out of range",
                       window_len, rra_idx);
-        return;
+        return -1;
     }
 #ifdef DEBUG
     fprintf(stderr, "scratch buffer before erase:\n");
@@ -135,6 +135,7 @@ void erase_violations(
     }
     fprintf(stderr, "\n");
 #endif
+    return 0;
 }
 
 /* Smooth a periodic array with a moving average: equal weights and
@@ -394,7 +395,8 @@ void reset_aberrant_coefficients(
             }
             break;
         case CF_FAILURES:
-            erase_violations(rrd, cdp_idx, rra_idx);
+            if (erase_violations(rrd, cdp_idx, rra_idx) != 0)
+                return;
             break;
         default:
             break;

--- a/src/rrd_hw.c
+++ b/src/rrd_hw.c
@@ -88,6 +88,7 @@ void erase_violations(
     unsigned long rra_idx)
 {
     unsigned short i;
+    unsigned long window_len;
     char     *violations_array;
 
     /* check that rra_idx is a CF_FAILURES array */
@@ -96,6 +97,19 @@ void erase_violations(
         fprintf(stderr, "erase_violations called for non-FAILURES RRA: %s\n",
                 rrd->rra_def[rra_idx].cf_nam);
 #endif
+        return;
+    }
+
+    /* window_len comes straight from the on-disk rra_def and is not tied
+     * to any count rrd_open validates; rrd_create/rrd_tune only enforce
+     * MAX_FAILURES_WINDOW_LEN when the value is set through them, so a
+     * hand-crafted file can carry an arbitrary window_len here. scratch[]
+     * is a fixed MAX_CDP_PAR_EN-element buffer, so bound the erase to it
+     * before it is used as a violations_array index. */
+    window_len = rrd->rra_def[rra_idx].par[RRA_window_len].u_cnt;
+    if (window_len > MAX_FAILURES_WINDOW_LEN) {
+        rrd_set_error("erase_violations: window_len %lu for RRA %lu out of range",
+                      window_len, rra_idx);
         return;
     }
 #ifdef DEBUG
@@ -111,7 +125,7 @@ void erase_violations(
     violations_array = (char *) ((void *) rrd->cdp_prep[cdp_idx].scratch);
     /* erase everything in the part of the CDP scratch array that will be
      * used to store violations for the current window */
-    for (i = rrd->rra_def[rra_idx].par[RRA_window_len].u_cnt; i > 0; i--) {
+    for (i = window_len; i > 0; i--) {
         violations_array[i - 1] = 0;
     }
 #ifdef DEBUG

--- a/src/rrd_hw.h
+++ b/src/rrd_hw.h
@@ -26,7 +26,7 @@ int       lookup_seasonal(
     rrd_file_t *rrd_file,
     unsigned long offset,
     rrd_value_t **seasonal_coef);
-void      erase_violations(
+int       erase_violations(
     rrd_t *rrd,
     unsigned long cdp_idx,
     unsigned long rra_idx);

--- a/src/rrd_open.c
+++ b/src/rrd_open.c
@@ -515,6 +515,18 @@ rrd_file_t *rrd_open(
     __rrd_read(rrd->rra_def, rra_def_t,
                rrd->stat_head->rra_cnt);
 
+    /* Validate disk-supplied FAILURES history bounds before any consumer
+     * (including info and update) can use the fixed-size scratch buffer. */
+    for (unsigned long i = 0; i < rrd->stat_head->rra_cnt; ++i) {
+        if (strncmp(rrd->rra_def[i].cf_nam, "FAILURES", CF_NAM_SIZE) == 0 &&
+            (rrd->rra_def[i].par[RRA_window_len].u_cnt < 1 ||
+             rrd->rra_def[i].par[RRA_window_len].u_cnt > MAX_FAILURES_WINDOW_LEN)) {
+            rrd_set_error("invalid RRA %lu: window_len %lu out of range", i,
+                          rrd->rra_def[i].par[RRA_window_len].u_cnt);
+            goto out_close;
+        }
+    }
+
     /* handle different format for the live_head */
     if (version < 3) {
         rrd->live_head = (live_head_t *) malloc(sizeof(live_head_t));

--- a/src/rrd_restore.c
+++ b/src/rrd_restore.c
@@ -923,6 +923,14 @@ static int parse_tag_rra(
         }
         else if (xmlStrcasecmp(element,(const xmlChar *) "/rra") == 0){
             xmlFree(element);
+            if (strcmp(cur_rra_def->cf_nam, "FAILURES") == 0 &&
+                (cur_rra_def->par[RRA_window_len].u_cnt < 1 ||
+                 cur_rra_def->par[RRA_window_len].u_cnt > MAX_FAILURES_WINDOW_LEN)) {
+                rrd_set_error("invalid RRA %lu: window_len %lu out of range",
+                              rrd->stat_head->rra_cnt - 1,
+                              cur_rra_def->par[RRA_window_len].u_cnt);
+                return -1;
+            }
             return status;
         }  /* }}} */        
        else {

--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -622,8 +622,7 @@ static int set_windowarg(
     /* erase existing violations */
     for (i = 0; i < rrd->stat_head->ds_cnt; i++) {
         cdp_idx = rra_idx * (rrd->stat_head->ds_cnt) + i;
-        erase_violations(rrd, cdp_idx, rra_idx);
-        if (rrd_test_error()) {
+        if (erase_violations(rrd, cdp_idx, rra_idx) != 0) {
             return -1;
         }
     }

--- a/src/rrd_tune.c
+++ b/src/rrd_tune.c
@@ -623,6 +623,9 @@ static int set_windowarg(
     for (i = 0; i < rrd->stat_head->ds_cnt; i++) {
         cdp_idx = rra_idx * (rrd->stat_head->ds_cnt) + i;
         erase_violations(rrd, cdp_idx, rra_idx);
+        if (rrd_test_error()) {
+            return -1;
+        }
     }
     return 0;
 }

--- a/src/rrd_update.c
+++ b/src/rrd_update.c
@@ -198,7 +198,7 @@ static void initialize_cdp_val(
     unsigned long start_pdp_offset,
     unsigned long pdp_cnt);
 
-static void reset_cdp(
+static int reset_cdp(
     rrd_t *rrd,
     unsigned long elapsed_pdp_st,
     rrd_value_t *pdp_temp,
@@ -1987,9 +1987,10 @@ static int update_cdp_prep(
             /* Nothing to consolidate if there's one PDP per CDP. However, if
              * we've missed some PDPs, let's update null counters etc. */
             if (elapsed_pdp_st > 2) {
-                reset_cdp(rrd, elapsed_pdp_st, pdp_temp, last_seasonal_coef,
-                          seasonal_coef, rra_idx, ds_idx, cdp_idx,
-                          (enum cf_en)current_cf);
+                if (reset_cdp(rrd, elapsed_pdp_st, pdp_temp, last_seasonal_coef,
+                              seasonal_coef, rra_idx, ds_idx, cdp_idx,
+                              (enum cf_en)current_cf) != 0)
+                    return -1;
             }
         }
 
@@ -2145,7 +2146,7 @@ static void initialize_cdp_val(
  * well as other functions that don't actually consolidate multiple
  * PDPs.
  */
-static void reset_cdp(
+static int reset_cdp(
     rrd_t *rrd,
     unsigned long elapsed_pdp_st,
     rrd_value_t *pdp_temp,
@@ -2192,9 +2193,9 @@ static void reset_cdp(
         /* need to reset violations buffer.
          * could do this more carefully, but for now, just
          * assume a bulk update wipes away all violations. */
-        erase_violations(rrd, cdp_idx, rra_idx);
-        break;
+        return erase_violations(rrd, cdp_idx, rra_idx);
     }
+    return 0;
 }
 
 static rrd_value_t initialize_carry_over(

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,8 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-1 create-with-source-2 create-with-source-3 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
-	pdp-calc1 graph3 graph4 graph5
+	pdp-calc1 graph3 graph4 graph5 \
+	security-tune-failures-window
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,7 +7,7 @@ TESTS = modify1 modify2 modify3 modify4 modify5 \
 	create-with-source-4 create-with-source-and-mapping-1 \
 	create-from-template-1 dcounter1 vformatter1 xport1 xport2 xport3 list1 \
 	pdp-calc1 graph3 graph4 graph5 \
-	security-tune-failures-window
+	security-tune-failures-window security-dump-failures-window
 
 EXTRA_DIST = Makefile.am \
 	functions $(TESTS) \

--- a/tests/security-dump-failures-window
+++ b/tests/security-dump-failures-window
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname $0)/functions
+. "$(dirname "$0")/functions"
 
 # rrdtool routes through RRDCACHED_ADDRESS when it's set, and the crafted
 # file lives outside the daemon's base directory, so dump would fail with
@@ -12,9 +12,9 @@
 # exercises the LP64 rra_def_t layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77
 
-BUILD=$BUILDDIR/$(basename $0)
+BUILD="$BUILDDIR/$(basename "$0")"
 
-$RRDTOOL create ${BUILD}.rrd --start 0 --step 300 \
+$RRDTOOL create "${BUILD}.rrd" --start 0 --step 300 \
   DS:val:GAUGE:600:U:U \
   RRA:AVERAGE:0.5:1:100 \
   RRA:HWPREDICT:100:0.1:0.0035:20 || fail create
@@ -24,18 +24,18 @@ $RRDTOOL create ${BUILD}.rrd --start 0 --step 300 \
 # a fixed MAX_CDP_PAR_EN-element scratch buffer; window_len is read straight
 # from the file, 72 bytes past the "FAILURES" cf_nam marker (20-byte cf_nam
 # padded to 24, + row_cnt + pdp_cnt, landing on par[] index 4).
-cp ${BUILD}.rrd ${BUILD}-overflow.rrd
+cp "${BUILD}.rrd" "${BUILD}-overflow.rrd"
 perl -0777 -pi -e '
   my $off = index($_, "FAILURES");
   die "FAILURES cf_nam not found\n" if $off < 0;
-  substr($_, $off + 72, 8, pack("Q<", 60000));
-' ${BUILD}-overflow.rrd
+  substr($_, $off + 72, 8, pack("Q", 60000));
+' "${BUILD}-overflow.rrd"
 
-if $RRDTOOL dump ${BUILD}-overflow.rrd ${BUILD}-overflow.xml \
-    >${BUILD}.out 2>&1; then
+if $RRDTOOL dump "${BUILD}-overflow.rrd" "${BUILD}-overflow.xml" \
+    >"${BUILD}.out" 2>&1; then
   fail 1 "dump accepted an out-of-range window_len"
 fi
-grep -q "window_len.*out of range" ${BUILD}.out || \
+grep -q "window_len.*out of range" "${BUILD}.out" || \
   fail 1 "dump did not diagnose the out-of-range window_len"
 
 report "reject out-of-range FAILURES window_len in rrd_dump"

--- a/tests/security-dump-failures-window
+++ b/tests/security-dump-failures-window
@@ -13,6 +13,8 @@
 test "$(getconf LONG_BIT)" = 64 || exit 77
 
 BUILD="$BUILDDIR/$(basename "$0")"
+trap 'rm -f "${BUILD}"*.rrd "${BUILD}"*.xml "${BUILD}"*.out' EXIT
+[ -n "$MSYSTEM" ] && exit 77
 
 $RRDTOOL create "${BUILD}.rrd" --start 0 --step 300 \
   DS:val:GAUGE:600:U:U \
@@ -39,3 +41,31 @@ grep -q "window_len.*out of range" "${BUILD}.out" || \
   fail 1 "dump did not diagnose the out-of-range window_len"
 
 report "reject out-of-range FAILURES window_len in rrd_dump"
+
+# Check every file-opening consumer and the XML ingestion boundary, including
+# the valid maximum and the first invalid value, not only a large corruption.
+$RRDTOOL dump "${BUILD}.rrd" "${BUILD}-valid.xml" || fail dump
+for window in 0 28 29 60000; do
+  cp "${BUILD}.rrd" "${BUILD}-boundary.rrd"
+  perl -0777 -pi -e 'BEGIN { $window=shift @ARGV }
+    my $off=index($_,"FAILURES"); die if $off<0;
+    substr($_,$off+72,8,pack("Q",$window));' "$window" "${BUILD}-boundary.rrd"
+  sed "s@<window_len>[^<]*</window_len>@<window_len>$window</window_len>@" \
+    "${BUILD}-valid.xml" > "${BUILD}-boundary.xml"
+  for command in info update restore; do
+    case "$command" in
+      info) args=(info "${BUILD}-boundary.rrd") ;;
+      update) args=(update "${BUILD}-boundary.rrd" N:1) ;;
+      restore) args=(restore -f "${BUILD}-boundary.xml" "${BUILD}-restored.rrd") ;;
+    esac
+    $RRDTOOL "${args[@]}" >"${BUILD}-boundary.out" 2>&1
+    rc=$?
+    if [ "$window" = 28 ]; then
+      [ "$rc" = 0 ] || fail 1 "$command rejected the valid maximum window"
+    else
+      [ "$rc" -gt 0 ] && [ "$rc" -lt 128 ] || fail 1 "$command did not reject window $window cleanly"
+      grep -q 'window_len.*out of range' "${BUILD}-boundary.out" || fail 1 "$command gave the wrong error"
+    fi
+  done
+done
+report "validate FAILURES history boundaries in info, update, and restore"

--- a/tests/security-dump-failures-window
+++ b/tests/security-dump-failures-window
@@ -2,6 +2,12 @@
 
 . $(dirname $0)/functions
 
+# rrdtool routes through RRDCACHED_ADDRESS when it's set, and the crafted
+# file lives outside the daemon's base directory, so dump would fail with
+# "No such file or directory" rather than exercising the check being
+# tested here (same reasoning as security-tune-failures-window).
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+
 # window_len is stored as an on-disk unsigned long; the crafted value below
 # exercises the LP64 rra_def_t layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77

--- a/tests/security-dump-failures-window
+++ b/tests/security-dump-failures-window
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# window_len is stored as an on-disk unsigned long; the crafted value below
+# exercises the LP64 rra_def_t layout used by the supported Unix builds.
+test "$(getconf LONG_BIT)" = 64 || exit 77
+
+BUILD=$BUILDDIR/$(basename $0)
+
+$RRDTOOL create ${BUILD}.rrd --start 0 --step 300 \
+  DS:val:GAUGE:600:U:U \
+  RRA:AVERAGE:0.5:1:100 \
+  RRA:HWPREDICT:100:0.1:0.0035:20 || fail create
+
+# rra[5] is the FAILURES RRA rrd_create derives from the HWPREDICT period.
+# rrd_dump's CF_FAILURES branch walks violations_array[0..window_len) out of
+# a fixed MAX_CDP_PAR_EN-element scratch buffer; window_len is read straight
+# from the file, 72 bytes past the "FAILURES" cf_nam marker (20-byte cf_nam
+# padded to 24, + row_cnt + pdp_cnt, landing on par[] index 4).
+cp ${BUILD}.rrd ${BUILD}-overflow.rrd
+perl -0777 -pi -e '
+  my $off = index($_, "FAILURES");
+  die "FAILURES cf_nam not found\n" if $off < 0;
+  substr($_, $off + 72, 8, pack("Q<", 60000));
+' ${BUILD}-overflow.rrd
+
+if $RRDTOOL dump ${BUILD}-overflow.rrd ${BUILD}-overflow.xml \
+    >${BUILD}.out 2>&1; then
+  fail 1 "dump accepted an out-of-range window_len"
+fi
+grep -q "window_len.*out of range" ${BUILD}.out || \
+  fail 1 "dump did not diagnose the out-of-range window_len"
+
+report "reject out-of-range FAILURES window_len in rrd_dump"

--- a/tests/security-tune-failures-window
+++ b/tests/security-tune-failures-window
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. $(dirname $0)/functions
+. "$(dirname "$0")/functions"
 
 # rrdtool routes through RRDCACHED_ADDRESS when it's set, and the test
 # harness's own compat shim doesn't rewrite paths for tune ("rrdcached
@@ -13,9 +13,9 @@
 # exercises the LP64 rra_def_t layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77
 
-BUILD=$BUILDDIR/$(basename $0)
+BUILD="$BUILDDIR/$(basename "$0")"
 
-$RRDTOOL create ${BUILD}.rrd --start 0 --step 300 \
+$RRDTOOL create "${BUILD}.rrd" --start 0 --step 300 \
   DS:val:GAUGE:600:U:U \
   RRA:AVERAGE:0.5:1:100 \
   RRA:HWPREDICT:100:0.1:0.0035:20 || fail create
@@ -29,30 +29,30 @@ $RRDTOOL create ${BUILD}.rrd --start 0 --step 300 \
 # MAX_CDP_PAR_EN-element scratch buffer -- an oversized value here used to
 # walk that buffer out of bounds.
 craft_window_len() {
-  cp ${BUILD}.rrd $1
+  cp "${BUILD}.rrd" "$1"
   perl -0777 -pi -e '
     my $off = index($_, "FAILURES");
     die "FAILURES cf_nam not found\n" if $off < 0;
-    substr($_, $off + 72, 8, pack("Q<", 60000));
-  ' $1
+    substr($_, $off + 72, 8, pack("Q", 60000));
+  ' "$1"
 }
 
-craft_window_len ${BUILD}-aberrant-reset.rrd
-$RRDTOOL tune --aberrant-reset val ${BUILD}-aberrant-reset.rrd \
-  >${BUILD}-aberrant-reset.out 2>&1
+craft_window_len "${BUILD}-aberrant-reset.rrd"
+$RRDTOOL tune --aberrant-reset val "${BUILD}-aberrant-reset.rrd" \
+  >"${BUILD}-aberrant-reset.out" 2>&1
 if [ $? -eq 0 ]; then
   fail 1 "tune --aberrant-reset accepted an out-of-range window_len"
 fi
-grep -q "window_len.*out of range" ${BUILD}-aberrant-reset.out || \
+grep -q "window_len.*out of range" "${BUILD}-aberrant-reset.out" || \
   fail 1 "tune --aberrant-reset did not diagnose the out-of-range window_len"
 
-craft_window_len ${BUILD}-failure-threshold.rrd
-$RRDTOOL tune --failure-threshold 2 ${BUILD}-failure-threshold.rrd \
-  >${BUILD}-failure-threshold.out 2>&1
+craft_window_len "${BUILD}-failure-threshold.rrd"
+$RRDTOOL tune --failure-threshold 2 "${BUILD}-failure-threshold.rrd" \
+  >"${BUILD}-failure-threshold.out" 2>&1
 if [ $? -eq 0 ]; then
   fail 1 "tune --failure-threshold accepted an out-of-range window_len"
 fi
-grep -q "window_len.*out of range" ${BUILD}-failure-threshold.out || \
+grep -q "window_len.*out of range" "${BUILD}-failure-threshold.out" || \
   fail 1 "tune --failure-threshold did not diagnose the out-of-range window_len"
 
 report "reject out-of-range FAILURES window_len in rrd_tune"

--- a/tests/security-tune-failures-window
+++ b/tests/security-tune-failures-window
@@ -2,6 +2,13 @@
 
 . $(dirname $0)/functions
 
+# rrdtool routes through RRDCACHED_ADDRESS when it's set, and the test
+# harness's own compat shim doesn't rewrite paths for tune ("rrdcached
+# does not support tune", see tests/functions) -- the crafted file lives
+# outside the daemon's base directory, so tune fails with "No such file
+# or directory" rather than exercising the check being tested here.
+[ -n "$RRDCACHED_ADDRESS" ] && exit 77
+
 # window_len is stored as an on-disk unsigned long; the crafted value below
 # exercises the LP64 rra_def_t layout used by the supported Unix builds.
 test "$(getconf LONG_BIT)" = 64 || exit 77

--- a/tests/security-tune-failures-window
+++ b/tests/security-tune-failures-window
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+. $(dirname $0)/functions
+
+# window_len is stored as an on-disk unsigned long; the crafted value below
+# exercises the LP64 rra_def_t layout used by the supported Unix builds.
+test "$(getconf LONG_BIT)" = 64 || exit 77
+
+BUILD=$BUILDDIR/$(basename $0)
+
+$RRDTOOL create ${BUILD}.rrd --start 0 --step 300 \
+  DS:val:GAUGE:600:U:U \
+  RRA:AVERAGE:0.5:1:100 \
+  RRA:HWPREDICT:100:0.1:0.0035:20 || fail create
+
+# rra[5] is the FAILURES RRA rrd_create derives from the HWPREDICT period.
+# Its cf_nam is a unique "FAILURES" marker in the file; window_len is the
+# 5th unival (index 4) in that rra_def_t's par[] array, i.e. 72 bytes past
+# the start of cf_nam (20-byte cf_nam padded to 24, + row_cnt + pdp_cnt).
+# rrd_tune's set_windowarg()/reset_aberrant_coefficients() feed window_len
+# straight into erase_violations(), which zeroes it into a fixed
+# MAX_CDP_PAR_EN-element scratch buffer -- an oversized value here used to
+# walk that buffer out of bounds.
+craft_window_len() {
+  cp ${BUILD}.rrd $1
+  perl -0777 -pi -e '
+    my $off = index($_, "FAILURES");
+    die "FAILURES cf_nam not found\n" if $off < 0;
+    substr($_, $off + 72, 8, pack("Q<", 60000));
+  ' $1
+}
+
+craft_window_len ${BUILD}-aberrant-reset.rrd
+$RRDTOOL tune --aberrant-reset val ${BUILD}-aberrant-reset.rrd \
+  >${BUILD}-aberrant-reset.out 2>&1
+if [ $? -eq 0 ]; then
+  fail 1 "tune --aberrant-reset accepted an out-of-range window_len"
+fi
+grep -q "window_len.*out of range" ${BUILD}-aberrant-reset.out || \
+  fail 1 "tune --aberrant-reset did not diagnose the out-of-range window_len"
+
+craft_window_len ${BUILD}-failure-threshold.rrd
+$RRDTOOL tune --failure-threshold 2 ${BUILD}-failure-threshold.rrd \
+  >${BUILD}-failure-threshold.out 2>&1
+if [ $? -eq 0 ]; then
+  fail 1 "tune --failure-threshold accepted an out-of-range window_len"
+fi
+grep -q "window_len.*out of range" ${BUILD}-failure-threshold.out || \
+  fail 1 "tune --failure-threshold did not diagnose the out-of-range window_len"
+
+report "reject out-of-range FAILURES window_len in rrd_tune"


### PR DESCRIPTION
rra_def_t.par[RRA_window_len].u_cnt is an on-disk unsigned long, only
bounded to MAX_FAILURES_WINDOW_LEN (28) via rrd_create/rrd_tune's own
CLI validation -- a hand-crafted file can set it to anything. Both
rrd_dump.c and rrd_hw.c use it to index a fixed 10-element
(MAX_CDP_PAR_EN) cdp_prep.scratch buffer treated as a byte array:

- rrd_dump.c's <history> output reads violations_array[vidx] up to
  window_len -- OOB heap read, and since vidx is unsigned short any
  window_len > 65535 makes the loop condition permanently true.
- rrd_hw.c's erase_violations() writes zeros for window_len bytes into
  the same buffer -- OOB heap write. Reachable from rrd_tune.c via
  --aberrant-reset and, more subtly, --failure-threshold (which only
  validates the new parameter, not the pre-existing window_len it reads
  to erase old violations).

Verified with a crafted RRD (window_len patched to 60000 at its on-disk
offset) under AddressSanitizer: rrdtool dump SEGVs reading rrd_dump.c,
rrdtool tune --aberrant-reset SEGVs writing rrd_hw.c, and
--failure-threshold hits the same write path independently. Even a
plain non-ASan build produces a real Bus error on --aberrant-reset.

Both call sites now bound window_len against MAX_FAILURES_WINDOW_LEN
before use, with regression tests for each (revert/rebuild/confirm
crash, restore/rebuild/confirm clean rejection, both under ASan and via
the real test harness).