### PR TITLE
hardening: size the rrd_diff scratch buffer for its largest input

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ RRDtool - master ...
 ====================
 Bugfixes
 --------
+* hardening: size the rrd_diff scratch buffer for its largest input @somethingwithproof
 * `rrdtool dump` now uses a numeric UTC offset (`%z`, e.g. `+0900`) instead
   of the locale timezone name (`%Z`) in XML comments. Locale timezone names
   can be encoded in a non-UTF-8 encoding (e.g. CJK locales), which breaks

--- a/src/rrd_diff.c
+++ b/src/rrd_diff.c
@@ -14,7 +14,11 @@ double rrd_diff(
     char *a,
     char *b)
 {
-    char      res[LAST_DS_LEN + 1], *a1, *b1, *r1, *fix;
+    /* res is filled up to res[m+2] (the space fill writes res[m+1] and the
+     * trailing NUL lands on res[m+2]) while m is only bounded to <=
+     * LAST_DS_LEN below, so the scratch buffer needs LAST_DS_LEN + 3 bytes,
+     * not + 1. */
+    char      res[LAST_DS_LEN + 3], *a1, *b1, *r1, *fix;
     int       c, x, m;
     char      a_neg = 0, b_neg = 0;
     double    result;


### PR DESCRIPTION
rrd_diff() subtracts two decimal-string operands into a stack buffer
`res`. It accepts operands up to LAST_DS_LEN digits (the guard is
`m > LAST_DS_LEN`), but then writes the space fill through `res[m+1]`
and the trailing NUL at `res[m+2]`, while `res` was declared
`LAST_DS_LEN + 1` bytes. A maximum-length operand runs two bytes past
the buffer.

Give `res` the `LAST_DS_LEN + 3` bytes it actually indexes. No change to
results (the buffer is scratch space; the value is returned as a double)
and LAST_DS_LEN itself is untouched.

Verified with AddressSanitizer: an update carrying a max-length value
reports a stack-buffer-overflow before this change and is clean after,
and the counter regression tests still pass with correct rates.