### PR TITLE
xport: fix invalid JSON output with PRINT

### DIFF
--- a/src/rrd_xport.c
+++ b/src/rrd_xport.c
@@ -906,14 +906,6 @@ static int rrd_xport_format_xmljson(
         return -1;
     }
 
-    /* if we have got a trailing , then kill it */
-    if (buffer->data) {
-        if (buffer->data[buffer->len - 2] == ',') {
-            buffer->data[buffer->len - 2] = buffer->data[buffer->len - 1];
-            buffer->len--;
-        }
-    }
-
     /* end meta */
     if (json) {
         snprintf(buf, sizeof(buf), "     },\n");
@@ -1362,10 +1354,10 @@ static int rrd_xport_format_addprints(
     /* now add prints */
     if (prints.len) {
         if (json) {
-            snprintf(buf, sizeof(buf), "    \"%s\": [\n", "prints");
+            snprintf(buf, sizeof(buf), "    ,\"%s\": [\n", "prints");
             addToBuffer(buffer, buf, 0);
             addToBuffer(buffer, (char *) prints.data + 2, prints.len - 2);
-            addToBuffer(buffer, "\n        ],\n", 0);
+            addToBuffer(buffer, "\n        ]\n", 0);
         } else {
             snprintf(buf, sizeof(buf), "    <%s>\n", "prints");
             addToBuffer(buffer, buf, 0);


### PR DESCRIPTION
## Problem

`rrdtool xport --json` produces invalid JSON when a `PRINT` statement is present and the output is written directly to a `FILE` stream.

The formatter currently appends a trailing comma after the `prints` array and later tries to remove it from `stringbuffer_t::data`.

This works for memory-buffer output, but when `stringbuffer_t::file` is set, `addToBuffer()` writes directly to the stream and `buffer->data` remains `NULL`. The trailing comma therefore remains in the output.

## Fix

Emit the separator before the optional `prints` member instead of appending a trailing comma and removing it afterwards.

This also matches the existing handling of the optional `gprints` and `rules` members.

## Testing

Tested with RRDtool 1.11.0:

* JSON xport without `PRINT` remains valid.
* JSON xport with `PRINT` now produces valid JSON.
* `PRINT` result is unchanged (`avg= 21.50` in the test case).
* Default XML xport with `PRINT` remains valid and unchanged.
